### PR TITLE
feat: add catchup playback support

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -179,7 +179,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
 
   Future<void> _openPlayer(BuildContext context, PlayerArgs args) async {
     var resolvedArgs = args;
-    if (resolvedArgs.type != 'live' &&
+    if ((resolvedArgs.type == 'vod' || resolvedArgs.type == 'series') &&
         resolvedArgs.startPosition == null &&
         resolvedArgs.streamId != null) {
       final target = resolvedArgs.type == 'series'
@@ -877,6 +877,36 @@ class _ContentNavigator extends StatelessWidget {
     );
   }
 
+  void _openCatchupProgram(Channel channel, EpgProgram program) {
+    if (appState.sourceType != AppSourceType.xtream) {
+      _openChannel(channel);
+      return;
+    }
+    final duration = program.end.difference(program.start);
+    final streamUrl = appState.xtreamService.getCatchupStreamUrl(
+      channel.id,
+      program.start,
+      duration,
+    );
+    onOpenPlayer?.call(
+      PlayerArgs(
+        streamUrl: streamUrl,
+        title: '${channel.name} - ${program.title}',
+        type: 'catchup',
+        streamId: channel.id,
+        startPosition: 0,
+        epgChannelId: channel.epgChannelId ?? channel.tvgName ?? channel.name,
+        headers: channel.headers,
+        metadata: <String, Object?>{
+          'catchup': true,
+          'program_title': program.title,
+          'program_start': program.start.toIso8601String(),
+          'program_end': program.end.toIso8601String(),
+        },
+      ),
+    );
+  }
+
   Future<void> _pushNamed(String routeName, {Object? arguments}) async {
     // Yield one microtask so that any requestFocus() call made synchronously
     // in InkWell.onTap (which itself schedules a microtask) has resolved before
@@ -1029,6 +1059,7 @@ class _ContentNavigator extends StatelessWidget {
             favoritesService: appState.favoritesService,
             epgService: appState.epgService,
             onChannelSelect: _openChannel,
+            onCatchupProgramSelect: _openCatchupProgram,
             onSidebarActivate: onSidebarActivate,
           ),
           RouteNames.vod => VodScreen(

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -5,6 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 
+typedef CatchupProgramSelect =
+    void Function(Channel channel, EpgProgram program);
+
 const double _kChannelColW = 128;
 const double _kTimeHeaderH = 28;
 const double _kRowH = 60;
@@ -21,12 +24,14 @@ class TimelineEpgView extends StatefulWidget {
     required this.channels,
     required this.epgService,
     required this.onChannelSelect,
+    this.onCatchupProgramSelect,
     this.windowHours = 6,
   });
 
   final List<Channel> channels;
   final EpgService epgService;
   final void Function(Channel) onChannelSelect;
+  final CatchupProgramSelect? onCatchupProgramSelect;
 
   /// How many hours the visible window spans (default 6).
   final int windowHours;
@@ -259,7 +264,20 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
                               pixelsPerMinute: _kPxPerMin,
                               totalWidth: _totalW,
                               rowHeight: _kRowH,
-                              onTap: () => widget.onChannelSelect(channel),
+                              onTap: (program) {
+                                final canReplay =
+                                    channel.catchupSupported &&
+                                    program.end.isBefore(DateTime.now());
+                                if (canReplay &&
+                                    widget.onCatchupProgramSelect != null) {
+                                  widget.onCatchupProgramSelect!(
+                                    channel,
+                                    program,
+                                  );
+                                  return;
+                                }
+                                widget.onChannelSelect(channel);
+                              },
                             ),
                           ),
                         );
