### PR TITLE
fix: improve continue watching cards

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1091,7 +1091,7 @@ class _HomeScreen extends StatelessWidget {
       title: 'Continue Watching',
       emptyLabel: 'No Continue Watching available',
       items: continueWatchingItems,
-      landscapeStyle: true,
+      posterStyle: true,
       onSidebarActivate: onSidebarActivate,
     );
     final liveSection = MediaPreviewSection(
@@ -1178,24 +1178,33 @@ class _HomeScreen extends StatelessWidget {
         !progress.completed;
   }
 
+  double? _resumeProgressFraction(Progress progress) {
+    final duration = progress.durationSeconds;
+    if (duration == null || duration <= 0) {
+      return null;
+    }
+    return (progress.positionSeconds / duration).clamp(0.0, 1.0);
+  }
+
+  String? _resumeProgressSubtitle(Progress progress) {
+    final fraction = _resumeProgressFraction(progress);
+    if (fraction == null) {
+      return null;
+    }
+    final percent = (fraction * 100).round().clamp(1, 99);
+    return '$percent% watched';
+  }
+
   MediaPreviewItem? _resumePreviewItem(Progress progress) {
     if (progress.contentType == ContentType.vod) {
       // Use enriched API data when available.
       if (progress.title != null) {
-        final hasBackdrop = progress.backdropUrl != null;
-        final fraction =
-            (progress.durationSeconds != null && progress.durationSeconds! > 0)
-            ? (progress.positionSeconds / progress.durationSeconds!).clamp(
-                0.0,
-                1.0,
-              )
-            : null;
+        final fraction = _resumeProgressFraction(progress);
         return MediaPreviewItem(
           title: progress.title!,
-          imageUrl: progress.backdropUrl ?? progress.thumbnailUrl,
+          imageUrl: progress.thumbnailUrl ?? progress.backdropUrl,
+          subtitle: _resumeProgressSubtitle(progress),
           fallbackIcon: Icons.movie,
-          imageFit: hasBackdrop ? BoxFit.cover : BoxFit.contain,
-          imageBackgroundColor: hasBackdrop ? null : Colors.black,
           fallbackTitle: progress.title,
           progressFraction: fraction,
           overlayBadges: <String>[
@@ -1213,11 +1222,10 @@ class _HomeScreen extends StatelessWidget {
       return MediaPreviewItem(
         title: 'Resume ${item.name}',
         imageUrl: item.logoUrl,
-        subtitle: 'Stream ${progress.streamId}',
-        fallbackIcon: Icons.play_circle_outline,
-        imageFit: BoxFit.contain,
-        imageBackgroundColor: Colors.black,
+        subtitle: _resumeProgressSubtitle(progress),
+        fallbackIcon: Icons.movie,
         fallbackTitle: item.name,
+        progressFraction: _resumeProgressFraction(progress),
         onTap: () => onProgressSelect(progress),
       );
     }
@@ -1228,13 +1236,7 @@ class _HomeScreen extends StatelessWidget {
       if (progress.seriesId != null &&
           (progress.seriesName != null || progress.title != null)) {
         final displayTitle = progress.seriesName ?? progress.title!;
-        final fraction =
-            (progress.durationSeconds != null && progress.durationSeconds! > 0)
-            ? (progress.positionSeconds / progress.durationSeconds!).clamp(
-                0.0,
-                1.0,
-              )
-            : null;
+        final fraction = _resumeProgressFraction(progress);
         final episodeSubtitle =
             progress.episodeTitle ??
             (progress.seasonNumber != null

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -19,6 +19,7 @@ import 'package:m3u_tv/services/resume_service.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
 import 'package:m3u_tv/services/viewer_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/transcoding/transcoding.dart';
 
 void main() {
@@ -295,6 +296,51 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(capturedArgs?.epgChannelId, 'Route News');
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Home continue watching uses portrait cards without stream IDs', (
+    tester,
+  ) async {
+    final appState = _testAppState(
+      xtreamService: _NavigationXtreamService(
+        recentlyWatched: const <Progress>[
+          Progress(
+            viewerId: 'viewer-1',
+            contentType: ContentType.vod,
+            streamId: 201,
+            positionSeconds: 91,
+            durationSeconds: 600,
+          ),
+        ],
+      ),
+    );
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(deviceType: DeviceType.tv, appState: appState),
+    );
+    await _pumpAppFrame(tester);
+
+    expect(find.text('Continue Watching'), findsOneWidget);
+    expect(find.text('Resume Route Movie'), findsOneWidget);
+    expect(find.text('Stream 201'), findsNothing);
+
+    final cardFinder = find.ancestor(
+      of: find.text('Resume Route Movie'),
+      matching: find.byType(MediaPreviewCard),
+    );
+    expect(cardFinder, findsOneWidget);
+    final cardSize = tester.getSize(cardFinder);
+    expect(cardSize.height, greaterThan(cardSize.width));
+
     await tester.pumpWidget(const SizedBox.shrink());
   });
 


### PR DESCRIPTION
## Summary

- Switch Home Continue Watching cards from landscape layout to portrait poster layout.
- Replace internal `Stream <id>` metadata with user-facing watched-percentage text when duration is available.
- Reuse shared resume progress helpers for progress bars and metadata.
- Add a widget regression test covering portrait card geometry and hiding stream IDs.

## Testing

- `/tmp/flutter/bin/flutter test test/ui/navigation/navigation_test.dart --plain-name 'Home continue watching uses portrait cards without stream IDs'`
- `/tmp/flutter/bin/flutter test test/ui/navigation/navigation_test.dart --plain-name 'selecting Home continue watching movie opens player route'`
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Closes #28
