### PR TITLE
feat: add player audio track selection

### DIFF
--- a/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/Media3PlaybackPlugin.kt
+++ b/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/Media3PlaybackPlugin.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.Tracks
 import androidx.media3.common.MimeTypes
 import androidx.media3.exoplayer.source.UnrecognizedInputFormatException
 import androidx.media3.common.PlaybackException
@@ -61,6 +63,14 @@ class Media3PlaybackPlugin(
                 }
                 "seek" -> {
                     requirePlayer().seekTo(call.longArgument("positionMs"))
+                    result.success(null)
+                }
+                "setAudioTrack" -> {
+                    selectTrack(C.TRACK_TYPE_AUDIO, call.optionalStringArgument("trackId"))
+                    result.success(null)
+                }
+                "setSubtitleTrack" -> {
+                    selectTrack(C.TRACK_TYPE_TEXT, call.optionalStringArgument("trackId"))
                     result.success(null)
                 }
                 "stop" -> {
@@ -178,6 +188,12 @@ class Media3PlaybackPlugin(
         positionMs: Long? = null,
         durationMs: Long? = null,
         textureId: Long? = null,
+        audioTracks: List<Map<String, Any?>>? = null,
+        subtitleTracks: List<Map<String, Any?>>? = null,
+        selectedAudioTrackId: String? = null,
+        selectedSubtitleTrackId: String? = null,
+        includeSelectedAudioTrackId: Boolean = false,
+        includeSelectedSubtitleTrackId: Boolean = false,
         code: String? = null,
         message: String? = null,
         recoverable: Boolean? = null,
@@ -187,10 +203,98 @@ class Media3PlaybackPlugin(
         if (positionMs != null) event["positionMs"] = positionMs
         if (durationMs != null) event["durationMs"] = durationMs
         if (textureId != null) event["textureId"] = textureId
+        if (audioTracks != null) event["audioTracks"] = audioTracks
+        if (subtitleTracks != null) event["subtitleTracks"] = subtitleTracks
+        if (includeSelectedAudioTrackId) event["selectedAudioTrackId"] = selectedAudioTrackId
+        if (includeSelectedSubtitleTrackId) event["selectedSubtitleTrackId"] = selectedSubtitleTrackId
         if (code != null) event["code"] = code
         if (message != null) event["message"] = message
         if (recoverable != null) event["recoverable"] = recoverable
         events?.success(event)
+    }
+
+    private fun selectTrack(trackType: Int, trackId: String?) {
+        val player = requirePlayer()
+        val builder = player.trackSelectionParameters.buildUpon()
+            .clearOverridesOfType(trackType)
+            .setTrackTypeDisabled(trackType, trackId == null)
+
+        if (trackId != null) {
+            val parsed = parseTrackId(trackId)
+            val group = parsed?.let { player.currentTracks.groups.getOrNull(it.first) }
+            if (group != null && group.type == trackType && parsed.second in 0 until group.length) {
+                builder.setOverrideForType(
+                    TrackSelectionOverride(group.mediaTrackGroup, listOf(parsed.second))
+                )
+            }
+        }
+
+        player.trackSelectionParameters = builder.build()
+        emitTrackSnapshot(player)
+    }
+
+    private fun emitTrackSnapshot(player: Player) {
+        emit(
+            type = if (player.isPlaying) "playing" else "ready",
+            positionMs = player.currentPosition,
+            durationMs = player.duration.takeIf { it != C.TIME_UNSET && it > 0 },
+            audioTracks = playbackTracks(player.currentTracks, C.TRACK_TYPE_AUDIO),
+            subtitleTracks = playbackTracks(player.currentTracks, C.TRACK_TYPE_TEXT),
+            selectedAudioTrackId = selectedTrackId(player.currentTracks, C.TRACK_TYPE_AUDIO),
+            selectedSubtitleTrackId = selectedTrackId(player.currentTracks, C.TRACK_TYPE_TEXT),
+            includeSelectedAudioTrackId = true,
+            includeSelectedSubtitleTrackId = true,
+        )
+    }
+
+    private fun playbackTracks(tracks: Tracks, trackType: Int): List<Map<String, Any?>> {
+        val result = mutableListOf<Map<String, Any?>>()
+        tracks.groups.forEachIndexed { groupIndex, group ->
+            if (group.type != trackType) return@forEachIndexed
+            for (trackIndex in 0 until group.length) {
+                val format = group.getTrackFormat(trackIndex)
+                val id = trackId(trackType, groupIndex, trackIndex)
+                result.add(
+                    mapOf(
+                        "id" to id,
+                        "label" to trackLabel(trackType, trackIndex, format.label, format.language),
+                        "language" to format.language,
+                    )
+                )
+            }
+        }
+        return result
+    }
+
+    private fun selectedTrackId(tracks: Tracks, trackType: Int): String? {
+        tracks.groups.forEachIndexed { groupIndex, group ->
+            if (group.type != trackType) return@forEachIndexed
+            for (trackIndex in 0 until group.length) {
+                if (group.isTrackSelected(trackIndex)) {
+                    return trackId(trackType, groupIndex, trackIndex)
+                }
+            }
+        }
+        return null
+    }
+
+    private fun trackId(trackType: Int, groupIndex: Int, trackIndex: Int): String {
+        val prefix = if (trackType == C.TRACK_TYPE_AUDIO) "audio" else "subtitle"
+        return "$prefix:$groupIndex:$trackIndex"
+    }
+
+    private fun parseTrackId(trackId: String): Pair<Int, Int>? {
+        val parts = trackId.split(':')
+        if (parts.size != 3) return null
+        val groupIndex = parts[1].toIntOrNull() ?: return null
+        val trackIndex = parts[2].toIntOrNull() ?: return null
+        return groupIndex to trackIndex
+    }
+
+    private fun trackLabel(trackType: Int, index: Int, label: String?, language: String?): String {
+        if (!label.isNullOrBlank()) return label
+        if (!language.isNullOrBlank()) return language.uppercase()
+        return if (trackType == C.TRACK_TYPE_AUDIO) "Audio ${index + 1}" else "Subtitle ${index + 1}"
     }
 
     private inner class Media3Listener : Player.Listener {
@@ -199,6 +303,11 @@ class Media3PlaybackPlugin(
             if (videoSize.width > 0 && videoSize.height > 0) {
                 state.surfaceProducer.setSize(videoSize.width, videoSize.height)
             }
+        }
+
+        override fun onTracksChanged(tracks: Tracks) {
+            val player = playerState?.player ?: return
+            emitTrackSnapshot(player)
         }
 
         override fun onPlaybackStateChanged(playbackState: Int) {
@@ -305,4 +414,10 @@ private fun PlaybackException.looksLikeFormatMismatch(): Boolean {
     val text = listOfNotNull(message, cause?.message).joinToString("\n")
     return text.contains("Input does not start with the #EXTM3U header") ||
         text.contains("UnrecognizedInputFormatException")
+}
+
+
+private fun MethodCall.optionalStringArgument(name: String): String? {
+    val args = arguments as? Map<*, *> ?: return null
+    return args[name] as? String
 }

--- a/flutter_client/ios/Runner/AvKitPlaybackPlugin.swift
+++ b/flutter_client/ios/Runner/AvKitPlaybackPlugin.swift
@@ -137,6 +137,16 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
             emit(type: "stopped")
             result(nil)
 
+        case "setAudioTrack":
+            let args = call.arguments as? [String: Any]
+            selectTrack(characteristic: .audible, trackId: args?["trackId"] as? String)
+            result(nil)
+
+        case "setSubtitleTrack":
+            let args = call.arguments as? [String: Any]
+            selectTrack(characteristic: .legible, trackId: args?["trackId"] as? String)
+            result(nil)
+
         case "dispose":
             releasePlayer()
             result(nil)
@@ -163,7 +173,16 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         switch item.status {
         case .readyToPlay:
             let posMs = currentPositionMs()
-            emit(type: s.player.rate > 0 ? "playing" : "ready", positionMs: posMs)
+            emit(
+                type: s.player.rate > 0 ? "playing" : "ready",
+                positionMs: posMs,
+                audioTracks: playbackTracks(characteristic: .audible),
+                subtitleTracks: playbackTracks(characteristic: .legible),
+                selectedAudioTrackId: selectedTrackId(characteristic: .audible),
+                selectedSubtitleTrackId: selectedTrackId(characteristic: .legible),
+                includeSelectedAudioTrackId: true,
+                includeSelectedSubtitleTrackId: true
+            )
         case .failed:
             let msg = item.error?.localizedDescription ?? "AVPlayer item failed"
             emit(type: "error", code: "avkit-item-failed", message: msg, recoverable: true)
@@ -182,6 +201,62 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         emit(type: "end", positionMs: currentPositionMs())
     }
 
+    private func selectTrack(characteristic: AVMediaCharacteristic, trackId: String?) {
+        guard let item = state?.item,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic) else {
+            return
+        }
+
+        if let trackId = trackId, let index = parseTrackIndex(trackId), index < group.options.count {
+            item.select(group.options[index], in: group)
+        } else {
+            item.select(nil, in: group)
+        }
+
+        emit(
+            type: state?.player.rate ?? 0 > 0 ? "playing" : "ready",
+            positionMs: currentPositionMs(),
+            audioTracks: playbackTracks(characteristic: .audible),
+            subtitleTracks: playbackTracks(characteristic: .legible),
+            selectedAudioTrackId: selectedTrackId(characteristic: .audible),
+            selectedSubtitleTrackId: selectedTrackId(characteristic: .legible),
+            includeSelectedAudioTrackId: true,
+            includeSelectedSubtitleTrackId: true
+        )
+    }
+
+    private func playbackTracks(characteristic: AVMediaCharacteristic) -> [[String: Any?]] {
+        guard let item = state?.item,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic) else {
+            return []
+        }
+        let prefix = characteristic == .audible ? "audio" : "subtitle"
+        return group.options.enumerated().map { index, option in
+            [
+                "id": "\(prefix):\(index)",
+                "label": option.displayName,
+                "language": option.locale?.identifier,
+            ]
+        }
+    }
+
+    private func selectedTrackId(characteristic: AVMediaCharacteristic) -> String? {
+        guard let item = state?.item,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic),
+              let selected = item.selectedMediaOption(in: group),
+              let index = group.options.firstIndex(of: selected) else {
+            return nil
+        }
+        let prefix = characteristic == .audible ? "audio" : "subtitle"
+        return "\(prefix):\(index)"
+    }
+
+    private func parseTrackIndex(_ trackId: String) -> Int? {
+        let parts = trackId.split(separator: ":")
+        guard parts.count == 2 else { return nil }
+        return Int(parts[1])
+    }
+
     private func currentPositionMs() -> Int64 {
         guard let player = state?.player else { return 0 }
         let seconds = CMTimeGetSeconds(player.currentTime())
@@ -193,6 +268,12 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         textureId: Int64? = nil,
         uri: String? = nil,
         positionMs: Int64? = nil,
+        audioTracks: [[String: Any?]]? = nil,
+        subtitleTracks: [[String: Any?]]? = nil,
+        selectedAudioTrackId: String? = nil,
+        selectedSubtitleTrackId: String? = nil,
+        includeSelectedAudioTrackId: Bool = false,
+        includeSelectedSubtitleTrackId: Bool = false,
         code: String? = nil,
         message: String? = nil,
         recoverable: Bool = false
@@ -201,6 +282,10 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         if let id = textureId  { event["textureId"]   = id       }
         if let u  = uri         { event["uri"]         = u        }
         if let p  = positionMs  { event["positionMs"]  = p        }
+        if let a  = audioTracks { event["audioTracks"] = a        }
+        if let st = subtitleTracks { event["subtitleTracks"] = st }
+        if includeSelectedAudioTrackId { event["selectedAudioTrackId"] = selectedAudioTrackId }
+        if includeSelectedSubtitleTrackId { event["selectedSubtitleTrackId"] = selectedSubtitleTrackId }
         if let c  = code        { event["code"]        = c        }
         if let m  = message     { event["message"]     = m        }
         if recoverable          { event["recoverable"] = true      }

--- a/flutter_client/lib/features/player/playback_controls.dart
+++ b/flutter_client/lib/features/player/playback_controls.dart
@@ -4,6 +4,8 @@ import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/features/player/format_time.dart';
+import 'package:m3u_tv/features/player/track_selector.dart';
+import 'package:m3u_tv/playback/player_adapter.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 
 /// Playback controls overlay for the player screen.
@@ -21,6 +23,12 @@ class PlaybackControls extends StatelessWidget {
     required this.onPlayPause,
     required this.onSeek,
     required this.onBack,
+    this.audioTracks = const <PlaybackTrack>[],
+    this.subtitleTracks = const <PlaybackTrack>[],
+    this.selectedAudioTrackId,
+    this.selectedSubtitleTrackId,
+    this.onAudioTrackSelected,
+    this.onSubtitleTrackSelected,
     this.fallbackReason,
     this.playPauseFocusNode,
     super.key,
@@ -34,6 +42,12 @@ class PlaybackControls extends StatelessWidget {
   final VoidCallback onPlayPause;
   final ValueChanged<Duration> onSeek;
   final VoidCallback onBack;
+  final List<PlaybackTrack> audioTracks;
+  final List<PlaybackTrack> subtitleTracks;
+  final String? selectedAudioTrackId;
+  final String? selectedSubtitleTrackId;
+  final ValueChanged<String?>? onAudioTrackSelected;
+  final ValueChanged<String?>? onSubtitleTrackSelected;
   final String? fallbackReason;
   final FocusNode? playPauseFocusNode;
 
@@ -121,8 +135,24 @@ class PlaybackControls extends StatelessWidget {
           if (canSeek) _buildProgressBar(colorScheme),
           if (canSeek) const SizedBox(height: 12),
           _buildControlRow(colorScheme),
+          if (_hasTrackControls) const SizedBox(height: 12),
+          if (_hasTrackControls) _buildTrackControls(),
         ],
       ),
+    );
+  }
+
+  bool get _hasTrackControls =>
+      audioTracks.isNotEmpty || subtitleTracks.isNotEmpty;
+
+  Widget _buildTrackControls() {
+    return TrackSelector(
+      audioTracks: audioTracks,
+      subtitleTracks: subtitleTracks,
+      selectedAudioTrackId: selectedAudioTrackId,
+      selectedSubtitleTrackId: selectedSubtitleTrackId,
+      onAudioTrackSelected: onAudioTrackSelected ?? (_) {},
+      onSubtitleTrackSelected: onSubtitleTrackSelected ?? (_) {},
     );
   }
 

--- a/flutter_client/lib/features/player/playback_controls.dart
+++ b/flutter_client/lib/features/player/playback_controls.dart
@@ -207,18 +207,41 @@ class PlaybackControls extends StatelessWidget {
       ],
     );
 
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        Center(child: transportControls),
-        Align(
-          alignment: Alignment.centerRight,
-          child: SizedBox(
-            width: TrackSelector.controlsWidth,
-            child: _hasTrackControls ? _buildTrackControls() : null,
-          ),
-        ),
-      ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final trackControlsWidth = _hasTrackControls
+            ? TrackSelector.controlsWidth
+            : 0.0;
+        final transportWidth = isLive ? 56.0 : 168.0;
+        final hasRoomForCenteredTransport =
+            constraints.maxWidth >= transportWidth + (trackControlsWidth * 2);
+
+        if (_hasTrackControls && !hasRoomForCenteredTransport) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Center(child: transportControls),
+              const SizedBox(height: 12),
+              Center(child: _buildTrackControls()),
+            ],
+          );
+        }
+
+        return Stack(
+          alignment: Alignment.center,
+          children: [
+            Center(child: transportControls),
+            if (_hasTrackControls)
+              Align(
+                alignment: Alignment.centerRight,
+                child: SizedBox(
+                  width: TrackSelector.controlsWidth,
+                  child: _buildTrackControls(),
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/flutter_client/lib/features/player/playback_controls.dart
+++ b/flutter_client/lib/features/player/playback_controls.dart
@@ -207,10 +207,17 @@ class PlaybackControls extends StatelessWidget {
       ],
     );
 
-    return Row(
+    return Stack(
+      alignment: Alignment.center,
       children: [
-        Expanded(child: Center(child: transportControls)),
-        if (_hasTrackControls) _buildTrackControls(),
+        Center(child: transportControls),
+        Align(
+          alignment: Alignment.centerRight,
+          child: SizedBox(
+            width: TrackSelector.controlsWidth,
+            child: _hasTrackControls ? _buildTrackControls() : null,
+          ),
+        ),
       ],
     );
   }

--- a/flutter_client/lib/features/player/playback_controls.dart
+++ b/flutter_client/lib/features/player/playback_controls.dart
@@ -124,6 +124,7 @@ class PlaybackControls extends StatelessWidget {
 
   Widget _buildControlsBar(ColorScheme colorScheme) {
     return Container(
+      width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
       decoration: BoxDecoration(
         color: Colors.black87,
@@ -135,8 +136,6 @@ class PlaybackControls extends StatelessWidget {
           if (canSeek) _buildProgressBar(colorScheme),
           if (canSeek) const SizedBox(height: 12),
           _buildControlRow(colorScheme),
-          if (_hasTrackControls) const SizedBox(height: 12),
-          if (_hasTrackControls) _buildTrackControls(),
         ],
       ),
     );
@@ -165,8 +164,8 @@ class PlaybackControls extends StatelessWidget {
   }
 
   Widget _buildControlRow(ColorScheme colorScheme) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
+    final transportControls = Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
         if (!isLive)
           _ControlButton(
@@ -205,6 +204,13 @@ class PlaybackControls extends StatelessWidget {
             },
             colorScheme: colorScheme,
           ),
+      ],
+    );
+
+    return Row(
+      children: [
+        Expanded(child: Center(child: transportControls)),
+        if (_hasTrackControls) _buildTrackControls(),
       ],
     );
   }

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -14,6 +14,7 @@ import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
+import 'package:media_kit_video/media_kit_video.dart' as mkv;
 
 /// Full-screen player screen with playback controls, EPG overlay,
 /// resume prompt, backend fallback display, and progress reporting.
@@ -461,6 +462,14 @@ class _PlayerScreenState extends State<PlayerScreen> {
                     textureId: widget.orchestrator.activeTextureId,
                   ),
                 ),
+
+                if (widget.orchestrator.activeSubtitleController != null)
+                  Positioned.fill(
+                    child: mkv.SubtitleView(
+                      controller: widget.orchestrator.activeSubtitleController!,
+                      configuration: const mkv.SubtitleViewConfiguration(),
+                    ),
+                  ),
 
                 // Loading indicator
                 if (_status == PlaybackStatus.loading && _errorMessage == null)

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -53,14 +53,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
   String? _fallbackReason;
   bool _isPlaying = false;
 
-  // Track state (used for future track selector integration)
-  // ignore: unused_field
   List<PlaybackTrack> _audioTracks = [];
-  // ignore: unused_field
   List<PlaybackTrack> _subtitleTracks = [];
-  // ignore: unused_field
   String? _selectedAudioTrackId;
-  // ignore: unused_field
   String? _selectedSubtitleTrackId;
 
   EpgCurrentNext? _epgData;
@@ -374,13 +369,10 @@ class _PlayerScreenState extends State<PlayerScreen> {
     unawaited(widget.orchestrator.seek(position));
   }
 
-  // Track selection handlers (for future track selector integration)
-  // ignore: unused_element
   void _handleAudioTrackSelected(String? trackId) {
     unawaited(widget.orchestrator.setAudioTrack(trackId));
   }
 
-  // ignore: unused_element
   void _handleSubtitleTrackSelected(String? trackId) {
     unawaited(widget.orchestrator.setSubtitleTrack(trackId));
   }
@@ -546,6 +538,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
                     onPlayPause: _togglePlayPause,
                     onSeek: _seekTo,
                     onBack: _goBack,
+                    audioTracks: _audioTracks,
+                    subtitleTracks: _subtitleTracks,
+                    selectedAudioTrackId: _selectedAudioTrackId,
+                    selectedSubtitleTrackId: _selectedSubtitleTrackId,
+                    onAudioTrackSelected: _handleAudioTrackSelected,
+                    onSubtitleTrackSelected: _handleSubtitleTrackSelected,
                     fallbackReason: _fallbackReason,
                     playPauseFocusNode: _controlsFocusNode,
                   ),

