### PR TITLE
fix: enable desktop category row scrolling

### DIFF
--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -460,7 +460,6 @@ class _SeasonChipsState extends State<_SeasonChips> {
       onPointerSignal: _handlePointerSignal,
       child: Scrollbar(
         controller: _controller,
-        thumbVisibility: true,
         child: SingleChildScrollView(
           controller: _controller,
           scrollDirection: Axis.horizontal,

--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/navigation/app_router.dart';
@@ -414,7 +415,7 @@ class _SeriesDetailsBody extends StatelessWidget {
   }
 }
 
-class _SeasonChips extends StatelessWidget {
+class _SeasonChips extends StatefulWidget {
   const _SeasonChips({
     required this.seasons,
     required this.selectedSeason,
@@ -426,23 +427,58 @@ class _SeasonChips extends StatelessWidget {
   final ValueChanged<int> onSeasonSelected;
 
   @override
+  State<_SeasonChips> createState() => _SeasonChipsState();
+}
+
+class _SeasonChipsState extends State<_SeasonChips> {
+  final ScrollController _controller = ScrollController();
+
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent || !_controller.hasClients) return;
+    final delta = event.scrollDelta.dx.abs() > event.scrollDelta.dy.abs()
+        ? event.scrollDelta.dx
+        : event.scrollDelta.dy;
+    if (delta == 0) return;
+    final position = _controller.position;
+    final target = (_controller.offset + delta).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    _controller.jumpTo(target);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (seasons.isEmpty) return const SizedBox.shrink();
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: seasons
-            .map((season) {
-              return Padding(
-                padding: const EdgeInsets.only(right: 8),
-                child: CategoryFilterChip(
-                  label: season.name,
-                  isSelected: season.number == selectedSeason,
-                  onTap: () => onSeasonSelected(season.number),
-                ),
-              );
-            })
-            .toList(growable: false),
+    if (widget.seasons.isEmpty) return const SizedBox.shrink();
+    return Listener(
+      onPointerSignal: _handlePointerSignal,
+      child: Scrollbar(
+        controller: _controller,
+        thumbVisibility: true,
+        child: SingleChildScrollView(
+          controller: _controller,
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: widget.seasons
+                .map((season) {
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 8),
+                    child: CategoryFilterChip(
+                      label: season.name,
+                      isSelected: season.number == widget.selectedSeason,
+                      onTap: () => widget.onSeasonSelected(season.number),
+                    ),
+                  );
+                })
+                .toList(growable: false),
+          ),
+        ),
       ),
     );
   }

--- a/flutter_client/lib/shared/media_browsing_widgets.dart
+++ b/flutter_client/lib/shared/media_browsing_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:dpad/dpad.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
@@ -254,6 +255,26 @@ class ScrollableCategoryBar extends StatefulWidget {
 class _ScrollableCategoryBarState extends State<ScrollableCategoryBar> {
   final ScrollController _controller = ScrollController();
 
+  void _handlePointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent || !_controller.hasClients) {
+      return;
+    }
+
+    final delta = event.scrollDelta.dx.abs() > event.scrollDelta.dy.abs()
+        ? event.scrollDelta.dx
+        : event.scrollDelta.dy;
+    if (delta == 0) {
+      return;
+    }
+
+    final position = _controller.position;
+    final target = (_controller.offset + delta).clamp(
+      position.minScrollExtent,
+      position.maxScrollExtent,
+    );
+    _controller.jumpTo(target);
+  }
+
   @override
   void dispose() {
     _controller.dispose();
@@ -277,21 +298,29 @@ class _ScrollableCategoryBarState extends State<ScrollableCategoryBar> {
             child: SizedBox(
               height: 36,
               child: ExcludeSemantics(
-                child: ListView.separated(
-                  controller: _controller,
-                  scrollDirection: Axis.horizontal,
-                  padding: EdgeInsets.zero,
-                  itemCount: widget.tabs.length,
-                  separatorBuilder: (_, _) =>
-                      const SizedBox(width: MediaBrowsingMetrics.chipGap),
-                  itemBuilder: (context, index) {
-                    final tab = widget.tabs[index];
-                    return CategoryFilterChip(
-                      label: tab.name,
-                      isSelected: widget.selectedId == tab.id,
-                      onTap: () => widget.onSelected(tab.id),
-                    );
-                  },
+                child: Listener(
+                  onPointerSignal: _handlePointerSignal,
+                  child: Scrollbar(
+                    controller: _controller,
+                    thumbVisibility: true,
+                    child: ListView.separated(
+                      controller: _controller,
+                      scrollDirection: Axis.horizontal,
+                      padding: EdgeInsets.zero,
+                      itemCount: widget.tabs.length,
+                      separatorBuilder: (_, _) => const SizedBox(
+                        width: MediaBrowsingMetrics.chipGap,
+                      ),
+                      itemBuilder: (context, index) {
+                        final tab = widget.tabs[index];
+                        return CategoryFilterChip(
+                          label: tab.name,
+                          isSelected: widget.selectedId == tab.id,
+                          onTap: () => widget.onSelected(tab.id),
+                        );
+                      },
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/flutter_client/lib/shared/media_browsing_widgets.dart
+++ b/flutter_client/lib/shared/media_browsing_widgets.dart
@@ -302,7 +302,6 @@ class _ScrollableCategoryBarState extends State<ScrollableCategoryBar> {
                   onPointerSignal: _handlePointerSignal,
                   child: Scrollbar(
                     controller: _controller,
-                    thumbVisibility: true,
                     child: ListView.separated(
                       controller: _controller,
                       scrollDirection: Axis.horizontal,

--- a/flutter_client/macos/Podfile.lock
+++ b/flutter_client/macos/Podfile.lock
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65
-  media_kit_video: fa6564e3799a0a28bff39442334817088b7ca758
+  media_kit_libs_macos_video: b3e2bbec2eef97c285f2b1baa7963c67c753fb82
+  media_kit_video: c75b07f14d59706c775778e4dd47dd027de8d1e5
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/flutter_client/test/ui/shared/scrollable_category_bar_test.dart
+++ b/flutter_client/test/ui/shared/scrollable_category_bar_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+void main() {
+  group('ScrollableCategoryBar', () {
+    testWidgets('mouse wheel scrolls the horizontal category row', (
+      tester,
+    ) async {
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await tester.binding.setSurfaceSize(const Size(360, 160));
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScrollableCategoryBar(
+              tabs: List<CategoryTabData>.generate(
+                18,
+                (index) => CategoryTabData(
+                  id: '$index',
+                  name: 'Category $index',
+                ),
+              ),
+              selectedId: '0',
+              onSelected: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Category 0'), findsOneWidget);
+
+      await tester.sendEventToBinding(
+        PointerScrollEvent(
+          position: tester.getCenter(find.byType(ScrollableCategoryBar)),
+          scrollDelta: const Offset(0, 420),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Category 0'), findsNothing);
+      expect(find.text('Category 3'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add pointer wheel handling to the shared category bar so vertical or horizontal wheel input scrolls overflowing category chips on desktop.
- Keep a visible scrollbar wired to the same controller.
- Add a widget regression test for mouse wheel scrolling over the category row.

## Testing

- `/tmp/flutter/bin/flutter test test/ui/shared/scrollable_category_bar_test.dart --plain-name 'mouse wheel scrolls the horizontal category row'`
- `/tmp/flutter/bin/flutter test test/ui/features/live_tv_screen_test.dart --plain-name 'category bar exposes scrollbar and arrow affordances'`
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed lib/shared/media_browsing_widgets.dart test/ui/shared/scrollable_category_bar_test.dart`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Closes #26
