### PR TITLE
fix: preserve playback aspect ratio

### DIFF
--- a/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/Media3PlaybackPlugin.kt
+++ b/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/Media3PlaybackPlugin.kt
@@ -178,6 +178,7 @@ class Media3PlaybackPlugin(
         positionMs: Long? = null,
         durationMs: Long? = null,
         textureId: Long? = null,
+        videoAspectRatio: Double? = null,
         code: String? = null,
         message: String? = null,
         recoverable: Boolean? = null,
@@ -187,6 +188,7 @@ class Media3PlaybackPlugin(
         if (positionMs != null) event["positionMs"] = positionMs
         if (durationMs != null) event["durationMs"] = durationMs
         if (textureId != null) event["textureId"] = textureId
+        if (videoAspectRatio != null) event["videoAspectRatio"] = videoAspectRatio
         if (code != null) event["code"] = code
         if (message != null) event["message"] = message
         if (recoverable != null) event["recoverable"] = recoverable
@@ -198,6 +200,13 @@ class Media3PlaybackPlugin(
             val state = playerState ?: return
             if (videoSize.width > 0 && videoSize.height > 0) {
                 state.surfaceProducer.setSize(videoSize.width, videoSize.height)
+                val aspectRatio = (videoSize.width * videoSize.pixelWidthHeightRatio) / videoSize.height
+                emit(
+                    "ready",
+                    positionMs = state.player.currentPosition,
+                    durationMs = state.player.duration.takeIf { it != C.TIME_UNSET && it > 0 },
+                    videoAspectRatio = aspectRatio.toDouble(),
+                )
             }
         }
 

--- a/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/Media3PlaybackPlugin.kt
+++ b/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/Media3PlaybackPlugin.kt
@@ -305,10 +305,11 @@ class Media3PlaybackPlugin(
             if (videoSize.width > 0 && videoSize.height > 0) {
                 state.surfaceProducer.setSize(videoSize.width, videoSize.height)
                 val aspectRatio = (videoSize.width * videoSize.pixelWidthHeightRatio) / videoSize.height
+                val player = state.player
                 emit(
-                    "ready",
-                    positionMs = state.player.currentPosition,
-                    durationMs = state.player.duration.takeIf { it != C.TIME_UNSET && it > 0 },
+                    type = if (player.isPlaying) "playing" else "ready",
+                    positionMs = player.currentPosition,
+                    durationMs = player.duration.takeIf { it != C.TIME_UNSET && it > 0 },
                     videoAspectRatio = aspectRatio.toDouble(),
                 )
             }

--- a/flutter_client/ios/Runner/AvKitPlaybackPlugin.swift
+++ b/flutter_client/ios/Runner/AvKitPlaybackPlugin.swift
@@ -163,7 +163,11 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         switch item.status {
         case .readyToPlay:
             let posMs = currentPositionMs()
-            emit(type: s.player.rate > 0 ? "playing" : "ready", positionMs: posMs)
+            emit(
+                type: s.player.rate > 0 ? "playing" : "ready",
+                positionMs: posMs,
+                videoAspectRatio: videoAspectRatio(for: item)
+            )
         case .failed:
             let msg = item.error?.localizedDescription ?? "AVPlayer item failed"
             emit(type: "error", code: "avkit-item-failed", message: msg, recoverable: true)
@@ -188,11 +192,18 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         return seconds.isFinite ? Int64(seconds * 1000) : 0
     }
 
+    private func videoAspectRatio(for item: AVPlayerItem) -> Double? {
+        let size = item.presentationSize
+        guard size.width > 0, size.height > 0 else { return nil }
+        return Double(size.width / size.height)
+    }
+
     private func emit(
         type: String,
         textureId: Int64? = nil,
         uri: String? = nil,
         positionMs: Int64? = nil,
+        videoAspectRatio: Double? = nil,
         code: String? = nil,
         message: String? = nil,
         recoverable: Bool = false
@@ -201,6 +212,7 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         if let id = textureId  { event["textureId"]   = id       }
         if let u  = uri         { event["uri"]         = u        }
         if let p  = positionMs  { event["positionMs"]  = p        }
+        if let ar = videoAspectRatio { event["videoAspectRatio"] = ar }
         if let c  = code        { event["code"]        = c        }
         if let m  = message     { event["message"]     = m        }
         if recoverable          { event["recoverable"] = true      }

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -52,6 +52,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   String? _errorMessage;
   String? _fallbackReason;
   bool _isPlaying = false;
+  double _videoAspectRatio = 16 / 9;
 
   // Track state (used for future track selector integration)
   // ignore: unused_field
@@ -216,6 +217,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
       _subtitleTracks = state.subtitleTracks;
       _selectedAudioTrackId = state.selectedAudioTrackId;
       _selectedSubtitleTrackId = state.selectedSubtitleTrackId;
+
+      final aspectRatio =
+          state.videoAspectRatio ?? state.source?.videoAspectRatio;
+      if (aspectRatio != null) {
+        _videoAspectRatio = aspectRatio;
+      }
 
       if (state.status == PlaybackStatus.playing) {
         _isPlaying = true;
@@ -467,6 +474,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
                 Positioned.fill(
                   child: _VideoSurface(
                     textureId: widget.orchestrator.activeTextureId,
+                    aspectRatio: _videoAspectRatio,
                   ),
                 ),
 
@@ -592,9 +600,10 @@ class _PlayerScreenState extends State<PlayerScreen> {
 }
 
 class _VideoSurface extends StatelessWidget {
-  const _VideoSurface({required this.textureId});
+  const _VideoSurface({required this.textureId, required this.aspectRatio});
 
   final int? textureId;
+  final double aspectRatio;
 
   @override
   Widget build(BuildContext context) {
@@ -604,7 +613,7 @@ class _VideoSurface extends StatelessWidget {
       color: Colors.black,
       child: Center(
         child: AspectRatio(
-          aspectRatio: 16 / 9,
+          aspectRatio: aspectRatio,
           child: Texture(textureId: id),
         ),
       ),

--- a/flutter_client/lib/playback/android_playback_adapter.dart
+++ b/flutter_client/lib/playback/android_playback_adapter.dart
@@ -307,6 +307,7 @@ class AndroidPlaybackAdapter implements PlayerAdapter, VideoTextureProvider {
         status: status,
         position: event.position ?? _state.position,
         duration: event.duration,
+        videoAspectRatio: event.videoAspectRatio,
       ),
     );
   }
@@ -407,6 +408,7 @@ class AndroidMedia3Event {
     this.position,
     this.duration,
     this.textureId,
+    this.videoAspectRatio,
     this.code,
     this.message,
     this.recoverable = false,
@@ -423,6 +425,14 @@ class AndroidMedia3Event {
           ? Duration(milliseconds: (map['durationMs']! as num).round())
           : null,
       textureId: (map['textureId'] as num?)?.toInt(),
+      videoAspectRatio: playbackAspectRatioFromValues(
+        aspectRatio:
+            map['videoAspectRatio'] ??
+            map['displayAspectRatio'] ??
+            map['aspectRatio'],
+        width: map['videoWidth'] ?? map['width'],
+        height: map['videoHeight'] ?? map['height'],
+      ),
       code: map['code'] as String?,
       message: map['message'] as String?,
       recoverable: map['recoverable'] == true,
@@ -434,6 +444,7 @@ class AndroidMedia3Event {
   final Duration? position;
   final Duration? duration;
   final int? textureId;
+  final double? videoAspectRatio;
   final String? code;
   final String? message;
   final bool recoverable;

--- a/flutter_client/lib/playback/apple_avkit_backend.dart
+++ b/flutter_client/lib/playback/apple_avkit_backend.dart
@@ -134,6 +134,7 @@ class AppleAvKitBackend implements PlayerAdapter, VideoTextureProvider {
         backend: PlaybackBackend.appleAvKit,
         status: status,
         position: event.position ?? _state.position,
+        videoAspectRatio: event.videoAspectRatio,
       ),
     );
   }
@@ -236,6 +237,7 @@ class _AvKitEvent {
   const _AvKitEvent({
     required this.type,
     this.position,
+    this.videoAspectRatio,
     this.code,
     this.message,
     this.recoverable = false,
@@ -246,6 +248,14 @@ class _AvKitEvent {
     position: map['positionMs'] is num
         ? Duration(milliseconds: (map['positionMs']! as num).round())
         : null,
+    videoAspectRatio: playbackAspectRatioFromValues(
+      aspectRatio:
+          map['videoAspectRatio'] ??
+          map['displayAspectRatio'] ??
+          map['aspectRatio'],
+      width: map['videoWidth'] ?? map['width'],
+      height: map['videoHeight'] ?? map['height'],
+    ),
     code: map['code'] as String?,
     message: map['message'] as String?,
     recoverable: map['recoverable'] == true,
@@ -253,6 +263,7 @@ class _AvKitEvent {
 
   final _AvKitEventType type;
   final Duration? position;
+  final double? videoAspectRatio;
   final String? code;
   final String? message;
   final bool recoverable;

--- a/flutter_client/lib/playback/desktop_libmpv_backend.dart
+++ b/flutter_client/lib/playback/desktop_libmpv_backend.dart
@@ -68,7 +68,20 @@ class DesktopLibmpvBackend implements PlayerAdapter, VideoTextureProvider {
       _errorController.add(PlaybackError.fromException(error));
       throw error;
     }
-    _emit(_state.copyWith(status: PlaybackStatus.ready, source: source));
+    _emit(
+      _state.copyWith(
+        status: PlaybackStatus.ready,
+        source: source,
+        videoAspectRatio: playbackAspectRatioFromValues(
+          aspectRatio:
+              response?['videoAspectRatio'] ??
+              response?['displayAspectRatio'] ??
+              response?['aspectRatio'],
+          width: response?['videoWidth'] ?? response?['width'],
+          height: response?['videoHeight'] ?? response?['height'],
+        ),
+      ),
+    );
   }
 
   @override

--- a/flutter_client/lib/playback/desktop_libmpv_backend.dart
+++ b/flutter_client/lib/playback/desktop_libmpv_backend.dart
@@ -68,20 +68,24 @@ class DesktopLibmpvBackend implements PlayerAdapter, VideoTextureProvider {
       _errorController.add(PlaybackError.fromException(error));
       throw error;
     }
+    final initialAspectRatio = playbackAspectRatioFromValues(
+      aspectRatio:
+          response?['videoAspectRatio'] ??
+          response?['displayAspectRatio'] ??
+          response?['aspectRatio'],
+      width: response?['videoWidth'] ?? response?['width'],
+      height: response?['videoHeight'] ?? response?['height'],
+    );
     _emit(
       _state.copyWith(
         status: PlaybackStatus.ready,
         source: source,
-        videoAspectRatio: playbackAspectRatioFromValues(
-          aspectRatio:
-              response?['videoAspectRatio'] ??
-              response?['displayAspectRatio'] ??
-              response?['aspectRatio'],
-          width: response?['videoWidth'] ?? response?['width'],
-          height: response?['videoHeight'] ?? response?['height'],
-        ),
+        videoAspectRatio: initialAspectRatio,
       ),
     );
+    if (initialAspectRatio == null) {
+      unawaited(_refreshVideoAspectRatio());
+    }
   }
 
   @override
@@ -141,6 +145,39 @@ class DesktopLibmpvBackend implements PlayerAdapter, VideoTextureProvider {
     }
     await _stateController.close();
     await _errorController.close();
+  }
+
+  Future<void> _refreshVideoAspectRatio() async {
+    final handle = _handle;
+    if (handle == null) return;
+
+    for (final delay in <Duration>[
+      Duration.zero,
+      const Duration(milliseconds: 100),
+      const Duration(milliseconds: 250),
+      const Duration(milliseconds: 500),
+      const Duration(seconds: 1),
+    ]) {
+      if (delay > Duration.zero) await Future<void>.delayed(delay);
+      if (_handle != handle) return;
+
+      final response = await _channel.invokeMapMethod<String, Object?>(
+        'getVideoAspectRatio',
+        <String, Object?>{'handle': handle},
+      );
+      final aspectRatio = playbackAspectRatioFromValues(
+        aspectRatio:
+            response?['videoAspectRatio'] ??
+            response?['displayAspectRatio'] ??
+            response?['aspectRatio'],
+        width: response?['videoWidth'] ?? response?['width'],
+        height: response?['videoHeight'] ?? response?['height'],
+      );
+      if (aspectRatio != null) {
+        _emit(_state.copyWith(videoAspectRatio: aspectRatio));
+        return;
+      }
+    }
   }
 
   Future<void> _invokeControl(

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -77,6 +77,15 @@ class MediaKitDesktopAdapter
         }),
       )
       ..add(
+        _player.stream.videoParams.listen((params) {
+          _emit(
+            _state.copyWith(
+              videoAspectRatio: mediaKitVideoAspectRatio(params),
+            ),
+          );
+        }),
+      )
+      ..add(
         _player.stream.tracks.listen((tracks) {
           _emit(
             _state.copyWith(
@@ -233,6 +242,14 @@ List<PlaybackTrack> mediaKitSubtitleTracksToPlaybackTracks(
         ),
       )
       .toList(growable: false);
+}
+
+double? mediaKitVideoAspectRatio(mk.VideoParams params) {
+  return playbackAspectRatioFromValues(
+    aspectRatio: params.aspect,
+    width: params.dw ?? params.w,
+    height: params.dh ?? params.h,
+  );
 }
 
 String _mediaKitTrackLabel({

--- a/flutter_client/lib/playback/media_kit_ios_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_ios_adapter.dart
@@ -77,6 +77,15 @@ class MediaKitIosAdapter
         }),
       )
       ..add(
+        _player.stream.videoParams.listen((params) {
+          _emit(
+            _state.copyWith(
+              videoAspectRatio: mediaKitVideoAspectRatio(params),
+            ),
+          );
+        }),
+      )
+      ..add(
         _player.stream.tracks.listen((tracks) {
           _emit(
             _state.copyWith(

--- a/flutter_client/lib/playback/player_adapter.dart
+++ b/flutter_client/lib/playback/player_adapter.dart
@@ -144,6 +144,42 @@ class PlaybackSource {
   final String? userAgent;
   final Map<String, String> headers;
   final Map<String, Object?> metadata;
+
+  double? get videoAspectRatio => playbackAspectRatioFromMetadata(metadata);
+}
+
+double? playbackAspectRatioFromMetadata(Map<String, Object?> metadata) {
+  return playbackAspectRatioFromValues(
+    aspectRatio:
+        metadata['videoAspectRatio'] ??
+        metadata['displayAspectRatio'] ??
+        metadata['aspectRatio'],
+    width: metadata['videoWidth'] ?? metadata['width'],
+    height: metadata['videoHeight'] ?? metadata['height'],
+  );
+}
+
+double? playbackAspectRatioFromValues({
+  Object? aspectRatio,
+  Object? width,
+  Object? height,
+}) {
+  final parsedRatio = _asPositiveDouble(aspectRatio);
+  if (parsedRatio != null) return parsedRatio;
+
+  final parsedWidth = _asPositiveDouble(width);
+  final parsedHeight = _asPositiveDouble(height);
+  if (parsedWidth == null || parsedHeight == null) return null;
+  return parsedWidth / parsedHeight;
+}
+
+double? _asPositiveDouble(Object? value) {
+  if (value is num && value > 0) return value.toDouble();
+  if (value is String) {
+    final parsed = double.tryParse(value.trim());
+    if (parsed != null && parsed > 0) return parsed;
+  }
+  return null;
 }
 
 class PlaybackTrack {
@@ -166,6 +202,7 @@ class PlaybackState {
     this.selectedAudioTrackId,
     this.selectedSubtitleTrackId,
     this.playbackSpeed = 1,
+    this.videoAspectRatio,
   });
 
   const PlaybackState.idle({required this.backend})
@@ -177,7 +214,8 @@ class PlaybackState {
       subtitleTracks = const <PlaybackTrack>[],
       selectedAudioTrackId = null,
       selectedSubtitleTrackId = null,
-      playbackSpeed = 1;
+      playbackSpeed = 1,
+      videoAspectRatio = null;
 
   final PlaybackBackend backend;
   final PlaybackStatus status;
@@ -189,6 +227,7 @@ class PlaybackState {
   final String? selectedAudioTrackId;
   final String? selectedSubtitleTrackId;
   final double playbackSpeed;
+  final double? videoAspectRatio;
 
   PlaybackState copyWith({
     PlaybackBackend? backend,
@@ -201,6 +240,7 @@ class PlaybackState {
     Object? selectedAudioTrackId = _unchanged,
     Object? selectedSubtitleTrackId = _unchanged,
     double? playbackSpeed,
+    double? videoAspectRatio,
   }) {
     return PlaybackState(
       backend: backend ?? this.backend,
@@ -217,6 +257,7 @@ class PlaybackState {
           ? this.selectedSubtitleTrackId
           : selectedSubtitleTrackId as String?,
       playbackSpeed: playbackSpeed ?? this.playbackSpeed,
+      videoAspectRatio: videoAspectRatio ?? this.videoAspectRatio,
     );
   }
 }

--- a/flutter_client/linux/desktop_libmpv_backend.cc
+++ b/flutter_client/linux/desktop_libmpv_backend.cc
@@ -32,6 +32,7 @@ using mpv_create_fn = mpv_handle* (*)();
 using mpv_initialize_fn = int (*)(mpv_handle*);
 using mpv_command_fn = int (*)(mpv_handle*, const char**);
 using mpv_set_option_string_fn = int (*)(mpv_handle*, const char*, const char*);
+using mpv_get_property_fn = int (*)(mpv_handle*, const char*, int, void*);
 using mpv_terminate_destroy_fn = void (*)(mpv_handle*);
 using mpv_render_update_fn = void (*)(void*);
 using mpv_render_context = struct mpv_render_context;
@@ -44,6 +45,8 @@ struct mpv_render_param {
   int type;
   void* data;
 };
+
+constexpr int MPV_FORMAT_DOUBLE = 5;
 
 constexpr int MPV_RENDER_PARAM_INVALID = 0;
 constexpr int MPV_RENDER_PARAM_API_TYPE = 1;
@@ -61,6 +64,7 @@ struct LibmpvApi {
   mpv_initialize_fn initialize = nullptr;
   mpv_command_fn command = nullptr;
   mpv_set_option_string_fn set_option_string = nullptr;
+  mpv_get_property_fn get_property = nullptr;
   mpv_terminate_destroy_fn terminate_destroy = nullptr;
   mpv_render_context_create_fn render_context_create = nullptr;
   mpv_render_context_set_update_callback_fn render_context_set_update_callback = nullptr;
@@ -72,7 +76,7 @@ struct LibmpvApi {
   bool client_available() const {
     return library != nullptr && create != nullptr && initialize != nullptr &&
            command != nullptr && set_option_string != nullptr &&
-           terminate_destroy != nullptr;
+           get_property != nullptr && terminate_destroy != nullptr;
   }
 
   bool render_api_available() const {
@@ -175,6 +179,7 @@ LibmpvApi& Api() {
   g_api.initialize = reinterpret_cast<mpv_initialize_fn>(LoadSymbol(g_api.library, "mpv_initialize"));
   g_api.command = reinterpret_cast<mpv_command_fn>(LoadSymbol(g_api.library, "mpv_command"));
   g_api.set_option_string = reinterpret_cast<mpv_set_option_string_fn>(LoadSymbol(g_api.library, "mpv_set_option_string"));
+  g_api.get_property = reinterpret_cast<mpv_get_property_fn>(LoadSymbol(g_api.library, "mpv_get_property"));
   g_api.terminate_destroy = reinterpret_cast<mpv_terminate_destroy_fn>(LoadSymbol(g_api.library, "mpv_terminate_destroy"));
   g_api.render_context_create = reinterpret_cast<mpv_render_context_create_fn>(LoadSymbol(g_api.library, "mpv_render_context_create"));
   g_api.render_context_set_update_callback = reinterpret_cast<mpv_render_context_set_update_callback_fn>(LoadSymbol(g_api.library, "mpv_render_context_set_update_callback"));
@@ -352,6 +357,44 @@ void mpv_texture_class_init(MpvTextureClass* klass) {
 
 void mpv_texture_init(MpvTexture* self) { self->player = nullptr; }
 
+
+bool DoubleProperty(PlayerInstance* player, const char* name, double* value) {
+  if (player == nullptr || player->api == nullptr ||
+      player->api->get_property == nullptr) {
+    return false;
+  }
+  double current = 0.0;
+  const int rc = player->api->get_property(
+      player->handle, name, MPV_FORMAT_DOUBLE, &current);
+  if (rc < 0 || current <= 0.0) return false;
+  *value = current;
+  return true;
+}
+
+FlValue* VideoAspectRatioResult(PlayerInstance* player) {
+  g_autoptr(FlValue) result = fl_value_new_map();
+  fl_value_set_string_take(result, "ok", fl_value_new_bool(TRUE));
+
+  double aspect = 0.0;
+  if (DoubleProperty(player, "video-params/aspect", &aspect)) {
+    fl_value_set_string_take(result, "videoAspectRatio",
+                             fl_value_new_float(aspect));
+  }
+
+  double width = 0.0;
+  double height = 0.0;
+  if (DoubleProperty(player, "dwidth", &width) &&
+      DoubleProperty(player, "dheight", &height)) {
+    fl_value_set_string_take(result, "videoWidth", fl_value_new_float(width));
+    fl_value_set_string_take(result, "videoHeight", fl_value_new_float(height));
+    if (aspect <= 0.0) {
+      fl_value_set_string_take(result, "videoAspectRatio",
+                               fl_value_new_float(width / height));
+    }
+  }
+  return fl_value_ref(result);
+}
+
 void RenderUpdate(void* data) {
   PlayerInstance* player = static_cast<PlayerInstance*>(data);
   if (player == nullptr || player->texture_registrar == nullptr ||
@@ -483,6 +526,9 @@ FlMethodResponse* Control(const gchar* method, FlValue* args) {
     const std::string speed_value = std::to_string(speed);
     const char* command[] = {"set", "speed", speed_value.c_str(), nullptr};
     player->api->command(player->handle, command);
+  } else if (g_strcmp0(method, "getVideoAspectRatio") == 0) {
+    g_autoptr(FlValue) result = VideoAspectRatioResult(player);
+    return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
   } else if (g_strcmp0(method, "dispose") == 0) {
     g_players.erase(it);
   }

--- a/flutter_client/test/playback/desktop_libmpv_backend_test.dart
+++ b/flutter_client/test/playback/desktop_libmpv_backend_test.dart
@@ -137,6 +137,7 @@ void main() {
       expect(calls, <String>[
         'probe',
         'load',
+        'getVideoAspectRatio',
         'play',
         'pause',
         'seek',
@@ -148,6 +149,51 @@ void main() {
 
       await backend.dispose();
     });
+
+    test(
+      'polls libmpv video dimensions when load response lacks aspect ratio',
+      () async {
+        final states = <PlaybackState>[];
+        final calls = <String>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              calls.add(call.method);
+              switch (call.method) {
+                case 'load':
+                  return <String, Object?>{
+                    'ok': true,
+                    'handle': 77,
+                    'textureId': 7700,
+                  };
+                case 'getVideoAspectRatio':
+                  expect(call.arguments, <String, Object?>{'handle': 77});
+                  return <String, Object?>{
+                    'videoWidth': 720,
+                    'videoHeight': 576,
+                  };
+                default:
+                  return null;
+              }
+            });
+
+        final backend = DesktopLibmpvBackend(channel: channel);
+        final subscription = backend.onState.listen(states.add);
+
+        await backend.load(
+          const PlaybackSource(uri: 'https://example.test/4-3.ts'),
+        );
+        await pumpEventQueue();
+
+        expect(
+          calls,
+          containsAllInOrder(<String>['load', 'getVideoAspectRatio']),
+        );
+        expect(states.last.videoAspectRatio, 1.25);
+
+        await subscription.cancel();
+        await backend.dispose();
+      },
+    );
 
     test('windows probe reports bundled DLL diagnostics', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -261,6 +307,7 @@ void main() {
       expect(backend.textureId, isNull);
       expect(calls.map((call) => call.method), <String>[
         'load',
+        'getVideoAspectRatio',
         'play',
         'pause',
         'seek',
@@ -270,20 +317,20 @@ void main() {
         'stop',
         'dispose',
       ]);
-      expect(calls[1].arguments, <String, Object?>{'handle': 41});
-      expect(calls[3].arguments, <String, Object?>{
+      expect(calls[2].arguments, <String, Object?>{'handle': 41});
+      expect(calls[4].arguments, <String, Object?>{
         'handle': 41,
         'positionMs': 2500,
       });
-      expect(calls[4].arguments, <String, Object?>{
+      expect(calls[5].arguments, <String, Object?>{
         'handle': 41,
         'trackId': null,
       });
-      expect(calls[5].arguments, <String, Object?>{
+      expect(calls[6].arguments, <String, Object?>{
         'handle': 41,
         'trackId': '3',
       });
-      expect(calls[6].arguments, <String, Object?>{
+      expect(calls[7].arguments, <String, Object?>{
         'handle': 41,
         'speed': 0.75,
       });

--- a/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
+++ b/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
@@ -68,5 +68,23 @@ void main() {
 
       expect(selectedTrackId, isNull);
     });
+
+    test('maps video params aspect ratio with display size fallback', () {
+      expect(
+        mediaKitVideoAspectRatio(
+          const mk.VideoParams(aspect: 4 / 3, w: 720, h: 576),
+        ),
+        closeTo(4 / 3, 0.0001),
+      );
+      expect(
+        mediaKitVideoAspectRatio(const mk.VideoParams(dw: 1024, dh: 576)),
+        closeTo(16 / 9, 0.0001),
+      );
+      expect(
+        mediaKitVideoAspectRatio(const mk.VideoParams(w: 720, h: 576)),
+        closeTo(1.25, 0.0001),
+      );
+      expect(mediaKitVideoAspectRatio(const mk.VideoParams()), isNull);
+    });
   });
 }

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -173,6 +173,10 @@ void main() {
 
         expect(linuxBackend, contains('char format[] = "rgba";'));
         expect(windowsBackend, contains('char format[] = "rgba";'));
+        expect(linuxBackend, contains('mpv_get_property'));
+        expect(windowsBackend, contains('mpv_get_property'));
+        expect(linuxBackend, contains('getVideoAspectRatio'));
+        expect(windowsBackend, contains('getVideoAspectRatio'));
         expect(linuxBackend, isNot(contains('char format[] = "bgra";')));
         expect(windowsBackend, isNot(contains('char format[] = "bgra";')));
       },

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -618,6 +618,58 @@ void main() {
       expect(texture.textureId, 42);
     });
 
+    testWidgets(
+      'preserves reported source aspect ratio for the video surface',
+      (
+        tester,
+      ) async {
+        final adapter = FakePlayerAdapter(
+          capabilities: PlaybackCapabilities.desktopLibmpv,
+          textureId: 42,
+        );
+        final orchestrator = PlaybackOrchestrator(
+          platform: PlaybackPlatform.desktop,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.desktopLibmpv: adapter,
+          },
+          transcodeGateway: FakeTranscodeGateway(),
+        );
+        addTearDown(orchestrator.dispose);
+
+        await tester.binding.setSurfaceSize(const Size(1600, 900));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: PlayerScreen(
+              args: const PlayerArgs(
+                streamUrl: 'https://example.com/four-three.m3u8',
+                title: '4:3 Fixture',
+                type: 'vod',
+              ),
+              orchestrator: orchestrator,
+              epgService: EpgService(clock: () => DateTime.utc(2026)),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        adapter.emitState(
+          const PlaybackState(
+            backend: PlaybackBackend.desktopLibmpv,
+            status: PlaybackStatus.ready,
+            videoAspectRatio: 4 / 3,
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final textureSize = tester.getSize(find.byType(Texture));
+        expect(textureSize.width, moreOrLessEquals(1200));
+        expect(textureSize.height, moreOrLessEquals(900));
+      },
+    );
+
     testWidgets('shows live EPG as soon as playback is ready', (tester) async {
       final now = DateTime.utc(2026, 1, 1, 12);
       final adapter = FakePlayerAdapter(

--- a/flutter_client/tvos/Runner/AvKitPlaybackPlugin.swift
+++ b/flutter_client/tvos/Runner/AvKitPlaybackPlugin.swift
@@ -163,7 +163,11 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         switch item.status {
         case .readyToPlay:
             let posMs = currentPositionMs()
-            emit(type: s.player.rate > 0 ? "playing" : "ready", positionMs: posMs)
+            emit(
+                type: s.player.rate > 0 ? "playing" : "ready",
+                positionMs: posMs,
+                videoAspectRatio: videoAspectRatio(for: item)
+            )
         case .failed:
             let msg = item.error?.localizedDescription ?? "AVPlayer item failed"
             emit(type: "error", code: "avkit-item-failed", message: msg, recoverable: true)
@@ -188,11 +192,18 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         return seconds.isFinite ? Int64(seconds * 1000) : 0
     }
 
+    private func videoAspectRatio(for item: AVPlayerItem) -> Double? {
+        let size = item.presentationSize
+        guard size.width > 0, size.height > 0 else { return nil }
+        return Double(size.width / size.height)
+    }
+
     private func emit(
         type: String,
         textureId: Int64? = nil,
         uri: String? = nil,
         positionMs: Int64? = nil,
+        videoAspectRatio: Double? = nil,
         code: String? = nil,
         message: String? = nil,
         recoverable: Bool = false
@@ -201,6 +212,7 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         if let id = textureId  { event["textureId"]   = id       }
         if let u  = uri         { event["uri"]         = u        }
         if let p  = positionMs  { event["positionMs"]  = p        }
+        if let ar = videoAspectRatio { event["videoAspectRatio"] = ar }
         if let c  = code        { event["code"]        = c        }
         if let m  = message     { event["message"]     = m        }
         if recoverable          { event["recoverable"] = true      }

--- a/flutter_client/windows/runner/desktop_libmpv_backend.cpp
+++ b/flutter_client/windows/runner/desktop_libmpv_backend.cpp
@@ -34,6 +34,7 @@ using mpv_create_fn = mpv_handle* (*)();
 using mpv_initialize_fn = int (*)(mpv_handle*);
 using mpv_command_fn = int (*)(mpv_handle*, const char**);
 using mpv_set_option_string_fn = int (*)(mpv_handle*, const char*, const char*);
+using mpv_get_property_fn = int (*)(mpv_handle*, const char*, int, void*);
 using mpv_terminate_destroy_fn = void (*)(mpv_handle*);
 using mpv_render_update_fn = void (*)(void*);
 using mpv_render_context = struct mpv_render_context;
@@ -46,6 +47,8 @@ struct mpv_render_param {
   int type;
   void* data;
 };
+
+constexpr int MPV_FORMAT_DOUBLE = 5;
 
 constexpr int MPV_RENDER_PARAM_INVALID = 0;
 constexpr int MPV_RENDER_PARAM_API_TYPE = 1;
@@ -96,6 +99,7 @@ struct LibmpvApi {
   mpv_initialize_fn initialize = nullptr;
   mpv_command_fn command = nullptr;
   mpv_set_option_string_fn set_option_string = nullptr;
+  mpv_get_property_fn get_property = nullptr;
   mpv_terminate_destroy_fn terminate_destroy = nullptr;
   mpv_render_context_create_fn render_context_create = nullptr;
   mpv_render_context_set_update_callback_fn render_context_set_update_callback = nullptr;
@@ -107,7 +111,7 @@ struct LibmpvApi {
   bool client_available() const {
     return library != nullptr && create != nullptr && initialize != nullptr &&
            command != nullptr && set_option_string != nullptr &&
-           terminate_destroy != nullptr;
+           get_property != nullptr && terminate_destroy != nullptr;
   }
 
   bool render_api_available() const {
@@ -218,6 +222,7 @@ LibmpvApi& Api() {
   g_api.initialize = reinterpret_cast<mpv_initialize_fn>(LoadSymbol(g_api.library, "mpv_initialize"));
   g_api.command = reinterpret_cast<mpv_command_fn>(LoadSymbol(g_api.library, "mpv_command"));
   g_api.set_option_string = reinterpret_cast<mpv_set_option_string_fn>(LoadSymbol(g_api.library, "mpv_set_option_string"));
+  g_api.get_property = reinterpret_cast<mpv_get_property_fn>(LoadSymbol(g_api.library, "mpv_get_property"));
   g_api.terminate_destroy = reinterpret_cast<mpv_terminate_destroy_fn>(LoadSymbol(g_api.library, "mpv_terminate_destroy"));
   g_api.render_context_create = reinterpret_cast<mpv_render_context_create_fn>(LoadSymbol(g_api.library, "mpv_render_context_create"));
   g_api.render_context_set_update_callback = reinterpret_cast<mpv_render_context_set_update_callback_fn>(LoadSymbol(g_api.library, "mpv_render_context_set_update_callback"));
@@ -391,6 +396,54 @@ ProbeMap Load(const flutter::EncodableMap* args, HWND hwnd) {
   };
 }
 
+
+bool DoubleProperty(PlayerInstance* player, const char* name, double* value) {
+  if (player == nullptr || player->api == nullptr ||
+      player->api->get_property == nullptr) {
+    return false;
+  }
+  double current = 0.0;
+  const int rc = player->api->get_property(
+      player->handle, name, MPV_FORMAT_DOUBLE, &current);
+  if (rc < 0 || current <= 0.0) return false;
+  *value = current;
+  return true;
+}
+
+ProbeMap VideoAspectRatioResult(PlayerInstance* player) {
+  ProbeMap result{
+      {flutter::EncodableValue("ok"), flutter::EncodableValue(true)},
+  };
+
+  double aspect = 0.0;
+  if (DoubleProperty(player, "video-params/aspect", &aspect)) {
+    result[flutter::EncodableValue("videoAspectRatio")] =
+        flutter::EncodableValue(aspect);
+  }
+
+  double width = 0.0;
+  double height = 0.0;
+  if (DoubleProperty(player, "dwidth", &width) &&
+      DoubleProperty(player, "dheight", &height)) {
+    result[flutter::EncodableValue("videoWidth")] = flutter::EncodableValue(width);
+    result[flutter::EncodableValue("videoHeight")] = flutter::EncodableValue(height);
+    if (aspect <= 0.0) {
+      result[flutter::EncodableValue("videoAspectRatio")] =
+          flutter::EncodableValue(width / height);
+    }
+  }
+  return result;
+}
+
+ProbeMap VideoAspectRatioForHandle(const flutter::EncodableMap* args) {
+  const int64_t id = IntArg(args, "handle");
+  auto it = g_players.find(id);
+  if (it == g_players.end()) {
+    return ProbeMap{{flutter::EncodableValue("ok"), flutter::EncodableValue(false)}};
+  }
+  return VideoAspectRatioResult(it->second.get());
+}
+
 void Control(const std::string& method, const flutter::EncodableMap* args) {
   const int64_t id = IntArg(args, "handle");
   auto it = g_players.find(id);
@@ -457,6 +510,10 @@ class DesktopLibmpvBackendPlugin : public flutter::Plugin {
     }
     if (method == "load") {
       result->Success(flutter::EncodableValue(Load(args, hwnd_)));
+      return;
+    }
+    if (method == "getVideoAspectRatio") {
+      result->Success(flutter::EncodableValue(VideoAspectRatioForHandle(args)));
       return;
     }
     Control(method, args);


### PR DESCRIPTION
## Summary
- Preserve reported video aspect ratios in the player surface instead of forcing 16:9
- Parse aspect ratio metadata from playback sources and backend events
- Poll desktop libmpv display dimensions after load so Linux and Windows playback update when source metadata is missing
- Forward Android Media3, iOS AVKit, and tvOS AVPlayer aspect-ratio signals when native video size is known
- Forward media_kit video params for macOS/iOS MPV-backed playback
- Add widget and desktop/media_kit backend coverage for non-16:9 playback

## Testing
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Closes #29