--- a/flutter_client/lib/features/player/track_selector.dart
+++ b/flutter_client/lib/features/player/track_selector.dart
@@ -21,6 +21,9 @@ class TrackSelector extends StatelessWidget {
     super.key,
   });
 
+  static const double buttonWidth = 112;
+  static const double controlsWidth = buttonWidth * 2 + 8;
+
   /// Available audio tracks.
   final List<PlaybackTrack> audioTracks;
 
@@ -47,7 +50,7 @@ class TrackSelector extends StatelessWidget {
         if (audioTracks.isNotEmpty)
           _TrackButton(
             icon: Icons.audiotrack,
-            label: _audioLabel,
+            label: 'Audio',
             onTap: () => _showAudioDialog(context),
           ),
         if (audioTracks.isNotEmpty && subtitleTracks.isNotEmpty)
@@ -55,27 +58,15 @@ class TrackSelector extends StatelessWidget {
         if (subtitleTracks.isNotEmpty)
           _TrackButton(
             icon: Icons.subtitles,
-            label: _subtitleLabel,
+            label: 'Subtitles',
             onTap: () => _showSubtitleDialog(context),
           ),
       ],
     );
   }
 
-  String get _audioLabel {
-    final track = selectedAudioTrackId == null
-        ? audioTracks.firstOrNull
-        : audioTracks.where((t) => t.id == selectedAudioTrackId).firstOrNull;
-    return 'Audio: ${track?.label ?? 'Select'}';
-  }
-
-  String get _subtitleLabel {
-    if (selectedSubtitleTrackId == null) return 'Subs: Off';
-    final track = subtitleTracks
-        .where((t) => t.id == selectedSubtitleTrackId)
-        .firstOrNull;
-    return 'Subs: ${track?.label ?? 'Select'}';
-  }
+  String? get _effectiveAudioTrackId =>
+      selectedAudioTrackId ?? audioTracks.firstOrNull?.id;
 
   void _showAudioDialog(BuildContext context) {
     unawaited(
@@ -88,7 +79,7 @@ class TrackSelector extends StatelessWidget {
               children: [
                 ListTile(
                   title: const Text('Disable'),
-                  selected: selectedAudioTrackId == null,
+                  selected: _effectiveAudioTrackId == null,
                   onTap: () {
                     onAudioTrackSelected(null);
                     Navigator.of(context).pop();
@@ -97,7 +88,7 @@ class TrackSelector extends StatelessWidget {
                 ...audioTracks.map(
                   (track) => ListTile(
                     title: Text(track.label),
-                    selected: track.id == selectedAudioTrackId,
+                    selected: track.id == _effectiveAudioTrackId,
                     onTap: () {
                       onAudioTrackSelected(track.id);
                       Navigator.of(context).pop();
@@ -197,7 +188,7 @@ class _TrackButton extends StatelessWidget {
       child: GestureDetector(
         onTap: onTap,
         child: Container(
-          width: 160,
+          width: TrackSelector.buttonWidth,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
           decoration: BoxDecoration(
             color: Colors.white10,

--- a/flutter_client/lib/features/player/track_selector.dart
+++ b/flutter_client/lib/features/player/track_selector.dart
@@ -63,19 +63,18 @@ class TrackSelector extends StatelessWidget {
   }
 
   String get _audioLabel {
-    if (selectedAudioTrackId == null) return 'Disabled';
-    final track = audioTracks
-        .where((t) => t.id == selectedAudioTrackId)
-        .firstOrNull;
-    return track?.label ?? 'Select';
+    final track = selectedAudioTrackId == null
+        ? audioTracks.firstOrNull
+        : audioTracks.where((t) => t.id == selectedAudioTrackId).firstOrNull;
+    return 'Audio: ${track?.label ?? 'Select'}';
   }
 
   String get _subtitleLabel {
-    if (selectedSubtitleTrackId == null) return 'Off';
+    if (selectedSubtitleTrackId == null) return 'Subs: Off';
     final track = subtitleTracks
         .where((t) => t.id == selectedSubtitleTrackId)
         .firstOrNull;
-    return track?.label ?? 'Select';
+    return 'Subs: ${track?.label ?? 'Select'}';
   }
 
   void _showAudioDialog(BuildContext context) {
@@ -85,8 +84,7 @@ class TrackSelector extends StatelessWidget {
         builder: (context) {
           return AlertDialog(
             title: const Text('Audio Track'),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
+            content: _TrackDialogList(
               children: [
                 ListTile(
                   title: const Text('Disable'),
@@ -121,8 +119,7 @@ class TrackSelector extends StatelessWidget {
         builder: (context) {
           return AlertDialog(
             title: const Text('Subtitle Track'),
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
+            content: _TrackDialogList(
               children: [
                 ListTile(
                   title: const Text('Off'),
@@ -146,6 +143,30 @@ class TrackSelector extends StatelessWidget {
             ),
           );
         },
+      ),
+    );
+  }
+}
+
+class _TrackDialogList extends StatelessWidget {
+  const _TrackDialogList({required this.children});
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final maxHeight = MediaQuery.sizeOf(context).height * 0.55;
+    return SizedBox(
+      width: double.maxFinite,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxHeight: maxHeight),
+        child: Scrollbar(
+          thumbVisibility: true,
+          child: ListView(
+            shrinkWrap: true,
+            children: children,
+          ),
+        ),
       ),
     );
   }
@@ -176,6 +197,7 @@ class _TrackButton extends StatelessWidget {
       child: GestureDetector(
         onTap: onTap,
         child: Container(
+          width: 160,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
           decoration: BoxDecoration(
             color: Colors.white10,
@@ -186,14 +208,17 @@ class _TrackButton extends StatelessWidget {
             children: [
               Icon(icon, size: 16, color: colorScheme.onSurface),
               const SizedBox(width: 6),
-              Text(
-                label,
-                style: TextStyle(
-                  color: colorScheme.onSurface,
-                  fontSize: 13,
-                  fontWeight: FontWeight.w600,
+              Expanded(
+                child: Text(
+                  label,
+                  style: TextStyle(
+                    color: colorScheme.onSurface,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
-                overflow: TextOverflow.ellipsis,
               ),
             ],
           ),

--- a/flutter_client/lib/features/player/track_selector.dart
+++ b/flutter_client/lib/features/player/track_selector.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
+import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:m3u_tv/shared/gradient_border_effect.dart';
 
 /// Track selector widget for audio and subtitle track selection.
 ///
@@ -164,29 +166,37 @@ class _TrackButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-        decoration: BoxDecoration(
-          color: Colors.white10,
-          borderRadius: BorderRadius.circular(8),
+    return DpadFocusable(
+      onSelect: onTap,
+      effects: const [
+        GradientBorderEffect(
+          borderRadius: BorderRadius.all(Radius.circular(8)),
         ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(icon, size: 16, color: colorScheme.onSurface),
-            const SizedBox(width: 6),
-            Text(
-              label,
-              style: TextStyle(
-                color: colorScheme.onSurface,
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
+      ],
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          decoration: BoxDecoration(
+            color: Colors.white10,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 16, color: colorScheme.onSurface),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+                overflow: TextOverflow.ellipsis,
               ),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/flutter_client/lib/features/player/track_selector.dart
+++ b/flutter_client/lib/features/player/track_selector.dart
@@ -21,7 +21,7 @@ class TrackSelector extends StatelessWidget {
     super.key,
   });
 
-  static const double buttonWidth = 112;
+  static const double buttonWidth = 136;
   static const double controlsWidth = buttonWidth * 2 + 8;
 
   /// Available audio tracks.
@@ -194,24 +194,26 @@ class _TrackButton extends StatelessWidget {
             color: Colors.white10,
             borderRadius: BorderRadius.circular(8),
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(icon, size: 16, color: colorScheme.onSurface),
-              const SizedBox(width: 6),
-              Expanded(
-                child: Text(
-                  label,
-                  style: TextStyle(
-                    color: colorScheme.onSurface,
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
+          child: Center(
+            child: FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(icon, size: 16, color: colorScheme.onSurface),
+                  const SizedBox(width: 6),
+                  Text(
+                    label,
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600,
+                    ),
+                    maxLines: 1,
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
+                ],
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/flutter_client/lib/playback/android_playback_adapter.dart
+++ b/flutter_client/lib/playback/android_playback_adapter.dart
@@ -195,11 +195,17 @@ class AndroidPlaybackAdapter implements PlayerAdapter, VideoTextureProvider {
 
   @override
   Future<void> setAudioTrack(String? trackId) async {
+    if (_activeBackend == PlaybackBackend.androidExoPlayer) {
+      await _media3Host.setAudioTrack(trackId);
+    }
     _emit(_state.copyWith(selectedAudioTrackId: trackId));
   }
 
   @override
   Future<void> setSubtitleTrack(String? trackId) async {
+    if (_activeBackend == PlaybackBackend.androidExoPlayer) {
+      await _media3Host.setSubtitleTrack(trackId);
+    }
     _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
   }
 
@@ -301,14 +307,25 @@ class AndroidPlaybackAdapter implements PlayerAdapter, VideoTextureProvider {
       AndroidMedia3EventType.disposed => PlaybackStatus.stopped,
       AndroidMedia3EventType.error => _state.status,
     };
-    _emit(
-      _state.copyWith(
-        backend: PlaybackBackend.androidExoPlayer,
-        status: status,
-        position: event.position ?? _state.position,
-        duration: event.duration,
-      ),
+    var nextState = _state.copyWith(
+      backend: PlaybackBackend.androidExoPlayer,
+      status: status,
+      position: event.position ?? _state.position,
+      duration: event.duration,
+      audioTracks: event.audioTracks,
+      subtitleTracks: event.subtitleTracks,
     );
+    if (event.hasSelectedAudioTrackId) {
+      nextState = nextState.copyWith(
+        selectedAudioTrackId: event.selectedAudioTrackId,
+      );
+    }
+    if (event.hasSelectedSubtitleTrackId) {
+      nextState = nextState.copyWith(
+        selectedSubtitleTrackId: event.selectedSubtitleTrackId,
+      );
+    }
+    _emit(nextState);
   }
 }
 
@@ -320,6 +337,8 @@ abstract class AndroidMedia3Host {
   Future<void> pause();
   Future<void> seek(Duration position);
   Future<void> stop();
+  Future<void> setAudioTrack(String? trackId);
+  Future<void> setSubtitleTrack(String? trackId);
   Future<void> dispose();
 }
 
@@ -381,6 +400,18 @@ class MethodChannelAndroidMedia3Host implements AndroidMedia3Host {
   Future<void> stop() => _methodChannel.invokeMethod<void>('stop');
 
   @override
+  Future<void> setAudioTrack(String? trackId) => _methodChannel.invokeMethod<void>(
+    'setAudioTrack',
+    <String, Object?>{'trackId': trackId},
+  );
+
+  @override
+  Future<void> setSubtitleTrack(String? trackId) => _methodChannel.invokeMethod<void>(
+    'setSubtitleTrack',
+    <String, Object?>{'trackId': trackId},
+  );
+
+  @override
   Future<void> dispose() async {
     try {
       await _methodChannel.invokeMethod<void>('dispose');
@@ -407,10 +438,19 @@ class AndroidMedia3Event {
     this.position,
     this.duration,
     this.textureId,
+    this.audioTracks,
+    this.subtitleTracks,
+    this.selectedAudioTrackId,
+    this.selectedSubtitleTrackId,
+    bool? hasSelectedAudioTrackId,
+    bool? hasSelectedSubtitleTrackId,
     this.code,
     this.message,
     this.recoverable = false,
-  });
+  }) : hasSelectedAudioTrackId =
+           hasSelectedAudioTrackId ?? selectedAudioTrackId != null,
+       hasSelectedSubtitleTrackId =
+           hasSelectedSubtitleTrackId ?? selectedSubtitleTrackId != null;
 
   factory AndroidMedia3Event.fromMap(Map<String, Object?> map) {
     return AndroidMedia3Event(
@@ -423,6 +463,12 @@ class AndroidMedia3Event {
           ? Duration(milliseconds: (map['durationMs']! as num).round())
           : null,
       textureId: (map['textureId'] as num?)?.toInt(),
+      audioTracks: _tracksFromMap(map['audioTracks']),
+      subtitleTracks: _tracksFromMap(map['subtitleTracks']),
+      selectedAudioTrackId: map['selectedAudioTrackId'] as String?,
+      selectedSubtitleTrackId: map['selectedSubtitleTrackId'] as String?,
+      hasSelectedAudioTrackId: map.containsKey('selectedAudioTrackId'),
+      hasSelectedSubtitleTrackId: map.containsKey('selectedSubtitleTrackId'),
       code: map['code'] as String?,
       message: map['message'] as String?,
       recoverable: map['recoverable'] == true,
@@ -434,9 +480,29 @@ class AndroidMedia3Event {
   final Duration? position;
   final Duration? duration;
   final int? textureId;
+  final List<PlaybackTrack>? audioTracks;
+  final List<PlaybackTrack>? subtitleTracks;
+  final String? selectedAudioTrackId;
+  final String? selectedSubtitleTrackId;
+  final bool hasSelectedAudioTrackId;
+  final bool hasSelectedSubtitleTrackId;
   final String? code;
   final String? message;
   final bool recoverable;
+
+  static List<PlaybackTrack>? _tracksFromMap(Object? raw) {
+    if (raw == null) return null;
+    return (raw as List<Object?>)
+        .map((item) => Map<String, Object?>.from(item! as Map<Object?, Object?>))
+        .map(
+          (track) => PlaybackTrack(
+            id: track['id']! as String,
+            label: track['label']! as String,
+            language: track['language'] as String?,
+          ),
+        )
+        .toList(growable: false);
+  }
 
   static AndroidMedia3EventType _typeFromString(String? value) {
     return switch (value) {

--- a/flutter_client/lib/playback/android_playback_adapter.dart
+++ b/flutter_client/lib/playback/android_playback_adapter.dart
@@ -400,16 +400,18 @@ class MethodChannelAndroidMedia3Host implements AndroidMedia3Host {
   Future<void> stop() => _methodChannel.invokeMethod<void>('stop');
 
   @override
-  Future<void> setAudioTrack(String? trackId) => _methodChannel.invokeMethod<void>(
-    'setAudioTrack',
-    <String, Object?>{'trackId': trackId},
-  );
+  Future<void> setAudioTrack(String? trackId) =>
+      _methodChannel.invokeMethod<void>(
+        'setAudioTrack',
+        <String, Object?>{'trackId': trackId},
+      );
 
   @override
-  Future<void> setSubtitleTrack(String? trackId) => _methodChannel.invokeMethod<void>(
-    'setSubtitleTrack',
-    <String, Object?>{'trackId': trackId},
-  );
+  Future<void> setSubtitleTrack(String? trackId) =>
+      _methodChannel.invokeMethod<void>(
+        'setSubtitleTrack',
+        <String, Object?>{'trackId': trackId},
+      );
 
   @override
   Future<void> dispose() async {
@@ -493,7 +495,9 @@ class AndroidMedia3Event {
   static List<PlaybackTrack>? _tracksFromMap(Object? raw) {
     if (raw == null) return null;
     return (raw as List<Object?>)
-        .map((item) => Map<String, Object?>.from(item! as Map<Object?, Object?>))
+        .map(
+          (item) => Map<String, Object?>.from(item! as Map<Object?, Object?>),
+        )
         .map(
           (track) => PlaybackTrack(
             id: track['id']! as String,

--- a/flutter_client/lib/playback/apple_avkit_backend.dart
+++ b/flutter_client/lib/playback/apple_avkit_backend.dart
@@ -87,11 +87,13 @@ class AppleAvKitBackend implements PlayerAdapter, VideoTextureProvider {
 
   @override
   Future<void> setAudioTrack(String? trackId) async {
+    await _host.setAudioTrack(trackId);
     _emit(_state.copyWith(selectedAudioTrackId: trackId));
   }
 
   @override
   Future<void> setSubtitleTrack(String? trackId) async {
+    await _host.setSubtitleTrack(trackId);
     _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
   }
 
@@ -129,13 +131,24 @@ class AppleAvKitBackend implements PlayerAdapter, VideoTextureProvider {
       _AvKitEventType.disposed => PlaybackStatus.stopped,
       _AvKitEventType.error => _state.status,
     };
-    _emit(
-      _state.copyWith(
-        backend: PlaybackBackend.appleAvKit,
-        status: status,
-        position: event.position ?? _state.position,
-      ),
+    var nextState = _state.copyWith(
+      backend: PlaybackBackend.appleAvKit,
+      status: status,
+      position: event.position ?? _state.position,
+      audioTracks: event.audioTracks,
+      subtitleTracks: event.subtitleTracks,
     );
+    if (event.hasSelectedAudioTrackId) {
+      nextState = nextState.copyWith(
+        selectedAudioTrackId: event.selectedAudioTrackId,
+      );
+    }
+    if (event.hasSelectedSubtitleTrackId) {
+      nextState = nextState.copyWith(
+        selectedSubtitleTrackId: event.selectedSubtitleTrackId,
+      );
+    }
+    _emit(nextState);
   }
 
   void _emit(PlaybackState state) {
@@ -154,6 +167,8 @@ abstract class _AvKitHost {
   Future<void> pause();
   Future<void> seek(Duration position);
   Future<void> stop();
+  Future<void> setAudioTrack(String? trackId);
+  Future<void> setSubtitleTrack(String? trackId);
   Future<void> dispose();
 }
 
@@ -211,6 +226,18 @@ class _MethodChannelAvKitHost implements _AvKitHost {
   Future<void> stop() => _method.invokeMethod<void>('stop');
 
   @override
+  Future<void> setAudioTrack(String? trackId) => _method.invokeMethod<void>(
+    'setAudioTrack',
+    <String, Object?>{'trackId': trackId},
+  );
+
+  @override
+  Future<void> setSubtitleTrack(String? trackId) => _method.invokeMethod<void>(
+    'setSubtitleTrack',
+    <String, Object?>{'trackId': trackId},
+  );
+
+  @override
   Future<void> dispose() async {
     try {
       await _method.invokeMethod<void>('dispose');
@@ -236,16 +263,31 @@ class _AvKitEvent {
   const _AvKitEvent({
     required this.type,
     this.position,
+    this.audioTracks,
+    this.subtitleTracks,
+    this.selectedAudioTrackId,
+    this.selectedSubtitleTrackId,
+    bool? hasSelectedAudioTrackId,
+    bool? hasSelectedSubtitleTrackId,
     this.code,
     this.message,
     this.recoverable = false,
-  });
+  }) : hasSelectedAudioTrackId =
+           hasSelectedAudioTrackId ?? selectedAudioTrackId != null,
+       hasSelectedSubtitleTrackId =
+           hasSelectedSubtitleTrackId ?? selectedSubtitleTrackId != null;
 
   factory _AvKitEvent.fromMap(Map<String, Object?> map) => _AvKitEvent(
     type: _typeFrom(map['type'] as String?),
     position: map['positionMs'] is num
         ? Duration(milliseconds: (map['positionMs']! as num).round())
         : null,
+    audioTracks: _tracksFromMap(map['audioTracks']),
+    subtitleTracks: _tracksFromMap(map['subtitleTracks']),
+    selectedAudioTrackId: map['selectedAudioTrackId'] as String?,
+    selectedSubtitleTrackId: map['selectedSubtitleTrackId'] as String?,
+    hasSelectedAudioTrackId: map.containsKey('selectedAudioTrackId'),
+    hasSelectedSubtitleTrackId: map.containsKey('selectedSubtitleTrackId'),
     code: map['code'] as String?,
     message: map['message'] as String?,
     recoverable: map['recoverable'] == true,
@@ -253,9 +295,29 @@ class _AvKitEvent {
 
   final _AvKitEventType type;
   final Duration? position;
+  final List<PlaybackTrack>? audioTracks;
+  final List<PlaybackTrack>? subtitleTracks;
+  final String? selectedAudioTrackId;
+  final String? selectedSubtitleTrackId;
+  final bool hasSelectedAudioTrackId;
+  final bool hasSelectedSubtitleTrackId;
   final String? code;
   final String? message;
   final bool recoverable;
+
+  static List<PlaybackTrack>? _tracksFromMap(Object? raw) {
+    if (raw == null) return null;
+    return (raw as List<Object?>)
+        .map((item) => Map<String, Object?>.from(item! as Map<Object?, Object?>))
+        .map(
+          (track) => PlaybackTrack(
+            id: track['id']! as String,
+            label: track['label']! as String,
+            language: track['language'] as String?,
+          ),
+        )
+        .toList(growable: false);
+  }
 
   static _AvKitEventType _typeFrom(String? value) => switch (value) {
     'buffering' => _AvKitEventType.buffering,

--- a/flutter_client/lib/playback/apple_avkit_backend.dart
+++ b/flutter_client/lib/playback/apple_avkit_backend.dart
@@ -308,7 +308,9 @@ class _AvKitEvent {
   static List<PlaybackTrack>? _tracksFromMap(Object? raw) {
     if (raw == null) return null;
     return (raw as List<Object?>)
-        .map((item) => Map<String, Object?>.from(item! as Map<Object?, Object?>))
+        .map(
+          (item) => Map<String, Object?>.from(item! as Map<Object?, Object?>),
+        )
         .map(
           (track) => PlaybackTrack(
             id: track['id']! as String,

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -72,6 +72,28 @@ class MediaKitDesktopAdapter implements PlayerAdapter, VideoTextureProvider {
         }),
       )
       ..add(
+        _player.stream.tracks.listen((tracks) {
+          _emit(
+            _state.copyWith(
+              audioTracks: mediaKitAudioTracksToPlaybackTracks(tracks.audio),
+              subtitleTracks: mediaKitSubtitleTracksToPlaybackTracks(
+                tracks.subtitle,
+              ),
+            ),
+          );
+        }),
+      )
+      ..add(
+        _player.stream.track.listen((track) {
+          _emit(
+            _state.copyWith(
+              selectedAudioTrackId: _selectedTrackId(track.audio.id),
+              selectedSubtitleTrackId: _selectedTrackId(track.subtitle.id),
+            ),
+          );
+        }),
+      )
+      ..add(
         _player.stream.completed.listen((completed) {
           if (completed) {
             _emit(_state.copyWith(status: PlaybackStatus.completed));
@@ -121,12 +143,26 @@ class MediaKitDesktopAdapter implements PlayerAdapter, VideoTextureProvider {
 
   @override
   Future<void> setAudioTrack(String? trackId) async {
-    // Track selection via media_kit typed objects is deferred.
+    final track = trackId == null
+        ? mk.AudioTrack.no()
+        : _player.state.tracks.audio.firstWhere(
+            (track) => track.id == trackId,
+            orElse: () => mk.AudioTrack(trackId, null, null),
+          );
+    await _player.setAudioTrack(track);
+    _emit(_state.copyWith(selectedAudioTrackId: trackId));
   }
 
   @override
   Future<void> setSubtitleTrack(String? trackId) async {
-    // Track selection via media_kit typed objects is deferred.
+    final track = trackId == null
+        ? mk.SubtitleTrack.no()
+        : _player.state.tracks.subtitle.firstWhere(
+            (track) => track.id == trackId,
+            orElse: () => mk.SubtitleTrack(trackId, null, null),
+          );
+    await _player.setSubtitleTrack(track);
+    _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
   }
 
   @override
@@ -148,3 +184,57 @@ class MediaKitDesktopAdapter implements PlayerAdapter, VideoTextureProvider {
     if (!_stateController.isClosed) _stateController.add(state);
   }
 }
+
+List<PlaybackTrack> mediaKitAudioTracksToPlaybackTracks(
+  List<mk.AudioTrack> tracks,
+) {
+  return tracks
+      .where((track) => !_isMediaKitSentinelTrack(track.id))
+      .map(
+        (track) => PlaybackTrack(
+          id: track.id,
+          label: _mediaKitTrackLabel(
+            id: track.id,
+            title: track.title,
+            language: track.language,
+          ),
+          language: track.language,
+        ),
+      )
+      .toList(growable: false);
+}
+
+List<PlaybackTrack> mediaKitSubtitleTracksToPlaybackTracks(
+  List<mk.SubtitleTrack> tracks,
+) {
+  return tracks
+      .where((track) => !_isMediaKitSentinelTrack(track.id))
+      .map(
+        (track) => PlaybackTrack(
+          id: track.id,
+          label: _mediaKitTrackLabel(
+            id: track.id,
+            title: track.title,
+            language: track.language,
+          ),
+          language: track.language,
+        ),
+      )
+      .toList(growable: false);
+}
+
+String _mediaKitTrackLabel({
+  required String id,
+  required String? title,
+  required String? language,
+}) {
+  final cleanTitle = title?.trim();
+  if (cleanTitle != null && cleanTitle.isNotEmpty) return cleanTitle;
+  final cleanLanguage = language?.trim();
+  if (cleanLanguage != null && cleanLanguage.isNotEmpty) return cleanLanguage;
+  return 'Track $id';
+}
+
+String? _selectedTrackId(String id) => id == 'no' ? null : id;
+
+bool _isMediaKitSentinelTrack(String id) => id == 'auto' || id == 'no';

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -79,6 +79,10 @@ class MediaKitDesktopAdapter implements PlayerAdapter, VideoTextureProvider {
               subtitleTracks: mediaKitSubtitleTracksToPlaybackTracks(
                 tracks.subtitle,
               ),
+              selectedAudioTrackId: selectedMediaKitAudioTrackId(
+                _player.state.track.audio,
+                tracks.audio,
+              ),
             ),
           );
         }),
@@ -87,7 +91,10 @@ class MediaKitDesktopAdapter implements PlayerAdapter, VideoTextureProvider {
         _player.stream.track.listen((track) {
           _emit(
             _state.copyWith(
-              selectedAudioTrackId: _selectedTrackId(track.audio.id),
+              selectedAudioTrackId: selectedMediaKitAudioTrackId(
+                track.audio,
+                _player.state.tracks.audio,
+              ),
               selectedSubtitleTrackId: _selectedTrackId(track.subtitle.id),
             ),
           );
@@ -235,6 +242,19 @@ String _mediaKitTrackLabel({
   return 'Track $id';
 }
 
-String? _selectedTrackId(String id) => id == 'no' ? null : id;
+String? selectedMediaKitAudioTrackId(
+  mk.AudioTrack selectedTrack,
+  List<mk.AudioTrack> availableTracks,
+) {
+  if (selectedTrack.id == 'no') return null;
+  if (selectedTrack.id != 'auto') return selectedTrack.id;
+
+  return availableTracks
+      .where((track) => !_isMediaKitSentinelTrack(track.id))
+      .firstOrNull
+      ?.id;
+}
+
+String? _selectedTrackId(String id) => id == 'no' || id == 'auto' ? null : id;
 
 bool _isMediaKitSentinelTrack(String id) => id == 'auto' || id == 'no';

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -2,10 +2,12 @@ import 'dart:async';
 
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:m3u_tv/playback/subtitle_controller_provider.dart';
 import 'package:media_kit/media_kit.dart' as mk;
 import 'package:media_kit_video/media_kit_video.dart' as mkv;
 
-class MediaKitDesktopAdapter implements PlayerAdapter, VideoTextureProvider {
+class MediaKitDesktopAdapter
+    implements PlayerAdapter, VideoTextureProvider, SubtitleControllerProvider {
   MediaKitDesktopAdapter() {
     _player = mk.Player();
     _controller = mkv.VideoController(_player);
@@ -28,6 +30,9 @@ class MediaKitDesktopAdapter implements PlayerAdapter, VideoTextureProvider {
 
   @override
   int? get textureId => _controller.id.value;
+
+  @override
+  mkv.VideoController get subtitleController => _controller;
 
   @override
   PlaybackCapabilities get capabilities => PlaybackCapabilities.desktopLibmpv;

--- a/flutter_client/lib/playback/media_kit_ios_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_ios_adapter.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 
+import 'package:m3u_tv/playback/media_kit_desktop_adapter.dart';
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:m3u_tv/playback/subtitle_controller_provider.dart';
 import 'package:media_kit/media_kit.dart' as mk;
 import 'package:media_kit_video/media_kit_video.dart' as mkv;
 
-class MediaKitIosAdapter implements PlayerAdapter, VideoTextureProvider {
+class MediaKitIosAdapter
+    implements PlayerAdapter, VideoTextureProvider, SubtitleControllerProvider {
   MediaKitIosAdapter() {
     _player = mk.Player();
     _controller = mkv.VideoController(_player);
@@ -28,6 +31,9 @@ class MediaKitIosAdapter implements PlayerAdapter, VideoTextureProvider {
 
   @override
   int? get textureId => _controller.id.value;
+
+  @override
+  mkv.VideoController get subtitleController => _controller;
 
   @override
   PlaybackCapabilities get capabilities => PlaybackCapabilities.appleMpvKit;
@@ -68,6 +74,38 @@ class MediaKitIosAdapter implements PlayerAdapter, VideoTextureProvider {
       ..add(
         _player.stream.duration.listen((dur) {
           _emit(_state.copyWith(duration: dur));
+        }),
+      )
+      ..add(
+        _player.stream.tracks.listen((tracks) {
+          _emit(
+            _state.copyWith(
+              audioTracks: mediaKitAudioTracksToPlaybackTracks(tracks.audio),
+              subtitleTracks: mediaKitSubtitleTracksToPlaybackTracks(
+                tracks.subtitle,
+              ),
+              selectedAudioTrackId: selectedMediaKitAudioTrackId(
+                _player.state.track.audio,
+                tracks.audio,
+              ),
+            ),
+          );
+        }),
+      )
+      ..add(
+        _player.stream.track.listen((track) {
+          _emit(
+            _state.copyWith(
+              selectedAudioTrackId: selectedMediaKitAudioTrackId(
+                track.audio,
+                _player.state.tracks.audio,
+              ),
+              selectedSubtitleTrackId:
+                  track.subtitle.id == 'no' || track.subtitle.id == 'auto'
+                  ? null
+                  : track.subtitle.id,
+            ),
+          );
         }),
       )
       ..add(
@@ -119,10 +157,28 @@ class MediaKitIosAdapter implements PlayerAdapter, VideoTextureProvider {
   }
 
   @override
-  Future<void> setAudioTrack(String? trackId) async {}
+  Future<void> setAudioTrack(String? trackId) async {
+    final track = trackId == null
+        ? mk.AudioTrack.no()
+        : _player.state.tracks.audio.firstWhere(
+            (t) => t.id == trackId,
+            orElse: () => mk.AudioTrack(trackId, null, null),
+          );
+    await _player.setAudioTrack(track);
+    _emit(_state.copyWith(selectedAudioTrackId: trackId));
+  }
 
   @override
-  Future<void> setSubtitleTrack(String? trackId) async {}
+  Future<void> setSubtitleTrack(String? trackId) async {
+    final track = trackId == null
+        ? mk.SubtitleTrack.no()
+        : _player.state.tracks.subtitle.firstWhere(
+            (t) => t.id == trackId,
+            orElse: () => mk.SubtitleTrack(trackId, null, null),
+          );
+    await _player.setSubtitleTrack(track);
+    _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
+  }
 
   @override
   Future<void> setPlaybackSpeed(double speed) => _player.setRate(speed);

--- a/flutter_client/lib/playback/playback_orchestrator.dart
+++ b/flutter_client/lib/playback/playback_orchestrator.dart
@@ -4,7 +4,9 @@ import 'dart:async';
 
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:m3u_tv/playback/subtitle_controller_provider.dart';
 import 'package:m3u_tv/transcoding/transcoding.dart';
+import 'package:media_kit_video/media_kit_video.dart' as mkv;
 
 abstract class PlaybackTranscodeGateway {
   Future<TranscodeResponse> startServerTranscode(StreamRequest request);
@@ -70,6 +72,12 @@ class PlaybackOrchestrator {
     final adapter = _activeAdapter;
     if (adapter is! VideoTextureProvider) return null;
     return (adapter! as VideoTextureProvider).textureId;
+  }
+
+  mkv.VideoController? get activeSubtitleController {
+    final adapter = _activeAdapter;
+    if (adapter == null || adapter is! SubtitleControllerProvider) return null;
+    return (adapter as SubtitleControllerProvider).subtitleController;
   }
 
   List<String> get diagnostics => List<String>.unmodifiable(_diagnostics);

--- a/flutter_client/lib/playback/subtitle_controller_provider.dart
+++ b/flutter_client/lib/playback/subtitle_controller_provider.dart
@@ -1,0 +1,8 @@
+import 'package:media_kit_video/media_kit_video.dart' as mkv;
+
+/// Implemented by adapters that expose a [mkv.VideoController] for use with
+/// [mkv.SubtitleView], which renders text subtitles as a Flutter overlay
+/// without interfering with the native video rendering pipeline.
+abstract class SubtitleControllerProvider {
+  mkv.VideoController get subtitleController;
+}

--- a/flutter_client/test/playback/android_backend_fallback_test.dart
+++ b/flutter_client/test/playback/android_backend_fallback_test.dart
@@ -239,6 +239,64 @@ void main() {
       },
     );
 
+
+
+    test('maps native Media3 track events and forwards track selection', () async {
+      final host = _FakeAndroidMedia3Host();
+      final adapter = AndroidPlaybackAdapter(
+        probe: const AndroidPlaybackProbe(
+          hardwareCodecs: <VideoCodec>{VideoCodec.h264},
+          passthroughAudioCodecs: <AudioCodec>{AudioCodec.aac},
+          mpvAvailable: false,
+          serverTranscodeAvailable: false,
+        ),
+        media3Host: host,
+      );
+      final states = <PlaybackState>[];
+      final subscription = adapter.onState.listen(states.add);
+
+      await adapter.load(
+        const PlaybackSource(uri: 'https://fixtures.example/movie.m3u8'),
+      );
+      host.emit(
+        const AndroidMedia3Event(
+          type: AndroidMedia3EventType.ready,
+          audioTracks: <PlaybackTrack>[
+            PlaybackTrack(id: 'audio:0:0', label: 'English', language: 'en'),
+            PlaybackTrack(id: 'audio:0:1', label: 'Deutsch', language: 'de'),
+          ],
+          subtitleTracks: <PlaybackTrack>[
+            PlaybackTrack(id: 'subtitle:1:0', label: 'English CC', language: 'en'),
+          ],
+          selectedAudioTrackId: 'audio:0:0',
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(states.last.audioTracks.map((track) => track.label), <String>[
+        'English',
+        'Deutsch',
+      ]);
+      expect(states.last.subtitleTracks.single.label, 'English CC');
+      expect(states.last.selectedAudioTrackId, 'audio:0:0');
+
+      await adapter.setAudioTrack('audio:0:1');
+      await adapter.setSubtitleTrack('subtitle:1:0');
+      await adapter.setSubtitleTrack(null);
+      await pumpEventQueue();
+
+      expect(host.commands, containsAll(<String>[
+        'setAudioTrack:audio:0:1',
+        'setSubtitleTrack:subtitle:1:0',
+        'setSubtitleTrack:null',
+      ]));
+      expect(states.last.selectedAudioTrackId, 'audio:0:1');
+      expect(states.last.selectedSubtitleTrackId, isNull);
+
+      await subscription.cancel();
+      await adapter.dispose();
+    });
+
     test(
       'maps ExoPlayer commands and typed native events through Media3 host',
       () async {
@@ -408,6 +466,14 @@ class _FakeAndroidMedia3Host implements AndroidMedia3Host {
 
   @override
   Future<void> stop() async => commands.add('stop');
+
+  @override
+  Future<void> setAudioTrack(String? trackId) async =>
+      commands.add('setAudioTrack:$trackId');
+
+  @override
+  Future<void> setSubtitleTrack(String? trackId) async =>
+      commands.add('setSubtitleTrack:$trackId');
 
   @override
   Future<void> dispose() async {

--- a/flutter_client/test/playback/android_backend_fallback_test.dart
+++ b/flutter_client/test/playback/android_backend_fallback_test.dart
@@ -239,63 +239,71 @@ void main() {
       },
     );
 
+    test(
+      'maps native Media3 track events and forwards track selection',
+      () async {
+        final host = _FakeAndroidMedia3Host();
+        final adapter = AndroidPlaybackAdapter(
+          probe: const AndroidPlaybackProbe(
+            hardwareCodecs: <VideoCodec>{VideoCodec.h264},
+            passthroughAudioCodecs: <AudioCodec>{AudioCodec.aac},
+            mpvAvailable: false,
+            serverTranscodeAvailable: false,
+          ),
+          media3Host: host,
+        );
+        final states = <PlaybackState>[];
+        final subscription = adapter.onState.listen(states.add);
 
+        await adapter.load(
+          const PlaybackSource(uri: 'https://fixtures.example/movie.m3u8'),
+        );
+        host.emit(
+          const AndroidMedia3Event(
+            type: AndroidMedia3EventType.ready,
+            audioTracks: <PlaybackTrack>[
+              PlaybackTrack(id: 'audio:0:0', label: 'English', language: 'en'),
+              PlaybackTrack(id: 'audio:0:1', label: 'Deutsch', language: 'de'),
+            ],
+            subtitleTracks: <PlaybackTrack>[
+              PlaybackTrack(
+                id: 'subtitle:1:0',
+                label: 'English CC',
+                language: 'en',
+              ),
+            ],
+            selectedAudioTrackId: 'audio:0:0',
+          ),
+        );
+        await pumpEventQueue();
 
-    test('maps native Media3 track events and forwards track selection', () async {
-      final host = _FakeAndroidMedia3Host();
-      final adapter = AndroidPlaybackAdapter(
-        probe: const AndroidPlaybackProbe(
-          hardwareCodecs: <VideoCodec>{VideoCodec.h264},
-          passthroughAudioCodecs: <AudioCodec>{AudioCodec.aac},
-          mpvAvailable: false,
-          serverTranscodeAvailable: false,
-        ),
-        media3Host: host,
-      );
-      final states = <PlaybackState>[];
-      final subscription = adapter.onState.listen(states.add);
+        expect(states.last.audioTracks.map((track) => track.label), <String>[
+          'English',
+          'Deutsch',
+        ]);
+        expect(states.last.subtitleTracks.single.label, 'English CC');
+        expect(states.last.selectedAudioTrackId, 'audio:0:0');
 
-      await adapter.load(
-        const PlaybackSource(uri: 'https://fixtures.example/movie.m3u8'),
-      );
-      host.emit(
-        const AndroidMedia3Event(
-          type: AndroidMedia3EventType.ready,
-          audioTracks: <PlaybackTrack>[
-            PlaybackTrack(id: 'audio:0:0', label: 'English', language: 'en'),
-            PlaybackTrack(id: 'audio:0:1', label: 'Deutsch', language: 'de'),
-          ],
-          subtitleTracks: <PlaybackTrack>[
-            PlaybackTrack(id: 'subtitle:1:0', label: 'English CC', language: 'en'),
-          ],
-          selectedAudioTrackId: 'audio:0:0',
-        ),
-      );
-      await pumpEventQueue();
+        await adapter.setAudioTrack('audio:0:1');
+        await adapter.setSubtitleTrack('subtitle:1:0');
+        await adapter.setSubtitleTrack(null);
+        await pumpEventQueue();
 
-      expect(states.last.audioTracks.map((track) => track.label), <String>[
-        'English',
-        'Deutsch',
-      ]);
-      expect(states.last.subtitleTracks.single.label, 'English CC');
-      expect(states.last.selectedAudioTrackId, 'audio:0:0');
+        expect(
+          host.commands,
+          containsAll(<String>[
+            'setAudioTrack:audio:0:1',
+            'setSubtitleTrack:subtitle:1:0',
+            'setSubtitleTrack:null',
+          ]),
+        );
+        expect(states.last.selectedAudioTrackId, 'audio:0:1');
+        expect(states.last.selectedSubtitleTrackId, isNull);
 
-      await adapter.setAudioTrack('audio:0:1');
-      await adapter.setSubtitleTrack('subtitle:1:0');
-      await adapter.setSubtitleTrack(null);
-      await pumpEventQueue();
-
-      expect(host.commands, containsAll(<String>[
-        'setAudioTrack:audio:0:1',
-        'setSubtitleTrack:subtitle:1:0',
-        'setSubtitleTrack:null',
-      ]));
-      expect(states.last.selectedAudioTrackId, 'audio:0:1');
-      expect(states.last.selectedSubtitleTrackId, isNull);
-
-      await subscription.cancel();
-      await adapter.dispose();
-    });
+        await subscription.cancel();
+        await adapter.dispose();
+      },
+    );
 
     test(
       'maps ExoPlayer commands and typed native events through Media3 host',

--- a/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
+++ b/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/playback/media_kit_desktop_adapter.dart';
+import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:media_kit/media_kit.dart' as mk;
+
+void main() {
+  group('MediaKitDesktopAdapter track mapping', () {
+    test('maps real media_kit audio tracks and hides auto/no sentinels', () {
+      final tracks = mediaKitAudioTracksToPlaybackTracks(const <mk.AudioTrack>[
+        mk.AudioTrack('auto', null, null),
+        mk.AudioTrack('no', null, null),
+        mk.AudioTrack('1', 'English', 'eng'),
+        mk.AudioTrack('2', null, 'jpn'),
+      ]);
+
+      expect(tracks, hasLength(2));
+      expect(
+        tracks.first,
+        isA<PlaybackTrack>()
+            .having((track) => track.id, 'id', '1')
+            .having((track) => track.label, 'label', 'English')
+            .having((track) => track.language, 'language', 'eng'),
+      );
+      expect(tracks.last.id, '2');
+      expect(tracks.last.label, 'jpn');
+    });
+
+    test('maps real media_kit subtitle tracks and hides auto/no sentinels', () {
+      final tracks = mediaKitSubtitleTracksToPlaybackTracks(
+        const <mk.SubtitleTrack>[
+          mk.SubtitleTrack('auto', null, null),
+          mk.SubtitleTrack('no', null, null),
+          mk.SubtitleTrack('3', 'English CC', 'eng'),
+          mk.SubtitleTrack('4', null, null),
+        ],
+      );
+
+      expect(tracks, hasLength(2));
+      expect(tracks.first.id, '3');
+      expect(tracks.first.label, 'English CC');
+      expect(tracks.last.id, '4');
+      expect(tracks.last.label, 'Track 4');
+    });
+  });
+}

--- a/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
+++ b/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
@@ -41,5 +41,32 @@ void main() {
       expect(tracks.last.id, '4');
       expect(tracks.last.label, 'Track 4');
     });
+
+    test('resolves automatic audio selection to the first real track', () {
+      final selectedTrackId = selectedMediaKitAudioTrackId(
+        mk.AudioTrack.auto(),
+        const <mk.AudioTrack>[
+          mk.AudioTrack('auto', null, null),
+          mk.AudioTrack('no', null, null),
+          mk.AudioTrack('1', null, 'de'),
+          mk.AudioTrack('2', null, 'en'),
+        ],
+      );
+
+      expect(selectedTrackId, '1');
+    });
+
+    test('keeps disabled audio selection disabled', () {
+      final selectedTrackId = selectedMediaKitAudioTrackId(
+        mk.AudioTrack.no(),
+        const <mk.AudioTrack>[
+          mk.AudioTrack('auto', null, null),
+          mk.AudioTrack('no', null, null),
+          mk.AudioTrack('1', null, 'de'),
+        ],
+      );
+
+      expect(selectedTrackId, isNull);
+    });
   });
 }

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -166,6 +166,9 @@ void main() {
     testWidgets('keeps transport controls stable when tracks appear later', (
       tester,
     ) async {
+      await tester.binding.setSurfaceSize(const Size(1200, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
       await tester.pumpWidget(
         MaterialApp(
           home: PlaybackControls(
@@ -208,16 +211,115 @@ void main() {
         ),
       );
 
-      final forwardCenter = tester.getCenter(find.byIcon(Icons.forward_10));
-      final audioCenter = tester.getCenter(find.byIcon(Icons.audiotrack));
-      final subtitleCenter = tester.getCenter(find.byIcon(Icons.subtitles));
+      final replayRect = tester.getRect(find.byIcon(Icons.replay_10));
+      final pauseRect = tester.getRect(find.byIcon(Icons.pause));
+      final forwardRect = tester.getRect(find.byIcon(Icons.forward_10));
+      final audioRect = tester.getRect(find.byIcon(Icons.audiotrack));
+      final subtitleRect = tester.getRect(find.byIcon(Icons.subtitles));
 
-      expect(audioCenter.dx, greaterThan(forwardCenter.dx));
-      expect(subtitleCenter.dx, greaterThan(audioCenter.dx));
-      expect((audioCenter.dy - forwardCenter.dy).abs(), lessThan(1));
-      expect((subtitleCenter.dy - forwardCenter.dy).abs(), lessThan(1));
+      expect(replayRect.overlaps(audioRect), isFalse);
+      expect(pauseRect.overlaps(audioRect), isFalse);
+      expect(forwardRect.overlaps(audioRect), isFalse);
+      expect(forwardRect.overlaps(subtitleRect), isFalse);
       expect(tester.getCenter(find.byIcon(Icons.pause)), playPauseBefore);
     });
+
+
+    testWidgets('stacks track selectors below transport controls on narrow portrait screens', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(430, 932));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlaybackControls(
+            isPlaying: true,
+            isLive: false,
+            canSeek: true,
+            currentPosition: const Duration(seconds: 35),
+            duration: const Duration(hours: 1, minutes: 48),
+            audioTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'audio-eng', label: 'English'),
+            ],
+            subtitleTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'sub-eng', label: 'English CC'),
+            ],
+            selectedAudioTrackId: 'audio-eng',
+            selectedSubtitleTrackId: 'sub-eng',
+            onPlayPause: () {},
+            onSeek: (_) {},
+            onBack: () {},
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Audio'), findsOneWidget);
+      expect(find.text('Subtitles'), findsOneWidget);
+
+      final audioRect = tester.getRect(find.byIcon(Icons.audiotrack));
+      final subtitleRect = tester.getRect(find.byIcon(Icons.subtitles));
+      final replayRect = tester.getRect(find.byIcon(Icons.replay_10));
+      final pauseRect = tester.getRect(find.byIcon(Icons.pause));
+      final forwardRect = tester.getRect(find.byIcon(Icons.forward_10));
+
+      expect(audioRect.top, greaterThan(forwardRect.bottom));
+      expect(subtitleRect.top, greaterThan(forwardRect.bottom));
+      expect(replayRect.overlaps(audioRect), isFalse);
+      expect(pauseRect.overlaps(audioRect), isFalse);
+      expect(forwardRect.overlaps(subtitleRect), isFalse);
+    });
+
+    testWidgets('keeps audio and subtitle selectors visible without transport overlap in landscape', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(932, 430));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlaybackControls(
+            isPlaying: true,
+            isLive: false,
+            canSeek: true,
+            currentPosition: const Duration(seconds: 35),
+            duration: const Duration(hours: 1, minutes: 48),
+            audioTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'audio-eng', label: 'English'),
+            ],
+            subtitleTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'sub-eng', label: 'English CC'),
+            ],
+            selectedAudioTrackId: 'audio-eng',
+            selectedSubtitleTrackId: 'sub-eng',
+            onPlayPause: () {},
+            onSeek: (_) {},
+            onBack: () {},
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Audio'), findsOneWidget);
+      expect(find.text('Subtitles'), findsOneWidget);
+
+      final audioRect = tester.getRect(find.byIcon(Icons.audiotrack));
+      final subtitleRect = tester.getRect(find.byIcon(Icons.subtitles));
+      final replayRect = tester.getRect(find.byIcon(Icons.replay_10));
+      final pauseRect = tester.getRect(find.byIcon(Icons.pause));
+      final forwardRect = tester.getRect(find.byIcon(Icons.forward_10));
+
+      expect(replayRect.overlaps(audioRect), isFalse);
+      expect(pauseRect.overlaps(audioRect), isFalse);
+      expect(forwardRect.overlaps(audioRect), isFalse);
+      expect(forwardRect.overlaps(subtitleRect), isFalse);
+    });
+
 
     testWidgets('labels track controls by type only', (
       tester,

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -250,6 +251,21 @@ void main() {
       expect(find.text('Subtitles'), findsOneWidget);
       expect(find.text('Audio: English'), findsNothing);
       expect(find.text('Subs: English CC'), findsNothing);
+
+      final audioButtonRect = tester.getRect(
+        find.ancestor(
+          of: find.text('Audio'),
+          matching: find.byType(DpadFocusable),
+        ),
+      );
+      final audioIconRect = tester.getRect(find.byIcon(Icons.audiotrack));
+      final audioTextRect = tester.getRect(find.text('Audio'));
+      final audioContentCenter =
+          (audioIconRect.left + audioTextRect.right) / 2;
+      expect(
+        (audioContentCenter - audioButtonRect.center.dx).abs(),
+        lessThan(1),
+      );
     });
 
     testWidgets('marks first audio track active while selected track is unknown', (

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -757,6 +757,60 @@ void main() {
       expect(requests.last.params, {'stream_id': '101', 'limit': '4'});
     });
 
+    testWidgets('shows audio track selector and applies selection', (
+      tester,
+    ) async {
+      final adapter = FakePlayerAdapter(
+        capabilities: PlaybackCapabilities.desktopLibmpv,
+        textureId: 42,
+      );
+      final orchestrator = PlaybackOrchestrator(
+        platform: PlaybackPlatform.desktop,
+        adapters: <PlaybackBackend, PlayerAdapter>{
+          PlaybackBackend.desktopLibmpv: adapter,
+        },
+        transcodeGateway: FakeTranscodeGateway(),
+      );
+      addTearDown(orchestrator.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlayerScreen(
+            args: const PlayerArgs(
+              streamUrl: 'https://example.com/movie.m3u8',
+              title: 'Multi Audio Fixture',
+              type: 'movie',
+            ),
+            orchestrator: orchestrator,
+            epgService: EpgService(clock: () => DateTime.utc(2026)),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      adapter.emitState(
+        const PlaybackState(
+          backend: PlaybackBackend.desktopLibmpv,
+          status: PlaybackStatus.ready,
+          duration: Duration(hours: 1),
+          audioTracks: <PlaybackTrack>[
+            PlaybackTrack(id: 'audio-eng', label: 'English', language: 'eng'),
+            PlaybackTrack(id: 'audio-spa', label: 'Spanish', language: 'spa'),
+          ],
+          selectedAudioTrackId: 'audio-eng',
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.audiotrack), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.audiotrack));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Spanish').last);
+      await tester.pumpAndSettle();
+
+      expect(adapter.setAudioTrackCalls, <String?>['audio-spa']);
+    });
+
     testWidgets('backs out of the route when playback error is visible', (
       tester,
     ) async {

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -162,9 +162,26 @@ void main() {
       expect(playPauseCenter.dx, lessThan(forwardCenter.dx));
     });
 
-    testWidgets('places track controls inline to the right of transport buttons', (
+    testWidgets('keeps transport controls stable when tracks appear later', (
       tester,
     ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlaybackControls(
+            isPlaying: true,
+            isLive: false,
+            canSeek: true,
+            currentPosition: const Duration(minutes: 5),
+            duration: const Duration(hours: 1),
+            onPlayPause: () {},
+            onSeek: (_) {},
+            onBack: () {},
+          ),
+        ),
+      );
+
+      final playPauseBefore = tester.getCenter(find.byIcon(Icons.pause));
+
       await tester.pumpWidget(
         MaterialApp(
           home: PlaybackControls(
@@ -198,9 +215,10 @@ void main() {
       expect(subtitleCenter.dx, greaterThan(audioCenter.dx));
       expect((audioCenter.dy - forwardCenter.dy).abs(), lessThan(1));
       expect((subtitleCenter.dy - forwardCenter.dy).abs(), lessThan(1));
+      expect(tester.getCenter(find.byIcon(Icons.pause)), playPauseBefore);
     });
 
-    testWidgets('labels track controls by type and current selection', (
+    testWidgets('labels track controls by type only', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -228,11 +246,13 @@ void main() {
         ),
       );
 
-      expect(find.text('Audio: English'), findsOneWidget);
-      expect(find.text('Subs: English CC'), findsOneWidget);
+      expect(find.text('Audio'), findsOneWidget);
+      expect(find.text('Subtitles'), findsOneWidget);
+      expect(find.text('Audio: English'), findsNothing);
+      expect(find.text('Subs: English CC'), findsNothing);
     });
 
-    testWidgets('shows first audio track while backend has not emitted selected track', (
+    testWidgets('marks first audio track active while selected track is unknown', (
       tester,
     ) async {
       await tester.pumpWidget(
@@ -256,8 +276,17 @@ void main() {
         ),
       );
 
-      expect(find.text('Audio: de'), findsOneWidget);
-      expect(find.text('Select'), findsNothing);
+      expect(find.text('Audio'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.audiotrack));
+      await tester.pumpAndSettle();
+
+      final disableTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Disable'),
+      );
+      final deTile = tester.widget<ListTile>(find.widgetWithText(ListTile, 'de'));
+      expect(disableTile.selected, isFalse);
+      expect(deTile.selected, isTrue);
     });
 
     testWidgets('calls onSeek with 10 second replay target', (tester) async {

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -162,6 +162,104 @@ void main() {
       expect(playPauseCenter.dx, lessThan(forwardCenter.dx));
     });
 
+    testWidgets('places track controls inline to the right of transport buttons', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlaybackControls(
+            isPlaying: true,
+            isLive: false,
+            canSeek: true,
+            currentPosition: const Duration(minutes: 5),
+            duration: const Duration(hours: 1),
+            audioTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'audio-eng', label: 'English'),
+            ],
+            subtitleTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'sub-eng', label: 'English CC'),
+            ],
+            selectedAudioTrackId: 'audio-eng',
+            selectedSubtitleTrackId: 'sub-eng',
+            onPlayPause: () {},
+            onSeek: (_) {},
+            onBack: () {},
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+
+      final forwardCenter = tester.getCenter(find.byIcon(Icons.forward_10));
+      final audioCenter = tester.getCenter(find.byIcon(Icons.audiotrack));
+      final subtitleCenter = tester.getCenter(find.byIcon(Icons.subtitles));
+
+      expect(audioCenter.dx, greaterThan(forwardCenter.dx));
+      expect(subtitleCenter.dx, greaterThan(audioCenter.dx));
+      expect((audioCenter.dy - forwardCenter.dy).abs(), lessThan(1));
+      expect((subtitleCenter.dy - forwardCenter.dy).abs(), lessThan(1));
+    });
+
+    testWidgets('labels track controls by type and current selection', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlaybackControls(
+            isPlaying: true,
+            isLive: false,
+            canSeek: true,
+            currentPosition: const Duration(minutes: 5),
+            duration: const Duration(hours: 1),
+            audioTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'audio-eng', label: 'English'),
+            ],
+            subtitleTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'sub-eng', label: 'English CC'),
+            ],
+            selectedAudioTrackId: 'audio-eng',
+            selectedSubtitleTrackId: 'sub-eng',
+            onPlayPause: () {},
+            onSeek: (_) {},
+            onBack: () {},
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+
+      expect(find.text('Audio: English'), findsOneWidget);
+      expect(find.text('Subs: English CC'), findsOneWidget);
+    });
+
+    testWidgets('shows first audio track while backend has not emitted selected track', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlaybackControls(
+            isPlaying: true,
+            isLive: false,
+            canSeek: true,
+            currentPosition: const Duration(minutes: 5),
+            duration: const Duration(hours: 1),
+            audioTracks: const <PlaybackTrack>[
+              PlaybackTrack(id: 'audio-de', label: 'de'),
+              PlaybackTrack(id: 'audio-en', label: 'en'),
+            ],
+            onPlayPause: () {},
+            onSeek: (_) {},
+            onBack: () {},
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+
+      expect(find.text('Audio: de'), findsOneWidget);
+      expect(find.text('Select'), findsNothing);
+    });
+
     testWidgets('calls onSeek with 10 second replay target', (tester) async {
       Duration? seekTarget;
       await tester.pumpWidget(
@@ -453,6 +551,43 @@ void main() {
       await tester.tap(find.text('Spanish').last);
       await tester.pumpAndSettle();
       expect(selectedTrack, '2');
+    });
+
+    testWidgets('audio track dialog scrolls instead of overflowing', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(320, 360));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TrackSelector(
+            audioTracks: List<PlaybackTrack>.generate(
+              12,
+              (index) => PlaybackTrack(
+                id: '$index',
+                label: 'Language $index',
+              ),
+            ),
+            subtitleTracks: const [],
+            selectedAudioTrackId: '0',
+            selectedSubtitleTrackId: null,
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+      await tester.tap(find.byIcon(Icons.audiotrack));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(Scrollable), findsWidgets);
+      expect(find.text('Language 11'), findsNothing);
+
+      await tester.drag(find.byType(Scrollable).last, const Offset(0, -1000));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Language 11'), findsOneWidget);
     });
   });
 

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -224,102 +224,106 @@ void main() {
       expect(tester.getCenter(find.byIcon(Icons.pause)), playPauseBefore);
     });
 
+    testWidgets(
+      'stacks track selectors below transport controls on narrow portrait screens',
+      (
+        tester,
+      ) async {
+        await tester.binding.setSurfaceSize(const Size(430, 932));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
 
-    testWidgets('stacks track selectors below transport controls on narrow portrait screens', (
-      tester,
-    ) async {
-      await tester.binding.setSurfaceSize(const Size(430, 932));
-      addTearDown(() => tester.binding.setSurfaceSize(null));
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PlaybackControls(
-            isPlaying: true,
-            isLive: false,
-            canSeek: true,
-            currentPosition: const Duration(seconds: 35),
-            duration: const Duration(hours: 1, minutes: 48),
-            audioTracks: const <PlaybackTrack>[
-              PlaybackTrack(id: 'audio-eng', label: 'English'),
-            ],
-            subtitleTracks: const <PlaybackTrack>[
-              PlaybackTrack(id: 'sub-eng', label: 'English CC'),
-            ],
-            selectedAudioTrackId: 'audio-eng',
-            selectedSubtitleTrackId: 'sub-eng',
-            onPlayPause: () {},
-            onSeek: (_) {},
-            onBack: () {},
-            onAudioTrackSelected: (_) {},
-            onSubtitleTrackSelected: (_) {},
+        await tester.pumpWidget(
+          MaterialApp(
+            home: PlaybackControls(
+              isPlaying: true,
+              isLive: false,
+              canSeek: true,
+              currentPosition: const Duration(seconds: 35),
+              duration: const Duration(hours: 1, minutes: 48),
+              audioTracks: const <PlaybackTrack>[
+                PlaybackTrack(id: 'audio-eng', label: 'English'),
+              ],
+              subtitleTracks: const <PlaybackTrack>[
+                PlaybackTrack(id: 'sub-eng', label: 'English CC'),
+              ],
+              selectedAudioTrackId: 'audio-eng',
+              selectedSubtitleTrackId: 'sub-eng',
+              onPlayPause: () {},
+              onSeek: (_) {},
+              onBack: () {},
+              onAudioTrackSelected: (_) {},
+              onSubtitleTrackSelected: (_) {},
+            ),
           ),
-        ),
-      );
+        );
 
-      expect(tester.takeException(), isNull);
-      expect(find.text('Audio'), findsOneWidget);
-      expect(find.text('Subtitles'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+        expect(find.text('Audio'), findsOneWidget);
+        expect(find.text('Subtitles'), findsOneWidget);
 
-      final audioRect = tester.getRect(find.byIcon(Icons.audiotrack));
-      final subtitleRect = tester.getRect(find.byIcon(Icons.subtitles));
-      final replayRect = tester.getRect(find.byIcon(Icons.replay_10));
-      final pauseRect = tester.getRect(find.byIcon(Icons.pause));
-      final forwardRect = tester.getRect(find.byIcon(Icons.forward_10));
+        final audioRect = tester.getRect(find.byIcon(Icons.audiotrack));
+        final subtitleRect = tester.getRect(find.byIcon(Icons.subtitles));
+        final replayRect = tester.getRect(find.byIcon(Icons.replay_10));
+        final pauseRect = tester.getRect(find.byIcon(Icons.pause));
+        final forwardRect = tester.getRect(find.byIcon(Icons.forward_10));
 
-      expect(audioRect.top, greaterThan(forwardRect.bottom));
-      expect(subtitleRect.top, greaterThan(forwardRect.bottom));
-      expect(replayRect.overlaps(audioRect), isFalse);
-      expect(pauseRect.overlaps(audioRect), isFalse);
-      expect(forwardRect.overlaps(subtitleRect), isFalse);
-    });
+        expect(audioRect.top, greaterThan(forwardRect.bottom));
+        expect(subtitleRect.top, greaterThan(forwardRect.bottom));
+        expect(replayRect.overlaps(audioRect), isFalse);
+        expect(pauseRect.overlaps(audioRect), isFalse);
+        expect(forwardRect.overlaps(subtitleRect), isFalse);
+      },
+    );
 
-    testWidgets('keeps audio and subtitle selectors visible without transport overlap in landscape', (
-      tester,
-    ) async {
-      await tester.binding.setSurfaceSize(const Size(932, 430));
-      addTearDown(() => tester.binding.setSurfaceSize(null));
+    testWidgets(
+      'keeps audio and subtitle selectors visible without transport overlap in landscape',
+      (
+        tester,
+      ) async {
+        await tester.binding.setSurfaceSize(const Size(932, 430));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
 
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PlaybackControls(
-            isPlaying: true,
-            isLive: false,
-            canSeek: true,
-            currentPosition: const Duration(seconds: 35),
-            duration: const Duration(hours: 1, minutes: 48),
-            audioTracks: const <PlaybackTrack>[
-              PlaybackTrack(id: 'audio-eng', label: 'English'),
-            ],
-            subtitleTracks: const <PlaybackTrack>[
-              PlaybackTrack(id: 'sub-eng', label: 'English CC'),
-            ],
-            selectedAudioTrackId: 'audio-eng',
-            selectedSubtitleTrackId: 'sub-eng',
-            onPlayPause: () {},
-            onSeek: (_) {},
-            onBack: () {},
-            onAudioTrackSelected: (_) {},
-            onSubtitleTrackSelected: (_) {},
+        await tester.pumpWidget(
+          MaterialApp(
+            home: PlaybackControls(
+              isPlaying: true,
+              isLive: false,
+              canSeek: true,
+              currentPosition: const Duration(seconds: 35),
+              duration: const Duration(hours: 1, minutes: 48),
+              audioTracks: const <PlaybackTrack>[
+                PlaybackTrack(id: 'audio-eng', label: 'English'),
+              ],
+              subtitleTracks: const <PlaybackTrack>[
+                PlaybackTrack(id: 'sub-eng', label: 'English CC'),
+              ],
+              selectedAudioTrackId: 'audio-eng',
+              selectedSubtitleTrackId: 'sub-eng',
+              onPlayPause: () {},
+              onSeek: (_) {},
+              onBack: () {},
+              onAudioTrackSelected: (_) {},
+              onSubtitleTrackSelected: (_) {},
+            ),
           ),
-        ),
-      );
+        );
 
-      expect(tester.takeException(), isNull);
-      expect(find.text('Audio'), findsOneWidget);
-      expect(find.text('Subtitles'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+        expect(find.text('Audio'), findsOneWidget);
+        expect(find.text('Subtitles'), findsOneWidget);
 
-      final audioRect = tester.getRect(find.byIcon(Icons.audiotrack));
-      final subtitleRect = tester.getRect(find.byIcon(Icons.subtitles));
-      final replayRect = tester.getRect(find.byIcon(Icons.replay_10));
-      final pauseRect = tester.getRect(find.byIcon(Icons.pause));
-      final forwardRect = tester.getRect(find.byIcon(Icons.forward_10));
+        final audioRect = tester.getRect(find.byIcon(Icons.audiotrack));
+        final subtitleRect = tester.getRect(find.byIcon(Icons.subtitles));
+        final replayRect = tester.getRect(find.byIcon(Icons.replay_10));
+        final pauseRect = tester.getRect(find.byIcon(Icons.pause));
+        final forwardRect = tester.getRect(find.byIcon(Icons.forward_10));
 
-      expect(replayRect.overlaps(audioRect), isFalse);
-      expect(pauseRect.overlaps(audioRect), isFalse);
-      expect(forwardRect.overlaps(audioRect), isFalse);
-      expect(forwardRect.overlaps(subtitleRect), isFalse);
-    });
-
+        expect(replayRect.overlaps(audioRect), isFalse);
+        expect(pauseRect.overlaps(audioRect), isFalse);
+        expect(forwardRect.overlaps(audioRect), isFalse);
+        expect(forwardRect.overlaps(subtitleRect), isFalse);
+      },
+    );
 
     testWidgets('labels track controls by type only', (
       tester,

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -260,50 +260,54 @@ void main() {
       );
       final audioIconRect = tester.getRect(find.byIcon(Icons.audiotrack));
       final audioTextRect = tester.getRect(find.text('Audio'));
-      final audioContentCenter =
-          (audioIconRect.left + audioTextRect.right) / 2;
+      final audioContentCenter = (audioIconRect.left + audioTextRect.right) / 2;
       expect(
         (audioContentCenter - audioButtonRect.center.dx).abs(),
         lessThan(1),
       );
     });
 
-    testWidgets('marks first audio track active while selected track is unknown', (
-      tester,
-    ) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PlaybackControls(
-            isPlaying: true,
-            isLive: false,
-            canSeek: true,
-            currentPosition: const Duration(minutes: 5),
-            duration: const Duration(hours: 1),
-            audioTracks: const <PlaybackTrack>[
-              PlaybackTrack(id: 'audio-de', label: 'de'),
-              PlaybackTrack(id: 'audio-en', label: 'en'),
-            ],
-            onPlayPause: () {},
-            onSeek: (_) {},
-            onBack: () {},
-            onAudioTrackSelected: (_) {},
-            onSubtitleTrackSelected: (_) {},
+    testWidgets(
+      'marks first audio track active while selected track is unknown',
+      (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: PlaybackControls(
+              isPlaying: true,
+              isLive: false,
+              canSeek: true,
+              currentPosition: const Duration(minutes: 5),
+              duration: const Duration(hours: 1),
+              audioTracks: const <PlaybackTrack>[
+                PlaybackTrack(id: 'audio-de', label: 'de'),
+                PlaybackTrack(id: 'audio-en', label: 'en'),
+              ],
+              onPlayPause: () {},
+              onSeek: (_) {},
+              onBack: () {},
+              onAudioTrackSelected: (_) {},
+              onSubtitleTrackSelected: (_) {},
+            ),
           ),
-        ),
-      );
+        );
 
-      expect(find.text('Audio'), findsOneWidget);
+        expect(find.text('Audio'), findsOneWidget);
 
-      await tester.tap(find.byIcon(Icons.audiotrack));
-      await tester.pumpAndSettle();
+        await tester.tap(find.byIcon(Icons.audiotrack));
+        await tester.pumpAndSettle();
 
-      final disableTile = tester.widget<ListTile>(
-        find.widgetWithText(ListTile, 'Disable'),
-      );
-      final deTile = tester.widget<ListTile>(find.widgetWithText(ListTile, 'de'));
-      expect(disableTile.selected, isFalse);
-      expect(deTile.selected, isTrue);
-    });
+        final disableTile = tester.widget<ListTile>(
+          find.widgetWithText(ListTile, 'Disable'),
+        );
+        final deTile = tester.widget<ListTile>(
+          find.widgetWithText(ListTile, 'de'),
+        );
+        expect(disableTile.selected, isFalse);
+        expect(deTile.selected, isTrue);
+      },
+    );
 
     testWidgets('calls onSeek with 10 second replay target', (tester) async {
       Duration? seekTarget;


### PR DESCRIPTION
## Summary
- Adds audio and subtitle track controls to the player overlay when tracks are available.
- Wires player track selection through the playback orchestrator.
- Maps media_kit audio and subtitle tracks into the shared playback track model.
- Keeps the selector usable with D-pad focus on TV-style layouts.

## Testing
- `../.tmp/flutter_sdk/bin/flutter analyze`
- `../.tmp/flutter_sdk/bin/flutter test test/playback/media_kit_desktop_adapter_test.dart test/ui/player/player_screen_test.dart`
- `../.tmp/flutter_sdk/bin/flutter test`

Closes #13
