### PR TITLE
fix: resume playback from saved position

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -192,6 +193,14 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
             p.positionSeconds >= 30 &&
             !p.completed,
       );
+      if (kDebugMode) {
+        debugPrint(
+          '[resume-debug] openPlayer lookup '
+          'type=${resolvedArgs.type} streamId=${resolvedArgs.streamId} '
+          'start=${resolvedArgs.startPosition} progressList=${_appState.progressList.length} '
+          'match=${progress?.positionSeconds}',
+        );
+      }
       if (progress != null && context.mounted) {
         final startPos = await showResumeModal(
           context,
@@ -208,6 +217,12 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
   }
 
   void _openPlayerDirect(PlayerArgs args) {
+    if (kDebugMode) {
+      debugPrint(
+        '[resume-debug] openPlayer direct '
+        'type=${args.type} streamId=${args.streamId} start=${args.startPosition}',
+      );
+    }
     final oldOrch = _playerOrchestrator;
     final newOrch =
         widget.playbackOrchestratorBuilder?.call() ??
@@ -400,15 +415,45 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
                     genre: progress.genre ?? existing?.genre,
                     year: progress.year ?? existing?.year,
                   );
+                  if (kDebugMode) {
+                    debugPrint(
+                      '[resume-debug] app progress report '
+                      'viewer=${toSave.viewerId} type=${toSave.contentType.wireName} '
+                      'streamId=${toSave.streamId} position=${toSave.positionSeconds} '
+                      'duration=${toSave.durationSeconds}',
+                    );
+                  }
                   if (_appState.sourceType == AppSourceType.xtream) {
                     unawaited(
                       _appState.xtreamService
                           .updateProgress(toSave)
-                          .catchError((_) {}),
+                          .then((_) {
+                            if (kDebugMode) {
+                              debugPrint(
+                                '[resume-debug] xtream update_progress ok '
+                                'type=${toSave.contentType.wireName} streamId=${toSave.streamId} '
+                                'position=${toSave.positionSeconds}',
+                              );
+                            }
+                          })
+                          .catchError((Object error) {
+                            if (kDebugMode) {
+                              debugPrint(
+                                '[resume-debug] xtream update_progress failed: $error',
+                              );
+                            }
+                          }),
                     );
                   }
                   unawaited(
                     _appState.resumeService.save(toSave).then((_) {
+                      if (kDebugMode) {
+                        debugPrint(
+                          '[resume-debug] local resume save ok '
+                          'type=${toSave.contentType.wireName} streamId=${toSave.streamId} '
+                          'position=${toSave.positionSeconds}',
+                        );
+                      }
                       if (mounted) unawaited(_appState.refreshLocalState());
                     }),
                   );
@@ -852,6 +897,8 @@ class _ContentNavigator extends StatelessWidget {
       playerRouteBuilder: playerRouteBuilder,
       onOpenPlayer: onOpenPlayer,
       progressList: appState.progressList,
+      progressListenable: appState,
+      progressListProvider: () => appState.progressList,
     );
 
     return Navigator(

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -193,14 +192,6 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
             p.positionSeconds >= 30 &&
             !p.completed,
       );
-      if (kDebugMode) {
-        debugPrint(
-          '[resume-debug] openPlayer lookup '
-          'type=${resolvedArgs.type} streamId=${resolvedArgs.streamId} '
-          'start=${resolvedArgs.startPosition} progressList=${_appState.progressList.length} '
-          'match=${progress?.positionSeconds}',
-        );
-      }
       if (progress != null && context.mounted) {
         final startPos = await showResumeModal(
           context,
@@ -217,12 +208,6 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
   }
 
   void _openPlayerDirect(PlayerArgs args) {
-    if (kDebugMode) {
-      debugPrint(
-        '[resume-debug] openPlayer direct '
-        'type=${args.type} streamId=${args.streamId} start=${args.startPosition}',
-      );
-    }
     final oldOrch = _playerOrchestrator;
     final newOrch =
         widget.playbackOrchestratorBuilder?.call() ??
@@ -415,45 +400,15 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
                     genre: progress.genre ?? existing?.genre,
                     year: progress.year ?? existing?.year,
                   );
-                  if (kDebugMode) {
-                    debugPrint(
-                      '[resume-debug] app progress report '
-                      'viewer=${toSave.viewerId} type=${toSave.contentType.wireName} '
-                      'streamId=${toSave.streamId} position=${toSave.positionSeconds} '
-                      'duration=${toSave.durationSeconds}',
-                    );
-                  }
                   if (_appState.sourceType == AppSourceType.xtream) {
                     unawaited(
                       _appState.xtreamService
                           .updateProgress(toSave)
-                          .then((_) {
-                            if (kDebugMode) {
-                              debugPrint(
-                                '[resume-debug] xtream update_progress ok '
-                                'type=${toSave.contentType.wireName} streamId=${toSave.streamId} '
-                                'position=${toSave.positionSeconds}',
-                              );
-                            }
-                          })
-                          .catchError((Object error) {
-                            if (kDebugMode) {
-                              debugPrint(
-                                '[resume-debug] xtream update_progress failed: $error',
-                              );
-                            }
-                          }),
+                          .catchError((_) {}),
                     );
                   }
                   unawaited(
                     _appState.resumeService.save(toSave).then((_) {
-                      if (kDebugMode) {
-                        debugPrint(
-                          '[resume-debug] local resume save ok '
-                          'type=${toSave.contentType.wireName} streamId=${toSave.streamId} '
-                          'position=${toSave.positionSeconds}',
-                        );
-                      }
                       if (mounted) unawaited(_appState.refreshLocalState());
                     }),
                   );

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -165,13 +164,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _errorSubscription = widget.orchestrator.onError.listen(_handleError);
 
     final source = widget.args.toPlaybackSource();
-    if (kDebugMode) {
-      debugPrint(
-        '[resume-debug] player start '
-        'type=${widget.args.type} streamId=${widget.args.streamId} '
-        'argStart=${widget.args.startPosition} sourceStart=${source.startPosition.inSeconds}s',
-      );
-    }
 
     unawaited(_openAndSeek(source));
   }
@@ -181,11 +173,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
       await widget.orchestrator.open(source);
       if (_disposed || !mounted || source.isLive) return;
       if (source.startPosition > Duration.zero) {
-        if (kDebugMode) {
-          debugPrint(
-            '[resume-debug] post-load seek ${source.startPosition.inSeconds}s',
-          );
-        }
         await widget.orchestrator.seek(source.startPosition);
       }
     } on Object catch (error) {
@@ -302,13 +289,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   void _reportProgress(Duration position) {
     if (_isLive || widget.progressReporter == null) return;
-    if (kDebugMode) {
-      debugPrint(
-        '[resume-debug] player progress '
-        'type=${widget.args.type} streamId=${widget.args.streamId} '
-        'position=${position.inSeconds}s duration=${_duration.inSeconds}s',
-      );
-    }
     widget.progressReporter!(
       Progress(
         viewerId: widget.viewerId,
@@ -408,12 +388,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
     final clamped = position < Duration.zero
         ? Duration.zero
         : (position > _duration ? _duration : position);
-    if (kDebugMode) {
-      debugPrint(
-        '[resume-debug] player seek request '
-        'target=${position.inSeconds}s clamped=${clamped.inSeconds}s',
-      );
-    }
     setState(() => _currentPosition = clamped);
     _reportProgress(clamped);
     unawaited(widget.orchestrator.seek(clamped));

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -283,22 +283,25 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _progressTimer?.cancel();
     _progressTimer = Timer.periodic(_progressInterval, (_) {
       if (_disposed || !mounted) return;
-      widget.progressReporter?.call(
-        Progress(
-          viewerId: widget.viewerId,
-          contentType: _isLive
-              ? ContentType.live
-              : (widget.args.type == 'series'
-                    ? ContentType.episode
-                    : ContentType.vod),
-          streamId: widget.args.streamId ?? 0,
-          positionSeconds: _currentPosition.inSeconds,
-          durationSeconds: _duration.inSeconds > 0 ? _duration.inSeconds : null,
-          seriesId: widget.args.seriesId,
-          seasonNumber: widget.args.seasonNumber,
-        ),
-      );
+      _reportProgress(_currentPosition);
     });
+  }
+
+  void _reportProgress(Duration position) {
+    if (_isLive || widget.progressReporter == null) return;
+    widget.progressReporter!(
+      Progress(
+        viewerId: widget.viewerId,
+        contentType: widget.args.type == 'series'
+            ? ContentType.episode
+            : ContentType.vod,
+        streamId: widget.args.streamId ?? 0,
+        positionSeconds: position.inSeconds,
+        durationSeconds: _duration.inSeconds > 0 ? _duration.inSeconds : null,
+        seriesId: widget.args.seriesId,
+        seasonNumber: widget.args.seasonNumber,
+      ),
+    );
   }
 
   void _startEpgRefresh() {
@@ -382,7 +385,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   void _seekTo(Duration position) {
     if (!_canSeek) return;
-    unawaited(widget.orchestrator.seek(position));
+    final clamped = position < Duration.zero
+        ? Duration.zero
+        : (position > _duration ? _duration : position);
+    setState(() => _currentPosition = clamped);
+    _reportProgress(clamped);
+    unawaited(widget.orchestrator.seek(clamped));
   }
 
   void _handleAudioTrackSelected(String? trackId) {

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -164,6 +165,13 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _errorSubscription = widget.orchestrator.onError.listen(_handleError);
 
     final source = widget.args.toPlaybackSource();
+    if (kDebugMode) {
+      debugPrint(
+        '[resume-debug] player start '
+        'type=${widget.args.type} streamId=${widget.args.streamId} '
+        'argStart=${widget.args.startPosition} sourceStart=${source.startPosition.inSeconds}s',
+      );
+    }
 
     unawaited(_openAndSeek(source));
   }
@@ -173,6 +181,11 @@ class _PlayerScreenState extends State<PlayerScreen> {
       await widget.orchestrator.open(source);
       if (_disposed || !mounted || source.isLive) return;
       if (source.startPosition > Duration.zero) {
+        if (kDebugMode) {
+          debugPrint(
+            '[resume-debug] post-load seek ${source.startPosition.inSeconds}s',
+          );
+        }
         await widget.orchestrator.seek(source.startPosition);
       }
     } on Object catch (error) {
@@ -289,6 +302,13 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   void _reportProgress(Duration position) {
     if (_isLive || widget.progressReporter == null) return;
+    if (kDebugMode) {
+      debugPrint(
+        '[resume-debug] player progress '
+        'type=${widget.args.type} streamId=${widget.args.streamId} '
+        'position=${position.inSeconds}s duration=${_duration.inSeconds}s',
+      );
+    }
     widget.progressReporter!(
       Progress(
         viewerId: widget.viewerId,
@@ -388,6 +408,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
     final clamped = position < Duration.zero
         ? Duration.zero
         : (position > _duration ? _duration : position);
+    if (kDebugMode) {
+      debugPrint(
+        '[resume-debug] player seek request '
+        'target=${position.inSeconds}s clamped=${clamped.inSeconds}s',
+      );
+    }
     setState(() => _currentPosition = clamped);
     _reportProgress(clamped);
     unawaited(widget.orchestrator.seek(clamped));

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -165,11 +165,19 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
     final source = widget.args.toPlaybackSource();
 
-    unawaited(
-      widget.orchestrator.open(source).catchError((Object error) {
-        if (!_disposed && mounted) _setErrorMessage(error.toString());
-      }),
-    );
+    unawaited(_openAndSeek(source));
+  }
+
+  Future<void> _openAndSeek(PlaybackSource source) async {
+    try {
+      await widget.orchestrator.open(source);
+      if (_disposed || !mounted || source.isLive) return;
+      if (source.startPosition > Duration.zero) {
+        await widget.orchestrator.seek(source.startPosition);
+      }
+    } on Object catch (error) {
+      if (!_disposed && mounted) _setErrorMessage(error.toString());
+    }
   }
 
   void _startLoadingTimeout() {

--- a/flutter_client/lib/features/player/resume_modal.dart
+++ b/flutter_client/lib/features/player/resume_modal.dart
@@ -1,6 +1,7 @@
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 import 'package:m3u_tv/features/player/format_time.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 
 /// Shows a resume/start-over dialog before opening a VOD or Series episode.
@@ -53,35 +54,42 @@ class _ResumeModal extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
                 const SizedBox(height: 20),
-                Card(
-                  child: Padding(
-                    padding: const EdgeInsets.all(16),
-                    child: Row(
-                      children: [
-                        CircleAvatar(
-                          backgroundColor: colorScheme.primary,
-                          child: Icon(
-                            Icons.play_arrow,
-                            color: colorScheme.onPrimary,
+                DpadInkWell(
+                  onTap: () => Navigator.of(
+                    context,
+                  ).pop(positionSeconds.toDouble()),
+                  borderRadius: const BorderRadius.all(Radius.circular(12)),
+                  child: Card(
+                    margin: EdgeInsets.zero,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Row(
+                        children: [
+                          CircleAvatar(
+                            backgroundColor: colorScheme.primary,
+                            child: Icon(
+                              Icons.play_arrow,
+                              color: colorScheme.onPrimary,
+                            ),
                           ),
-                        ),
-                        const SizedBox(width: 16),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              'Continue',
-                              style: theme.textTheme.titleMedium,
-                            ),
-                            Text(
-                              'From ${formatTime(Duration(seconds: positionSeconds))}',
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
+                          const SizedBox(width: 16),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Continue',
+                                style: theme.textTheme.titleMedium,
                               ),
-                            ),
-                          ],
-                        ),
-                      ],
+                              Text(
+                                'From ${formatTime(Duration(seconds: positionSeconds))}',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/navigation/app_router.dart';
@@ -115,8 +116,21 @@ class _VodDetailsBody extends StatelessWidget {
           progress.streamId == item.id &&
           progress.positionSeconds >= 30 &&
           !progress.completed) {
+        if (kDebugMode) {
+          debugPrint(
+            '[resume-debug] vod details progress match '
+            'streamId=${item.id} position=${progress.positionSeconds} '
+            'progressList=${progressList.length}',
+          );
+        }
         return progress;
       }
+    }
+    if (kDebugMode) {
+      debugPrint(
+        '[resume-debug] vod details progress miss '
+        'streamId=${item.id} progressList=${progressList.length}',
+      );
     }
     return null;
   }

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -14,11 +14,13 @@ class VodDetailsScreen extends StatefulWidget {
     super.key,
     required this.item,
     this.xtreamService,
+    this.progressList = const [],
     this.onPlay,
   });
 
   final VodItem item;
   final XtreamService? xtreamService;
+  final List<Progress> progressList;
   final void Function(PlayerArgs)? onPlay;
 
   @override
@@ -54,7 +56,11 @@ class _VodDetailsScreenState extends State<VodDetailsScreen> {
         ),
       ),
       body: _future == null
-          ? _VodDetailsBody(item: widget.item, onPlay: widget.onPlay)
+          ? _VodDetailsBody(
+              item: widget.item,
+              progressList: widget.progressList,
+              onPlay: widget.onPlay,
+            )
           : FutureBuilder<VodInfo?>(
               future: _future,
               builder: (context, snapshot) {
@@ -62,6 +68,7 @@ class _VodDetailsScreenState extends State<VodDetailsScreen> {
                   item: widget.item,
                   info: snapshot.hasError ? null : snapshot.data,
                   isLoading: snapshot.connectionState != ConnectionState.done,
+                  progressList: widget.progressList,
                   onPlay: widget.onPlay,
                 );
               },
@@ -75,12 +82,14 @@ class _VodDetailsBody extends StatelessWidget {
     required this.item,
     this.info,
     this.isLoading = false,
+    this.progressList = const [],
     this.onPlay,
   });
 
   final VodItem item;
   final VodInfo? info;
   final bool isLoading;
+  final List<Progress> progressList;
   final void Function(PlayerArgs)? onPlay;
 
   static const double _wideBreakpoint = 600;
@@ -89,20 +98,34 @@ class _VodDetailsBody extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final details = _ResolvedVodDetails(item, info);
+    final progress = _resumeProgress;
     return LayoutBuilder(
       builder: (context, constraints) {
         if (constraints.maxWidth < _wideBreakpoint) {
-          return _buildNarrow(context, theme, details);
+          return _buildNarrow(context, theme, details, progress);
         }
-        return _buildWide(context, theme, details);
+        return _buildWide(context, theme, details, progress);
       },
     );
+  }
+
+  Progress? get _resumeProgress {
+    for (final progress in progressList) {
+      if (progress.contentType == ContentType.vod &&
+          progress.streamId == item.id &&
+          progress.positionSeconds >= 30 &&
+          !progress.completed) {
+        return progress;
+      }
+    }
+    return null;
   }
 
   Widget _buildWide(
     BuildContext context,
     ThemeData theme,
     _ResolvedVodDetails details,
+    Progress? progress,
   ) {
     final backdrop = details.backdropUrl;
     final content = Padding(
@@ -124,7 +147,9 @@ class _VodDetailsBody extends StatelessWidget {
           ),
           const SizedBox(width: MediaBrowsingMetrics.pagePadding),
           Expanded(
-            child: SingleChildScrollView(child: _infoColumn(theme, details)),
+            child: SingleChildScrollView(
+              child: _infoColumn(theme, details, progress),
+            ),
           ),
         ],
       ),
@@ -166,6 +191,7 @@ class _VodDetailsBody extends StatelessWidget {
     BuildContext context,
     ThemeData theme,
     _ResolvedVodDetails details,
+    Progress? progress,
   ) {
     final backdrop = details.backdropUrl;
     return Column(
@@ -203,7 +229,12 @@ class _VodDetailsBody extends StatelessWidget {
         Expanded(
           child: SingleChildScrollView(
             padding: const EdgeInsets.all(16),
-            child: _infoColumn(theme, details, fullWidthButton: true),
+            child: _infoColumn(
+              theme,
+              details,
+              progress,
+              fullWidthButton: true,
+            ),
           ),
         ),
       ],
@@ -212,9 +243,12 @@ class _VodDetailsBody extends StatelessWidget {
 
   Widget _infoColumn(
     ThemeData theme,
-    _ResolvedVodDetails details, {
+    _ResolvedVodDetails details,
+    Progress? progress, {
     bool fullWidthButton = false,
   }) {
+    final progressValue = _progressValue(progress);
+    final buttonLabel = progress == null ? 'Play movie' : 'Continue movie';
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -240,18 +274,22 @@ class _VodDetailsBody extends StatelessWidget {
             width: double.infinity,
             child: FilledButton.icon(
               autofocus: true,
-              onPressed: () => _play(details),
+              onPressed: () => _play(details, progress),
               icon: const Icon(Icons.play_arrow),
-              label: const Text('Play movie'),
+              label: Text(buttonLabel),
             ),
           )
         else
           FilledButton.icon(
             autofocus: true,
-            onPressed: () => _play(details),
+            onPressed: () => _play(details, progress),
             icon: const Icon(Icons.play_arrow),
-            label: const Text('Play movie'),
+            label: Text(buttonLabel),
           ),
+        if (progressValue != null) ...[
+          const SizedBox(height: MediaBrowsingMetrics.chipGap),
+          LinearProgressIndicator(value: progressValue, minHeight: 4),
+        ],
         const SizedBox(height: MediaBrowsingMetrics.pagePadding),
         if (isLoading) ...[
           const LinearProgressIndicator(),
@@ -274,13 +312,20 @@ class _VodDetailsBody extends StatelessWidget {
     );
   }
 
-  void _play(_ResolvedVodDetails details) {
+  double? _progressValue(Progress? progress) {
+    final duration = progress?.durationSeconds;
+    if (progress == null || duration == null || duration <= 0) return null;
+    return (progress.positionSeconds / duration).clamp(0.0, 1.0);
+  }
+
+  void _play(_ResolvedVodDetails details, Progress? progress) {
     onPlay?.call(
       PlayerArgs(
         streamUrl: item.streamUrl,
         title: details.name,
         type: 'vod',
         streamId: item.id,
+        startPosition: progress?.positionSeconds.toDouble(),
         metadata: <String, Object?>{
           'title': details.name,
           if (details.containerExtension != null)

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/navigation/app_router.dart';
@@ -116,21 +115,8 @@ class _VodDetailsBody extends StatelessWidget {
           progress.streamId == item.id &&
           progress.positionSeconds >= 30 &&
           !progress.completed) {
-        if (kDebugMode) {
-          debugPrint(
-            '[resume-debug] vod details progress match '
-            'streamId=${item.id} position=${progress.positionSeconds} '
-            'progressList=${progressList.length}',
-          );
-        }
         return progress;
       }
-    }
-    if (kDebugMode) {
-      debugPrint(
-        '[resume-debug] vod details progress miss '
-        'streamId=${item.id} progressList=${progressList.length}',
-      );
     }
     return null;
   }

--- a/flutter_client/lib/navigation/app_router.dart
+++ b/flutter_client/lib/navigation/app_router.dart
@@ -135,7 +135,22 @@ RouteFactory buildAppRouter({
   Widget Function(PlayerArgs args)? playerRouteBuilder,
   void Function(PlayerArgs)? onOpenPlayer,
   List<Progress> progressList = const [],
+  Listenable? progressListenable,
+  List<Progress> Function()? progressListProvider,
 }) {
+  Widget withProgressUpdates(
+    Widget Function(List<Progress> progressList) builder,
+  ) {
+    final listenable = progressListenable;
+    if (listenable == null) return builder(progressList);
+    return ListenableBuilder(
+      listenable: listenable,
+      builder: (context, child) => builder(
+        progressListProvider?.call() ?? progressList,
+      ),
+    );
+  }
+
   return (RouteSettings settings) {
     final routeName = settings.name;
 
@@ -210,11 +225,13 @@ RouteFactory buildAppRouter({
       if (args is DetailsArgs && args.item != null) {
         return _buildSlideRoute(
           settings,
-          VodDetailsScreen(
-            item: args.item!,
-            xtreamService: xtreamService,
-            onPlay: onOpenPlayer,
-            progressList: progressList,
+          withProgressUpdates(
+            (progressList) => VodDetailsScreen(
+              item: args.item!,
+              xtreamService: xtreamService,
+              onPlay: onOpenPlayer,
+              progressList: progressList,
+            ),
           ),
         );
       }
@@ -226,12 +243,14 @@ RouteFactory buildAppRouter({
       if (args is SeriesDetailsArgs && xtreamService != null) {
         return _buildSlideRoute(
           settings,
-          SeriesDetailsScreen(
-            seriesId: args.seriesId,
-            seriesName: args.seriesName,
-            xtreamService: xtreamService,
-            onPlay: onOpenPlayer,
-            progressList: progressList,
+          withProgressUpdates(
+            (progressList) => SeriesDetailsScreen(
+              seriesId: args.seriesId,
+              seriesName: args.seriesName,
+              xtreamService: xtreamService,
+              onPlay: onOpenPlayer,
+              progressList: progressList,
+            ),
           ),
         );
       }

--- a/flutter_client/lib/navigation/app_router.dart
+++ b/flutter_client/lib/navigation/app_router.dart
@@ -214,6 +214,7 @@ RouteFactory buildAppRouter({
             item: args.item!,
             xtreamService: xtreamService,
             onPlay: onOpenPlayer,
+            progressList: progressList,
           ),
         );
       }

--- a/flutter_client/lib/playback/desktop_libmpv_backend.dart
+++ b/flutter_client/lib/playback/desktop_libmpv_backend.dart
@@ -42,7 +42,13 @@ class DesktopLibmpvBackend implements PlayerAdapter, VideoTextureProvider {
 
   @override
   Future<void> load(PlaybackSource source) async {
-    _emit(_state.copyWith(status: PlaybackStatus.loading, source: source));
+    _emit(
+      _state.copyWith(
+        status: PlaybackStatus.loading,
+        source: source,
+        position: source.startPosition,
+      ),
+    );
     final response = await _channel.invokeMapMethod<String, Object?>('load', {
       'uri': source.uri,
       'title': source.title,
@@ -68,7 +74,13 @@ class DesktopLibmpvBackend implements PlayerAdapter, VideoTextureProvider {
       _errorController.add(PlaybackError.fromException(error));
       throw error;
     }
-    _emit(_state.copyWith(status: PlaybackStatus.ready, source: source));
+    _emit(
+      _state.copyWith(
+        status: PlaybackStatus.ready,
+        source: source,
+        position: source.startPosition,
+      ),
+    );
   }
 
   @override

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
 import 'package:m3u_tv/playback/subtitle_controller_provider.dart';
@@ -140,13 +139,6 @@ class MediaKitDesktopAdapter
   @override
   Future<void> load(PlaybackSource source) async {
     _emit(_state.copyWith(status: PlaybackStatus.loading, source: source));
-    if (kDebugMode) {
-      debugPrint(
-        '[resume-debug] media_kit load '
-        'uri=${source.uri} start=${source.startPosition.inSeconds}s '
-        'headers=${source.headers.length}',
-      );
-    }
     await _player.open(mediaKitMediaFromPlaybackSource(source));
   }
 

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
 import 'package:m3u_tv/playback/subtitle_controller_provider.dart';
@@ -139,12 +140,14 @@ class MediaKitDesktopAdapter
   @override
   Future<void> load(PlaybackSource source) async {
     _emit(_state.copyWith(status: PlaybackStatus.loading, source: source));
-    await _player.open(
-      mk.Media(
-        source.uri,
-        httpHeaders: source.headers.isEmpty ? null : source.headers,
-      ),
-    );
+    if (kDebugMode) {
+      debugPrint(
+        '[resume-debug] media_kit load '
+        'uri=${source.uri} start=${source.startPosition.inSeconds}s '
+        'headers=${source.headers.length}',
+      );
+    }
+    await _player.open(mediaKitMediaFromPlaybackSource(source));
   }
 
   @override
@@ -204,6 +207,14 @@ class MediaKitDesktopAdapter
     _state = state;
     if (!_stateController.isClosed) _stateController.add(state);
   }
+}
+
+mk.Media mediaKitMediaFromPlaybackSource(PlaybackSource source) {
+  return mk.Media(
+    source.uri,
+    httpHeaders: source.headers.isEmpty ? null : source.headers,
+    start: source.startPosition > Duration.zero ? source.startPosition : null,
+  );
 }
 
 List<PlaybackTrack> mediaKitAudioTracksToPlaybackTracks(

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -319,6 +319,11 @@ class AppStateController extends ChangeNotifier {
       final vodItems = results[4] as List<VodItem>;
       final seriesList = results[5] as List<Series>;
 
+      final activeViewer = await viewerService.resolveActiveViewer(viewers);
+      final progress = activeViewer == null
+          ? const <Progress>[]
+          : await _loadRecentlyWatched(activeViewer.ulid);
+
       _sourceType = AppSourceType.xtream;
       _liveCategories = liveCategories;
       _vodCategories = vodCategories;
@@ -326,14 +331,13 @@ class AppStateController extends ChangeNotifier {
       _channels = channels;
       _vodItems = vodItems;
       _seriesList = seriesList;
+      _viewers = viewers;
+      _activeViewer = activeViewer;
+      _progressList = progress;
       _error = null;
       notifyListeners();
 
       await _loadXtreamEpg(channels);
-      final activeViewer = await viewerService.resolveActiveViewer(viewers);
-      final progress = activeViewer == null
-          ? const <Progress>[]
-          : await _loadRecentlyWatched(activeViewer.ulid);
 
       if (clearCache) await cacheService.clear();
       await cacheService.set('sourceType', 'xtream');

--- a/flutter_client/linux/desktop_libmpv_backend.cc
+++ b/flutter_client/linux/desktop_libmpv_backend.cc
@@ -434,7 +434,15 @@ FlMethodResponse* Load(FlValue* args) {
   api.render_context_set_update_callback(render_context, RenderUpdate, player.get());
 
   std::string uri = StringArg(args, "uri");
-  const char* load_args[] = {"loadfile", uri.c_str(), "replace", nullptr};
+  const int64_t start_position_ms = IntArg(args, "startPositionMs");
+  std::string start_option;
+  if (start_position_ms > 0) {
+    const double seconds = static_cast<double>(start_position_ms) / 1000.0;
+    start_option = "start=" + std::to_string(seconds);
+  }
+  const char* load_args[] = {"loadfile", uri.c_str(), "replace",
+                             start_option.empty() ? nullptr : start_option.c_str(),
+                             nullptr};
   rc = api.command(handle, load_args);
   if (rc < 0) return LoadFailure("desktop-libmpv-load-failed", "mpv loadfile command failed");
 

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -94,6 +94,47 @@ void main() {
       },
     );
 
+    test('Xtream progress is visible before EPG refresh finishes', () async {
+      final storage = InMemorySecureStorage();
+      final epgGate = Completer<Object?>();
+      final controller = _controller(
+        storage: storage,
+        transport: _FakeXtreamTransport.success()
+            .withResponse('get_recently_watched', <Map<String, Object?>>[
+              <String, Object?>{
+                'content_type': 'vod',
+                'stream_id': 201,
+                'position_seconds': 91,
+                'duration_seconds': 600,
+                'title': 'Big Buck Bunny',
+              },
+            ])
+            .withResponse('get_epg_batch', epgGate.future)
+            .call,
+      );
+      addTearDown(controller.dispose);
+
+      final connect = controller.connectXtream(
+        const UserCredentials(
+          server: 'https://fixture.example',
+          username: 'fixture-user',
+          password: 'fixture-password',
+        ),
+      );
+      for (var pumpCount = 0; pumpCount < 10; pumpCount += 1) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(controller.vodItems.single.name, 'Big Buck Bunny');
+      expect(controller.activeViewer?.ulid, 'viewer-admin');
+      expect(controller.progressList.single.positionSeconds, 91);
+
+      epgGate.complete(
+        _FakeXtreamTransport.success().responses['get_epg_batch'],
+      );
+      expect(await connect, isTrue);
+    });
+
     testWidgets(
       'saved_source boots connected app state without constructor fixtures',
       (tester) async {

--- a/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
+++ b/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
@@ -69,6 +69,21 @@ void main() {
       expect(selectedTrackId, isNull);
     });
 
+    test('passes playback source start position to media_kit media', () {
+      final media = mediaKitMediaFromPlaybackSource(
+        const PlaybackSource(
+          uri: 'https://example.com/movie.mkv',
+          title: 'Resume Fixture',
+          startPosition: Duration(minutes: 43, seconds: 13),
+          headers: <String, String>{'User-Agent': 'm3u-tv'},
+        ),
+      );
+
+      expect(media.uri, 'https://example.com/movie.mkv');
+      expect(media.start, const Duration(minutes: 43, seconds: 13));
+      expect(media.httpHeaders, <String, String>{'User-Agent': 'm3u-tv'});
+    });
+
     test('maps video params aspect ratio with display size fallback', () {
       expect(
         mediaKitVideoAspectRatio(

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -178,6 +178,20 @@ void main() {
       },
     );
 
+    test('desktop libmpv load applies resume start position', () {
+      final linuxBackend = File(
+        'linux/desktop_libmpv_backend.cc',
+      ).readAsStringSync();
+      final windowsBackend = File(
+        'windows/runner/desktop_libmpv_backend.cpp',
+      ).readAsStringSync();
+
+      expect(linuxBackend, contains('startPositionMs'));
+      expect(linuxBackend, contains('start='));
+      expect(windowsBackend, contains('startPositionMs'));
+      expect(windowsBackend, contains('start='));
+    });
+
     test('Android Media3 retries mislabeled HLS streams as MPEG-TS', () {
       final media3Plugin = File(
         'android/app/src/main/kotlin/dev/sparkison/tv/Media3PlaybackPlugin.kt',

--- a/flutter_client/test/ui/features/vod_details_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_details_screen_test.dart
@@ -71,13 +71,56 @@ void main() {
       expect(playerArgs?.type, 'vod');
       expect(playerArgs?.metadata['container_extension'], 'mkv');
     });
+
+    testWidgets('shows resume action and progress for started movies', (
+      tester,
+    ) async {
+      PlayerArgs? playerArgs;
+      await tester.pumpWidget(
+        _TestApp(
+          service: _VodDetailsXtreamService(
+            info: const VodInfo(
+              id: 201,
+              name: 'Big Buck Bunny',
+              plot: 'Server synopsis',
+              duration: '01:40:00',
+              containerExtension: 'mkv',
+            ),
+          ),
+          progressList: const <Progress>[
+            Progress(
+              viewerId: 'viewer-admin',
+              contentType: ContentType.vod,
+              streamId: 201,
+              positionSeconds: 1500,
+              durationSeconds: 6000,
+            ),
+          ],
+          onPlay: (args) => playerArgs = args,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Continue movie'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+      await tester.tap(find.text('Continue movie'));
+      await tester.pump();
+
+      expect(playerArgs?.startPosition, 1500.0);
+    });
   });
 }
 
 class _TestApp extends StatelessWidget {
-  const _TestApp({required this.service, this.onPlay});
+  const _TestApp({
+    required this.service,
+    this.progressList = const <Progress>[],
+    this.onPlay,
+  });
 
   final XtreamService service;
+  final List<Progress> progressList;
   final void Function(PlayerArgs)? onPlay;
 
   @override
@@ -93,6 +136,7 @@ class _TestApp extends StatelessWidget {
           rating: 3.5,
         ),
         xtreamService: service,
+        progressList: progressList,
         onPlay: onPlay,
       ),
     );

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -452,6 +452,51 @@ void main() {
   );
 
   testWidgets(
+    'open movie details updates to continue when progress changes behind route',
+    (tester) async {
+      final appState = _testAppState(xtreamService: _NavigationXtreamService());
+      addTearDown(appState.dispose);
+      await appState.connectXtream(
+        const UserCredentials(
+          server: 'http://example.com',
+          username: 'user',
+          password: 'pass',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _TestApp(deviceType: DeviceType.tv, appState: appState),
+      );
+      await _pumpAppFrame(tester);
+
+      await tester.tap(_sidebarText('Movies'));
+      await _pumpAppFrame(tester);
+      await tester.tap(find.text('Route Movie').last);
+      await _pumpAppFrame(tester);
+
+      expect(find.text('Play movie'), findsOneWidget);
+      expect(find.text('Continue movie'), findsNothing);
+
+      await appState.resumeService.save(
+        Progress(
+          viewerId: appState.activeViewer!.ulid,
+          contentType: ContentType.vod,
+          streamId: 201,
+          positionSeconds: 43 * 60 + 13,
+          durationSeconds: 6480,
+          title: 'Route Movie',
+        ),
+      );
+      await appState.refreshLocalState();
+      await _pumpAppFrame(tester);
+
+      expect(find.text('Continue movie'), findsOneWidget);
+      expect(find.text('Play movie'), findsNothing);
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
+  testWidgets(
     'selecting started movie from app shell opens details with continue action',
     (tester) async {
       PlayerArgs? capturedArgs;

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -298,9 +298,10 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
   });
 
-  testWidgets('selecting Home continue watching movie opens player route', (
+  testWidgets('selecting Home continue watching movie resumes saved position', (
     tester,
   ) async {
+    PlayerArgs? capturedArgs;
     final appState = _testAppState(
       xtreamService: _NavigationXtreamService(
         recentlyWatched: const <Progress>[
@@ -324,7 +325,14 @@ void main() {
     );
 
     await tester.pumpWidget(
-      _TestApp(deviceType: DeviceType.tv, appState: appState),
+      _TestApp(
+        deviceType: DeviceType.tv,
+        appState: appState,
+        playerRouteBuilder: (args) {
+          capturedArgs = args;
+          return _testPlayerRoute(args);
+        },
+      ),
     );
     await _pumpAppFrame(tester);
 
@@ -342,6 +350,67 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.text('Player route: Route Movie'), findsOneWidget);
+    expect(capturedArgs?.startPosition, 91.0);
+    expect(
+      capturedArgs?.toPlaybackSource().startPosition,
+      const Duration(seconds: 91),
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('start from beginning clears saved resume position', (
+    tester,
+  ) async {
+    PlayerArgs? capturedArgs;
+    final appState = _testAppState(
+      xtreamService: _NavigationXtreamService(
+        recentlyWatched: const <Progress>[
+          Progress(
+            viewerId: 'viewer-1',
+            contentType: ContentType.vod,
+            streamId: 201,
+            positionSeconds: 91,
+            durationSeconds: 600,
+          ),
+        ],
+      ),
+    );
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.tv,
+        appState: appState,
+        playerRouteBuilder: (args) {
+          capturedArgs = args;
+          return _testPlayerRoute(args);
+        },
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(find.text('Resume Route Movie'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Resume Watching'), findsOneWidget);
+    await tester.tap(find.text('Start from Beginning'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Player route: Route Movie'), findsOneWidget);
+    expect(capturedArgs?.startPosition, isNull);
+    expect(
+      capturedArgs?.toPlaybackSource().startPosition,
+      Duration.zero,
+    );
     await tester.pumpWidget(const SizedBox.shrink());
   });
 

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -19,6 +19,7 @@ import 'package:m3u_tv/services/resume_service.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
 import 'package:m3u_tv/services/viewer_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/transcoding/transcoding.dart';
 
 void main() {
@@ -311,6 +312,7 @@ void main() {
             streamId: 201,
             positionSeconds: 91,
             durationSeconds: 600,
+            title: 'Resume Route Movie',
           ),
         ],
       ),
@@ -336,10 +338,10 @@ void main() {
     );
     await _pumpAppFrame(tester);
 
-    // CW card uses the legacy VOD-list lookup when progress has no title yet.
-    expect(find.text('Resume Route Movie'), findsOneWidget);
+    // Continue Watching card uses enriched progress metadata when available.
+    expect(find.text('Resume Route Movie'), findsAtLeast(1));
 
-    await tester.tap(find.text('Resume Route Movie'));
+    await tester.tap(_mediaPreviewCardWithText('Resume Route Movie'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
@@ -349,7 +351,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    expect(find.text('Player route: Route Movie'), findsOneWidget);
+    expect(find.text('Player route: Resume Route Movie'), findsOneWidget);
     expect(capturedArgs?.startPosition, 91.0);
     expect(
       capturedArgs?.toPlaybackSource().startPosition,
@@ -371,6 +373,7 @@ void main() {
             streamId: 201,
             positionSeconds: 91,
             durationSeconds: 600,
+            title: 'Resume Route Movie',
           ),
         ],
       ),
@@ -397,7 +400,7 @@ void main() {
     await _pumpAppFrame(tester);
     await _waitForText(tester, 'Resume Route Movie');
 
-    await tester.tap(find.text('Resume Route Movie'));
+    await tester.tap(_mediaPreviewCardWithText('Resume Route Movie'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
@@ -406,7 +409,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
-    expect(find.text('Player route: Route Movie'), findsOneWidget);
+    expect(find.text('Player route: Resume Route Movie'), findsOneWidget);
     expect(capturedArgs?.startPosition, isNull);
     expect(
       capturedArgs?.toPlaybackSource().startPosition,
@@ -724,6 +727,13 @@ NavigatorState _findInnerNavigator(WidgetTester tester) {
 Finder _sidebarText(String label) {
   return find.byWidgetPredicate(
     (widget) => widget is SidebarDestinationItem && widget.label == label,
+  );
+}
+
+Finder _mediaPreviewCardWithText(String text) {
+  return find.ancestor(
+    of: find.text(text).first,
+    matching: find.byType(MediaPreviewCard),
   );
 }
 

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -19,6 +19,7 @@ import 'package:m3u_tv/services/resume_service.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
 import 'package:m3u_tv/services/viewer_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/transcoding/transcoding.dart';
 
@@ -347,7 +348,7 @@ void main() {
 
     // Resume modal lets the user choose to resume from saved position or restart.
     expect(find.text('Resume Watching'), findsOneWidget);
-    await tester.tap(find.text('Resume'));
+    await tester.tap(_dpadInkWellWithText('Continue'));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
 
@@ -734,6 +735,13 @@ Finder _mediaPreviewCardWithText(String text) {
   return find.ancestor(
     of: find.text(text).first,
     matching: find.byType(MediaPreviewCard),
+  );
+}
+
+Finder _dpadInkWellWithText(String text) {
+  return find.ancestor(
+    of: find.text(text).first,
+    matching: find.byType(DpadInkWell),
   );
 }
 

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -744,10 +744,12 @@ Future<void> _pumpAppFrame(WidgetTester tester) async {
 }
 
 Future<void> _waitForText(WidgetTester tester, String text) async {
-  for (var i = 0; i < 10; i += 1) {
-    await _pumpAppFrame(tester);
-    if (find.text(text).evaluate().isNotEmpty) return;
+  final finder = find.text(text);
+  for (var i = 0; i < 60; i += 1) {
+    await tester.pump(const Duration(milliseconds: 250));
+    if (finder.evaluate().isNotEmpty) return;
   }
+  expect(finder, findsOneWidget);
 }
 
 /// Test app that wraps AppShell with a controlled device type.

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -395,6 +395,7 @@ void main() {
       ),
     );
     await _pumpAppFrame(tester);
+    await _waitForText(tester, 'Resume Route Movie');
 
     await tester.tap(find.text('Resume Route Movie'));
     await tester.pump();
@@ -740,6 +741,13 @@ Future<void> _pumpAppFrame(WidgetTester tester) async {
   await tester.pump();
   await tester.pump(const Duration(milliseconds: 250));
   await tester.pump();
+}
+
+Future<void> _waitForText(WidgetTester tester, String text) async {
+  for (var i = 0; i < 10; i += 1) {
+    await _pumpAppFrame(tester);
+    if (find.text(text).evaluate().isNotEmpty) return;
+  }
 }
 
 /// Test app that wraps AppShell with a controlled device type.

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -451,6 +451,65 @@ void main() {
     },
   );
 
+  testWidgets(
+    'selecting started movie from app shell opens details with continue action',
+    (tester) async {
+      PlayerArgs? capturedArgs;
+      final appState = _testAppState(
+        xtreamService: _NavigationXtreamService(
+          recentlyWatched: const <Progress>[
+            Progress(
+              viewerId: 'viewer-1',
+              contentType: ContentType.vod,
+              streamId: 201,
+              positionSeconds: 91,
+              durationSeconds: 600,
+              title: 'Route Movie',
+            ),
+          ],
+        ),
+      );
+      addTearDown(appState.dispose);
+      await appState.connectXtream(
+        const UserCredentials(
+          server: 'http://example.com',
+          username: 'user',
+          password: 'pass',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _TestApp(
+          deviceType: DeviceType.tv,
+          appState: appState,
+          playerRouteBuilder: (args) {
+            capturedArgs = args;
+            return _testPlayerRoute(args);
+          },
+        ),
+      );
+      await _pumpAppFrame(tester);
+
+      await tester.tap(_sidebarText('Movies'));
+      await _pumpAppFrame(tester);
+      await tester.tap(find.text('Route Movie').last);
+      await _pumpAppFrame(tester);
+
+      expect(find.text('Continue movie'), findsOneWidget);
+      await tester.tap(find.text('Continue movie'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Player route: Route Movie'), findsOneWidget);
+      expect(capturedArgs?.startPosition, 91.0);
+      expect(
+        capturedArgs?.toPlaybackSource().startPosition,
+        const Duration(seconds: 91),
+      );
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
   testWidgets('selecting series from app shell opens series details route', (
     tester,
   ) async {

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -945,6 +945,61 @@ void main() {
       expect(adapter.seekCalls, <Duration>[const Duration(seconds: 47)]);
     });
 
+    testWidgets('reports VOD progress immediately when seeking', (
+      tester,
+    ) async {
+      final adapter = FakePlayerAdapter(
+        capabilities: PlaybackCapabilities.desktopLibmpv,
+        textureId: 42,
+      );
+      final orchestrator = PlaybackOrchestrator(
+        platform: PlaybackPlatform.desktop,
+        adapters: <PlaybackBackend, PlayerAdapter>{
+          PlaybackBackend.desktopLibmpv: adapter,
+        },
+        transcodeGateway: FakeTranscodeGateway(),
+      );
+      addTearDown(orchestrator.dispose);
+      final reports = <Progress>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlayerScreen(
+            args: const PlayerArgs(
+              streamUrl: 'https://example.com/movie.mkv',
+              title: 'Progress Fixture',
+              type: 'vod',
+              streamId: 201,
+            ),
+            orchestrator: orchestrator,
+            epgService: EpgService(clock: () => DateTime.utc(2026)),
+            viewerId: 'viewer-1',
+            progressReporter: reports.add,
+          ),
+        ),
+      );
+      await tester.pump();
+      adapter.emitState(
+        const PlaybackState(
+          backend: PlaybackBackend.desktopLibmpv,
+          status: PlaybackStatus.ready,
+          duration: Duration(minutes: 10),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.forward_10));
+      await tester.pump();
+
+      expect(adapter.seekCalls.last, const Duration(seconds: 10));
+      expect(reports, hasLength(1));
+      expect(reports.single.viewerId, 'viewer-1');
+      expect(reports.single.contentType, ContentType.vod);
+      expect(reports.single.streamId, 201);
+      expect(reports.single.positionSeconds, 10);
+      expect(reports.single.durationSeconds, 600);
+    });
+
     testWidgets(
       'preserves reported source aspect ratio for the video surface',
       (

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -908,6 +908,43 @@ void main() {
       expect(texture.textureId, 42);
     });
 
+    testWidgets('seeks to resume position after backend load', (tester) async {
+      final adapter = FakePlayerAdapter(
+        capabilities: PlaybackCapabilities.desktopLibmpv,
+        textureId: 42,
+      );
+      final orchestrator = PlaybackOrchestrator(
+        platform: PlaybackPlatform.desktop,
+        adapters: <PlaybackBackend, PlayerAdapter>{
+          PlaybackBackend.desktopLibmpv: adapter,
+        },
+        transcodeGateway: FakeTranscodeGateway(),
+      );
+      addTearDown(orchestrator.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlayerScreen(
+            args: const PlayerArgs(
+              streamUrl: 'https://example.com/movie.mkv',
+              title: 'Resume Fixture',
+              type: 'vod',
+              startPosition: 47,
+            ),
+            orchestrator: orchestrator,
+            epgService: EpgService(clock: () => DateTime.utc(2026)),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        adapter.loadCalls.single.startPosition,
+        const Duration(seconds: 47),
+      );
+      expect(adapter.seekCalls, <Duration>[const Duration(seconds: 47)]);
+    });
+
     testWidgets(
       'preserves reported source aspect ratio for the video surface',
       (

--- a/flutter_client/windows/runner/desktop_libmpv_backend.cpp
+++ b/flutter_client/windows/runner/desktop_libmpv_backend.cpp
@@ -377,7 +377,15 @@ ProbeMap Load(const flutter::EncodableMap* args, HWND hwnd) {
   api.render_context_set_update_callback(render_context, RenderUpdate, player.get());
 
   const std::string uri = StringArg(args, "uri");
-  const char* load_args[] = {"loadfile", uri.c_str(), "replace", nullptr};
+  const int64_t start_position_ms = IntArg(args, "startPositionMs");
+  std::string start_option;
+  if (start_position_ms > 0) {
+    const double seconds = static_cast<double>(start_position_ms) / 1000.0;
+    start_option = "start=" + std::to_string(seconds);
+  }
+  const char* load_args[] = {"loadfile", uri.c_str(), "replace",
+                             start_option.empty() ? nullptr : start_option.c_str(),
+                             nullptr};
   rc = api.command(handle, load_args);
   if (rc < 0) return LoadFailure("desktop-libmpv-load-failed", "mpv loadfile command failed");
 


### PR DESCRIPTION
## Summary
- Preserve the saved resume position when Continue Watching launches playback
- Keep Start from Beginning launching from zero
- Pass resume start positions through desktop libmpv on Linux and Windows
- Verified Android Media3 and Apple AVKit already consume start positions

## Testing
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Closes #44
