### PR TITLE
fix: improve offline server recovery

### DIFF
--- a/flutter_client/lib/features/settings/settings_screen.dart
+++ b/flutter_client/lib/features/settings/settings_screen.dart
@@ -344,6 +344,7 @@ class _ConnectedView extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final auth = authNotifier.authResponse;
+    final hasSourceError = sourceError != null && sourceError!.isNotEmpty;
 
     return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
@@ -374,12 +375,37 @@ class _ConnectedView extends StatelessWidget {
                     value: auth.m3uEditorVersion ?? 'Unknown',
                   ),
                 ],
-                if (sourceError != null && sourceError!.isNotEmpty) ...[
+                if (hasSourceError) ...[
                   const Divider(),
                   _StatusRow(
                     label: 'Last error',
                     value: sourceError!,
                     valueColor: theme.colorScheme.error,
+                  ),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 8,
+                    children: [
+                      DpadFocusable(
+                        onSelect: onClearCache,
+                        effects: _kStadiumEffect,
+                        child: FilledButton.tonalIcon(
+                          onPressed: onClearCache,
+                          icon: const Icon(Icons.refresh),
+                          label: const Text('Retry connection'),
+                        ),
+                      ),
+                      DpadFocusable(
+                        onSelect: onDisconnect,
+                        effects: _kStadiumEffect,
+                        child: FilledButton.tonalIcon(
+                          onPressed: onDisconnect,
+                          icon: const Icon(Icons.settings),
+                          label: const Text('Edit server settings'),
+                        ),
+                      ),
+                    ],
                   ),
                 ],
               ],

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -355,7 +355,7 @@ class AppStateController extends ChangeNotifier {
       notifyListeners();
       return true;
     } on Object catch (error) {
-      _error = _redact('$error', xtreamService.credentials);
+      _error = _redact(userFacingXtreamError(error), xtreamService.credentials);
       return false;
     }
   }

--- a/flutter_client/lib/services/auth_notifier.dart
+++ b/flutter_client/lib/services/auth_notifier.dart
@@ -60,7 +60,7 @@ class AuthNotifier extends ChangeNotifier {
       notifyListeners();
       return false;
     } on Object catch (e) {
-      _error = _redact(e.toString(), credentials);
+      _error = _redact(userFacingXtreamError(e), credentials);
       _isLoading = false;
       notifyListeners();
       return false;

--- a/flutter_client/lib/services/xtream_service.dart
+++ b/flutter_client/lib/services/xtream_service.dart
@@ -11,6 +11,8 @@ typedef XtreamTransport = Future<Object?> Function(XtreamRequest request);
 
 enum AuthErrorCode { invalidCredentials, expired, serverError, notM3UEditor }
 
+const serverUnavailableMessage = 'Server is currently unavailable.';
+
 class XtreamAuthException implements Exception {
   const XtreamAuthException(this.code, this.message);
 
@@ -50,6 +52,26 @@ class XtreamHttpException implements Exception {
         : ' $reasonPhrase';
     return 'Xtream HTTP $statusCode$reason for $method $safeUri$serverDetail';
   }
+}
+
+String userFacingXtreamError(Object error) {
+  if (error is XtreamHttpException && error.isServerUnavailable) {
+    return serverUnavailableMessage;
+  }
+  final message = error.toString();
+  final lower = message.toLowerCase();
+  if (lower.contains('connection refused') ||
+      lower.contains('connection timed out') ||
+      lower.contains('failed host lookup') ||
+      lower.contains('network is unreachable')) {
+    return serverUnavailableMessage;
+  }
+  return message;
+}
+
+extension XtreamHttpExceptionClassification on XtreamHttpException {
+  bool get isServerUnavailable =>
+      statusCode == 502 || statusCode == 503 || statusCode == 504;
 }
 
 class XtreamResponseException implements Exception {

--- a/flutter_client/test/ui/settings/settings_test.dart
+++ b/flutter_client/test/ui/settings/settings_test.dart
@@ -187,6 +187,39 @@ void main() {
     });
 
     test(
+      'connect with unavailable server shows user-facing outage error',
+      () async {
+        final notifier = AuthNotifier(
+          xtreamService: XtreamService(
+            transport: (_) async {
+              throw XtreamHttpException(
+                statusCode: 503,
+                method: 'GET',
+                uri: Uri.parse('http://x.com/player_api.php'),
+                reasonPhrase: 'Service Unavailable',
+                serverMessage: 'no available server',
+              );
+            },
+          ),
+          secureStorage: InMemorySecureStorage(),
+        );
+
+        final result = await notifier.connect(
+          const UserCredentials(
+            server: 'http://x.com',
+            username: 'u',
+            password: 'p',
+          ),
+        );
+
+        expect(result, isFalse);
+        expect(notifier.error, 'Server is currently unavailable.');
+        expect(notifier.error, isNot(contains('Xtream HTTP 503')));
+        expect(notifier.error, isNot(contains('player_api.php')));
+      },
+    );
+
+    test(
       'connect with plaintext server failure hides parser details',
       () async {
         final notifier = AuthNotifier(
@@ -467,6 +500,41 @@ void main() {
       // Should show the connected view with status
       expect(find.text('Connection'), findsOneWidget);
       expect(find.text('Connected'), findsWidgets);
+    });
+
+    testWidgets('shows outage actions instead of setup copy when configured', (
+      tester,
+    ) async {
+      var retried = false;
+      var edited = false;
+      final notifier = AuthNotifier(
+        xtreamService: XtreamService(transport: _FakeTransport({}).call),
+        secureStorage: InMemorySecureStorage(),
+      );
+
+      await tester.pumpWidget(
+        _settingsApp(
+          notifier,
+          sourceError: 'Server is currently unavailable.',
+          isConfiguredOverride: true,
+          onClearCache: () => retried = true,
+          onDisconnect: () => edited = true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Server is currently unavailable.'), findsOneWidget);
+      expect(find.text('Retry connection'), findsOneWidget);
+      expect(find.text('Edit server settings'), findsOneWidget);
+      expect(find.text('Enter your Xtream codes details'), findsNothing);
+
+      await tester.tap(find.text('Retry connection'));
+      await tester.pumpAndSettle();
+      expect(retried, isTrue);
+
+      await tester.tap(find.text('Edit server settings'));
+      await tester.pumpAndSettle();
+      expect(edited, isTrue);
     });
 
     testWidgets('shows disconnect button when configured', (tester) async {
@@ -786,6 +854,9 @@ Widget _settingsApp(
   AuthNotifier notifier, {
   Viewer? activeViewer,
   String? sourceError,
+  bool? isConfiguredOverride,
+  VoidCallback? onClearCache,
+  VoidCallback? onDisconnect,
 }) {
   return MaterialApp(
     theme: ThemeData.dark(useMaterial3: true),
@@ -794,7 +865,9 @@ Widget _settingsApp(
         authNotifier: notifier,
         activeViewer: activeViewer,
         sourceError: sourceError,
-        onDisconnect: () => notifier.disconnect(),
+        isConfiguredOverride: isConfiguredOverride,
+        onClearCache: onClearCache,
+        onDisconnect: onDisconnect ?? () => notifier.disconnect(),
       ),
     ),
   );


### PR DESCRIPTION
## Summary
- Show a clear unavailable-server message for HTTP 502/503/504 and common network failures.
- Keep configured users in the connected settings view when content refresh fails.
- Add recovery actions to retry the connection or edit server settings.

## Testing
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Closes #25
