### PR TITLE
fix: show focus affordance in EPG timeline

### DIFF
--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -477,10 +477,6 @@ class _ProgramsRow extends StatelessWidget {
       final fgColor = isCurrent
           ? colorScheme.onPrimaryContainer
           : colorScheme.onSecondaryContainer;
-      final borderColor = isCurrent
-          ? colorScheme.primary.withValues(alpha: 0.6)
-          : colorScheme.outline.withValues(alpha: 0.25);
-
       blocks.add(
         Positioned(
           left: left + 1,
@@ -494,7 +490,6 @@ class _ProgramsRow extends StatelessWidget {
               decoration: BoxDecoration(
                 color: bgColor,
                 borderRadius: BorderRadius.circular(6),
-                border: Border.all(color: borderColor),
               ),
               padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
               child: Text(

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
 const double _kChannelColW = 128;
 const double _kTimeHeaderH = 28;
@@ -486,27 +487,24 @@ class _ProgramsRow extends StatelessWidget {
           top: isCurrent ? 2 : 4,
           height: rowHeight - (isCurrent ? 4 : 8),
           width: width - 2,
-          child: Material(
-            color: Colors.transparent,
-            child: InkWell(
-              onTap: onTap,
-              borderRadius: BorderRadius.circular(6),
-              child: Container(
-                decoration: BoxDecoration(
-                  color: bgColor,
-                  borderRadius: BorderRadius.circular(6),
-                  border: Border.all(color: borderColor),
+          child: DpadInkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(6),
+            child: Container(
+              decoration: BoxDecoration(
+                color: bgColor,
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(color: borderColor),
+              ),
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
+              child: Text(
+                p.title,
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: fgColor,
+                  fontWeight: isCurrent ? FontWeight.w600 : FontWeight.normal,
                 ),
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 4),
-                child: Text(
-                  p.title,
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: fgColor,
-                    fontWeight: isCurrent ? FontWeight.w600 : FontWeight.normal,
-                  ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ),

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -157,11 +157,7 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
                     ),
                   )
                 : switch (_viewMode) {
-                    _ViewMode.epgGrid => TimelineEpgView(
-                      channels: filtered,
-                      epgService: widget.epgService,
-                      onChannelSelect: widget.onChannelSelect,
-                    ),
+                    _ViewMode.epgGrid => _buildEpgGrid(filtered),
                     _ViewMode.logoGrid => _buildGridView(filtered),
                     _ViewMode.list => _buildListView(filtered),
                   },
@@ -243,6 +239,23 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
             },
           );
         },
+      ),
+    );
+  }
+
+  Widget _buildEpgGrid(List<Channel> channels) {
+    return DpadRegion(
+      memoryKey: 'live-tv/epg',
+      horizontalEdge: DpadEdgeBehavior.stop,
+      onEdge: (direction) {
+        if (direction == TraversalDirection.left) {
+          widget.onSidebarActivate?.call();
+        }
+      },
+      child: TimelineEpgView(
+        channels: channels,
+        epgService: widget.epgService,
+        onChannelSelect: widget.onChannelSelect,
       ),
     );
   }

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/epg/timeline_epg_view.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
+
+void main() {
+  testWidgets('program blocks use D-pad focusable selection affordance', (
+    tester,
+  ) async {
+    final now = DateTime.now();
+    const channel = Channel(
+      id: 101,
+      name: 'BBC One',
+      streamUrl: 'https://streams.example/live/101.m3u8',
+      epgChannelId: 'bbc.one',
+    );
+    final program = EpgProgram(
+      channelId: 'bbc.one',
+      title: 'Evening News',
+      description: 'Focusable fixture',
+      start: now.subtract(const Duration(minutes: 15)),
+      end: now.add(const Duration(minutes: 15)),
+    );
+    final epgService = EpgService()..loadPrograms([program]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 300,
+            child: TimelineEpgView(
+              channels: const [channel],
+              epgService: epgService,
+              onChannelSelect: (_) {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final programText = find.text('Evening News');
+    expect(programText, findsOneWidget);
+    expect(
+      find.ancestor(of: programText, matching: find.byType(DpadInkWell)),
+      findsOneWidget,
+    );
+  });
+}

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -1,3 +1,4 @@
+import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/epg/timeline_epg_view.dart';
@@ -6,48 +7,52 @@ import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
 void main() {
-  testWidgets('program blocks use D-pad focusable selection affordance', (
-    tester,
-  ) async {
-    final now = DateTime.now();
-    const channel = Channel(
-      id: 101,
-      name: 'BBC One',
-      streamUrl: 'https://streams.example/live/101.m3u8',
-      epgChannelId: 'bbc.one',
-    );
-    final program = EpgProgram(
-      channelId: 'bbc.one',
-      title: 'Evening News',
-      description: 'Focusable fixture',
-      start: now.subtract(const Duration(minutes: 15)),
-      end: now.add(const Duration(minutes: 15)),
-    );
-    final epgService = EpgService()..loadPrograms([program]);
+  group('TimelineEpgView', () {
+    testWidgets('program blocks use D-pad focusable selection affordance', (
+      tester,
+    ) async {
+      final now = DateTime.now();
+      const channel = Channel(
+        id: 101,
+        name: 'BBC One',
+        streamUrl: 'https://streams.example/live/101.m3u8',
+        epgChannelId: 'bbc.one',
+      );
+      final program = EpgProgram(
+        channelId: 'bbc.one',
+        title: 'Evening News',
+        description: 'Focusable fixture',
+        start: now.subtract(const Duration(minutes: 15)),
+        end: now.add(const Duration(minutes: 15)),
+      );
+      final epgService = EpgService()..loadPrograms([program]);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: ThemeData.dark(useMaterial3: true),
-        home: Scaffold(
-          body: SizedBox(
-            width: 800,
-            height: 300,
-            child: TimelineEpgView(
-              channels: const [channel],
-              epgService: epgService,
-              onChannelSelect: (_) {},
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          home: Scaffold(
+            body: DpadRegion(
+              child: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: const [channel],
+                  epgService: epgService,
+                  onChannelSelect: (_) {},
+                ),
+              ),
             ),
           ),
         ),
-      ),
-    );
-    await tester.pumpAndSettle();
+      );
+      await tester.pumpAndSettle();
 
-    final programText = find.text('Evening News');
-    expect(programText, findsOneWidget);
-    expect(
-      find.ancestor(of: programText, matching: find.byType(DpadInkWell)),
-      findsOneWidget,
-    );
+      final programText = find.text('Evening News');
+      expect(programText, findsOneWidget);
+      expect(
+        find.ancestor(of: programText, matching: find.byType(DpadInkWell)),
+        findsOneWidget,
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Wrap EPG timeline program blocks in the shared D-pad focusable `DpadInkWell`
- Add a regression test covering the focusable program-block affordance

## Testing
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Fixes #48