@@ -445,7 +463,7 @@ class _ProgramsRow extends StatelessWidget {
   final double pixelsPerMinute;
   final double totalWidth;
   final double rowHeight;
-  final VoidCallback onTap;
+  final void Function(EpgProgram program) onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -489,7 +507,10 @@ class _ProgramsRow extends StatelessWidget {
           child: Material(
             color: Colors.transparent,
             child: InkWell(
-              onTap: onTap,
+              key: ValueKey(
+                'timeline-program-${p.channelId}-${p.start.toIso8601String()}',
+              ),
+              onTap: () => onTap(p),
               borderRadius: BorderRadius.circular(6),
               child: Container(
                 decoration: BoxDecoration(

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -363,7 +363,59 @@ class _ChannelCell extends StatelessWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ),
+          if (channel.catchupSupported) ...[
+            const SizedBox(width: 4),
+            _CatchupBadge(days: channel.catchupDays),
+          ],
         ],
+      ),
+    );
+  }
+}
+
+class _CatchupBadge extends StatelessWidget {
+  const _CatchupBadge({this.days});
+
+  final int? days;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final label = days == null
+        ? 'Catchup available'
+        : 'Catchup available: ${days}d';
+    return Tooltip(
+      message: label,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+        decoration: BoxDecoration(
+          color: colorScheme.tertiaryContainer,
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(
+            color: colorScheme.tertiary.withValues(alpha: 0.55),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.replay_rounded,
+              size: 12,
+              color: colorScheme.onTertiaryContainer,
+            ),
+            if (days != null) ...[
+              const SizedBox(width: 2),
+              Text(
+                '${days}d',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: colorScheme.onTertiaryContainer,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -29,6 +29,7 @@ class LiveTvScreen extends StatefulWidget {
     required this.favoritesService,
     required this.epgService,
     required this.onChannelSelect,
+    this.onCatchupProgramSelect,
     this.onSidebarActivate,
   });
 
@@ -39,6 +40,7 @@ class LiveTvScreen extends StatefulWidget {
   final FavoritesService favoritesService;
   final EpgService epgService;
   final void Function(Channel) onChannelSelect;
+  final CatchupProgramSelect? onCatchupProgramSelect;
   final VoidCallback? onSidebarActivate;
 
   @override
@@ -161,6 +163,7 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
                       channels: filtered,
                       epgService: widget.epgService,
                       onChannelSelect: widget.onChannelSelect,
+                      onCatchupProgramSelect: widget.onCatchupProgramSelect,
                     ),
                     _ViewMode.logoGrid => _buildGridView(filtered),
                     _ViewMode.list => _buildListView(filtered),

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -137,7 +137,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   void _scrobble(String action) {
     final service = widget.traktService;
     if (service == null || service.status != TraktAuthStatus.connected) return;
-    if (_isLive) return;
+    if (_isLive || widget.args.type == 'catchup') return;
     final duration = _duration.inSeconds;
     var progress = duration > 0
         ? (_currentPosition.inSeconds / duration * 100).clamp(0.0, 100.0)

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -336,7 +336,11 @@ class _PlayerScreenState extends State<PlayerScreen> {
   }
 
   void _reportProgress(Duration position) {
-    if (_isLive || widget.progressReporter == null) return;
+    if (_isLive ||
+        widget.args.type == 'catchup' ||
+        widget.progressReporter == null) {
+      return;
+    }
     widget.progressReporter!(
       Progress(
         viewerId: widget.viewerId,

--- a/flutter_client/lib/navigation/app_router.dart
+++ b/flutter_client/lib/navigation/app_router.dart
@@ -55,7 +55,7 @@ class PlayerArgs {
 
   final String streamUrl;
   final String title;
-  final String type; // 'live' | 'vod' | 'series'
+  final String type; // 'live' | 'vod' | 'series' | 'catchup'
   final int? streamId;
   final int? seriesId;
   final int? seasonNumber;

--- a/flutter_client/lib/services/cache_service.dart
+++ b/flutter_client/lib/services/cache_service.dart
@@ -112,6 +112,9 @@ Object? _decodeCacheData(String key, Object? raw) {
               groupTitle: _nullableString(json['group_title']),
               epgChannelId: _nullableString(json['epg_channel_id']),
               tvgName: _nullableString(json['tvg_name']),
+              catchupSupported: _asBool(json['catchup_supported']),
+              catchupDays: _asIntOrNull(json['catchup_days']),
+              catchupSource: _nullableString(json['catchup_source']),
             );
           })
           .toList(growable: false),
@@ -153,6 +156,9 @@ Map<String, Object?> _channelToJson(Channel channel) => <String, Object?>{
   if (channel.groupTitle != null) 'group_title': channel.groupTitle,
   if (channel.epgChannelId != null) 'epg_channel_id': channel.epgChannelId,
   if (channel.tvgName != null) 'tvg_name': channel.tvgName,
+  if (channel.catchupSupported) 'catchup_supported': channel.catchupSupported,
+  if (channel.catchupDays != null) 'catchup_days': channel.catchupDays,
+  if (channel.catchupSource != null) 'catchup_source': channel.catchupSource,
 };
 
 Map<String, Object?> _vodToJson(VodItem item) => <String, Object?>{
@@ -179,8 +185,22 @@ Map<String, Object?> _asMap(Object? value) =>
 
 int _asInt(Object? value) => value is int ? value : int.tryParse('$value') ?? 0;
 
+int? _asIntOrNull(Object? value) {
+  if (value == null) return null;
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return int.tryParse('$value');
+}
+
 double? _asDouble(Object? value) =>
     value is num ? value.toDouble() : double.tryParse('$value');
+
+bool _asBool(Object? value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  final text = '$value'.trim().toLowerCase();
+  return text == '1' || text == 'true' || text == 'yes';
+}
 
 String? _nullableString(Object? value) {
   if (value == null) return null;

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -59,6 +59,9 @@ class Channel {
     this.epgChannelId,
     this.tvgName,
     this.headers = const {},
+    this.catchupSupported = false,
+    this.catchupDays,
+    this.catchupSource,
   });
 
   final int id;
@@ -70,16 +73,33 @@ class Channel {
   final String? epgChannelId;
   final String? tvgName;
   final Map<String, String> headers;
+  final bool catchupSupported;
+  final int? catchupDays;
+  final String? catchupSource;
 
-  factory Channel.fromXtream(Map<String, Object?> json, String streamUrl) =>
-      Channel(
-        id: _asInt(json['stream_id']),
-        name: '${json['name'] ?? ''}',
-        streamUrl: streamUrl,
-        logoUrl: _asNullableString(json['stream_icon']),
-        categoryId: _asNullableString(json['category_id']),
-        epgChannelId: _asNullableString(json['epg_channel_id']),
-      );
+  factory Channel.fromXtream(Map<String, Object?> json, String streamUrl) {
+    final catchupSource = _asNullableString(json['catchup_source']);
+    final catchupDays = _asIntOrNull(
+      json['tv_archive_duration'] ??
+          json['catchup_days'] ??
+          json['catchup-days'],
+    );
+    final catchupType = _asNullableString(json['catchup']);
+    final hasCatchupType = catchupType != null && catchupType != '0';
+    final catchupSupported =
+        _asBool(json['tv_archive']) || hasCatchupType || catchupSource != null;
+    return Channel(
+      id: _asInt(json['stream_id']),
+      name: '${json['name'] ?? ''}',
+      streamUrl: streamUrl,
+      logoUrl: _asNullableString(json['stream_icon']),
+      categoryId: _asNullableString(json['category_id']),
+      epgChannelId: _asNullableString(json['epg_channel_id']),
+      catchupSupported: catchupSupported,
+      catchupDays: catchupDays,
+      catchupSource: catchupSource,
+    );
+  }
 }
 
 class VodItem {
@@ -547,6 +567,13 @@ double? _asDoubleOrNull(Object? value) {
   if (value == null) return null;
   if (value is num) return value.toDouble();
   return double.tryParse('$value');
+}
+
+bool _asBool(Object? value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  final text = '$value'.trim().toLowerCase();
+  return text == '1' || text == 'true' || text == 'yes' || text == 'default';
 }
 
 String? _asNullableString(Object? value) {

--- a/flutter_client/lib/services/m3u_parser.dart
+++ b/flutter_client/lib/services/m3u_parser.dart
@@ -159,6 +159,10 @@ class _PendingEntry {
   Channel toChannel(int id, String streamUrl) {
     final group = _normalizeGroup(attributes['group-title']);
     final tvgName = attributes['tvg-name'];
+    final catchupSource = attributes['catchup-source'];
+    final catchupType = attributes['catchup'];
+    final catchupSupported =
+        catchupSource != null || (catchupType != null && catchupType != '0');
     return Channel(
       id: id,
       name: name.isNotEmpty ? name : (tvgName ?? 'Channel $id'),
@@ -169,6 +173,9 @@ class _PendingEntry {
       epgChannelId: attributes['tvg-id'],
       tvgName: tvgName,
       headers: Map.unmodifiable(headers),
+      catchupSupported: catchupSupported,
+      catchupDays: int.tryParse(attributes['catchup-days'] ?? ''),
+      catchupSource: catchupSource,
     );
   }
 }

--- a/flutter_client/lib/services/xtream_service.dart
+++ b/flutter_client/lib/services/xtream_service.dart
@@ -432,6 +432,19 @@ class XtreamService {
     return '${c.server}/live/${c.username}/${c.password}/$streamId.$format';
   }
 
+  String getCatchupStreamUrl(
+    int streamId,
+    DateTime start,
+    Duration duration, {
+    String extension = 'ts',
+  }) {
+    final c = _requireCredentials();
+    final normalizedStart = start.toUtc();
+    final startText = _formatTimeshiftStart(normalizedStart);
+    final durationMinutes = duration.inMinutes;
+    return '${c.server}/timeshift/${c.username}/${c.password}/$durationMinutes/$startText/$streamId.$extension';
+  }
+
   String getVodStreamUrl(int streamId, [String extension = 'mp4']) {
     final c = _requireCredentials();
     return '${c.server}/movie/${c.username}/${c.password}/$streamId.$extension';
@@ -657,6 +670,16 @@ String _decodeBase64WhenApplicable(String value) {
   } on FormatException {
     return value;
   }
+}
+
+String _formatTimeshiftStart(DateTime value) {
+  String twoDigits(int number) => number.toString().padLeft(2, '0');
+  final year = value.year.toString().padLeft(4, '0');
+  final month = twoDigits(value.month);
+  final day = twoDigits(value.day);
+  final hour = twoDigits(value.hour);
+  final minute = twoDigits(value.minute);
+  return '$year-$month-$day:$hour-$minute';
 }
 
 String? _stringOrNull(Object? value) {

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -8,6 +8,7 @@ import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/services/m3u_parser.dart';
+import 'package:m3u_tv/services/persistent_store.dart';
 import 'package:m3u_tv/services/resume_service.dart';
 import 'package:m3u_tv/services/viewer_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
@@ -195,6 +196,60 @@ void main() {
       expect((await service.getVodStreams()).single.containerExtension, 'mp4');
       expect((await service.getSeries()).single.id, 301);
       expect(transport.lastHeaders['X-M3UE-Client'], 'm3u-tv');
+    });
+
+    test('live streams parse Xtream catchup metadata', () async {
+      final service = XtreamService(
+        transport: FakeXtreamTransport({
+          'auth': xtreamAuth(auth: 1),
+          'get_live_streams': [
+            {
+              ...liveStream(101, 'BBC One', '10', 'bbc.one'),
+              'tv_archive': 1,
+              'tv_archive_duration': '7',
+            },
+            liveStream(102, 'BBC Two', '10', 'bbc.two'),
+          ],
+        }).call,
+      );
+      await service.authenticate(
+        const UserCredentials(
+          server: 'https://xtream.example',
+          username: 'demo',
+          password: 'secret',
+        ),
+      );
+
+      final channels = await service.getLiveStreams();
+
+      expect(channels.first.catchupSupported, isTrue);
+      expect(channels.first.catchupDays, 7);
+      expect(channels.last.catchupSupported, isFalse);
+      expect(channels.last.catchupDays, isNull);
+    });
+
+    test('builds Xtream catchup timeshift URL from program window', () async {
+      final service = XtreamService(
+        transport: FakeXtreamTransport({'auth': xtreamAuth(auth: 1)}).call,
+      );
+      await service.authenticate(
+        const UserCredentials(
+          server: 'https://xtream.example/',
+          username: 'demo',
+          password: 'secret',
+        ),
+      );
+
+      final url = service.getCatchupStreamUrl(
+        101,
+        DateTime.utc(2026, 1, 1, 12, 30),
+        const Duration(minutes: 45),
+      );
+
+      expect(
+        url,
+        'https://xtream.example/timeshift/demo/secret/45/2026-01-01:12-30/101.ts',
+      );
     });
 
     test(
@@ -550,6 +605,23 @@ void main() {
       },
     );
 
+    test('parses M3U catchup attributes into channel metadata', () {
+      final playlist = M3UParser().parse('''
+#EXTM3U
+#EXTINF:-1 tvg-id="bbc.one" tvg-name="BBC One" group-title="News" catchup="default" catchup-days="3" catchup-source="https://archive.example/{utc:Y-m-d:H-M}/{duration}/{channel-id}",BBC One
+https://streams.example/live/bbc-one.m3u8
+''');
+
+      final channel = playlist.channels.single;
+
+      expect(channel.catchupSupported, isTrue);
+      expect(channel.catchupDays, 3);
+      expect(
+        channel.catchupSource,
+        'https://archive.example/{utc:Y-m-d:H-M}/{duration}/{channel-id}',
+      );
+    });
+
     test('malformed playlist reports a typed parse error', () async {
       final text = await io.File(
         'test/fixtures/malformed_playlist.m3u',
@@ -627,6 +699,38 @@ void main() {
   });
 
   group('Local state services', () {
+    test('cache preserves channel catchup metadata', () async {
+      final file = io.File(
+        '${io.Directory.systemTemp.path}/m3u_tv_cache_catchup_${DateTime.now().microsecondsSinceEpoch}.json',
+      );
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+      final store = PersistentJsonStore(file: file);
+      final cache = CacheService(store: store);
+      await cache.set('liveStreams', const <Channel>[
+        Channel(
+          id: 101,
+          name: 'BBC One',
+          streamUrl: 'https://streams.example/live/bbc-one.m3u8',
+          catchupSupported: true,
+          catchupDays: 7,
+          catchupSource: 'https://archive.example/{utc}/{duration}',
+        ),
+      ]);
+
+      final restored = await CacheService(
+        store: PersistentJsonStore(file: file),
+      ).get<List<Channel>>('liveStreams');
+
+      expect(restored?.data.single.catchupSupported, isTrue);
+      expect(restored?.data.single.catchupDays, 7);
+      expect(
+        restored?.data.single.catchupSource,
+        'https://archive.example/{utc}/{duration}',
+      );
+    });
+
     test('favorites add and remove channel ids', () async {
       final service = FavoritesService(memory: <String, Object?>{});
 

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -5,6 +5,45 @@ import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 
 void main() {
+  testWidgets('catchup channels show replay availability indicator', (
+    tester,
+  ) async {
+    final epgService = EpgService();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 300,
+            child: TimelineEpgView(
+              channels: const [
+                Channel(
+                  id: 101,
+                  name: 'BBC One',
+                  streamUrl: 'https://streams.example/live/101.m3u8',
+                  catchupSupported: true,
+                  catchupDays: 7,
+                ),
+                Channel(
+                  id: 102,
+                  name: 'BBC Two',
+                  streamUrl: 'https://streams.example/live/102.m3u8',
+                ),
+              ],
+              epgService: epgService,
+              onChannelSelect: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byIcon(Icons.replay_rounded), findsOneWidget);
+    expect(find.text('7d'), findsOneWidget);
+  });
+
   testWidgets('tapping past catchup program invokes catchup callback', (
     tester,
   ) async {

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/epg/timeline_epg_view.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
+
+void main() {
+  testWidgets('tapping past catchup program invokes catchup callback', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    const channel = Channel(
+      id: 101,
+      name: 'BBC One',
+      streamUrl: 'https://streams.example/live/101.m3u8',
+      epgChannelId: 'bbc.one',
+      catchupSupported: true,
+      catchupDays: 7,
+    );
+    final program = EpgProgram(
+      channelId: 'bbc.one',
+      title: 'Archived News',
+      description: 'Replayable fixture',
+      start: now.subtract(const Duration(minutes: 45)),
+      end: now.subtract(const Duration(minutes: 15)),
+    );
+    final epgService = EpgService()..loadPrograms([program]);
+    Channel? selectedChannel;
+    EpgProgram? selectedProgram;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 300,
+            child: TimelineEpgView(
+              channels: const [channel],
+              epgService: epgService,
+              onChannelSelect: (_) {},
+              onCatchupProgramSelect: (channel, program) {
+                selectedChannel = channel;
+                selectedProgram = program;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final programBlock = tester.widget<InkWell>(
+      find.byKey(
+        ValueKey(
+          'timeline-program-${program.channelId}-${program.start.toIso8601String()}',
+        ),
+      ),
+    );
+    programBlock.onTap?.call();
+    await tester.pumpAndSettle();
+
+    expect(selectedChannel, channel);
+    expect(selectedProgram, program);
+  });
+}


### PR DESCRIPTION
## Summary
- Parse catchup/archive metadata from Xtream and M3U live channel sources
- Preserve catchup fields in cached channels and add an Xtream timeshift URL builder
- Route replayable past EPG programs from the timeline guide into catchup playback
- Keep catchup playback out of generic VOD resume/progress flows

## Testing
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Closes #16
