### PR TITLE
fix: align mouse hover with focus border

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -705,6 +705,7 @@ class SidebarDestinationItem extends StatefulWidget {
 
 class _SidebarDestinationItemState extends State<SidebarDestinationItem> {
   bool _focused = false;
+  bool _hovered = false;
 
   @override
   void initState() {
@@ -724,6 +725,11 @@ class _SidebarDestinationItemState extends State<SidebarDestinationItem> {
     });
   }
 
+  void _setHovered(bool v) {
+    if (_hovered == v) return;
+    setState(() => _hovered = v);
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -734,85 +740,93 @@ class _SidebarDestinationItemState extends State<SidebarDestinationItem> {
     if (widget.selected) {
       backgroundColor = colorScheme.primaryContainer;
       foregroundColor = colorScheme.onPrimaryContainer;
-    } else if (_focused) {
+    } else if (_focused || _hovered) {
       backgroundColor = colorScheme.surfaceContainerHigh;
       foregroundColor = colorScheme.onSurface;
     }
 
-    return Focus(
-      focusNode: widget.focusNode,
-      onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-                event.logicalKey == LogicalKeyboardKey.select ||
-            event is KeyDownEvent &&
-                event.logicalKey == LogicalKeyboardKey.enter) {
-          widget.onTap();
-          return KeyEventResult.handled;
-        }
-        return KeyEventResult.ignored;
-      },
-      child: InkWell(
-        onTap: () {
-          widget.focusNode.requestFocus();
-          widget.onTap();
+    return MouseRegion(
+      onEnter: (_) => _setHovered(true),
+      onExit: (_) => _setHovered(false),
+      child: Focus(
+        focusNode: widget.focusNode,
+        onKeyEvent: (node, event) {
+          if (event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.select ||
+              event is KeyDownEvent &&
+                  event.logicalKey == LogicalKeyboardKey.enter) {
+            widget.onTap();
+            return KeyEventResult.handled;
+          }
+          return KeyEventResult.ignored;
         },
-        customBorder: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Stack(
-          fit: StackFit.passthrough,
-          children: [
-            Container(
-              height: 48,
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              decoration: BoxDecoration(
-                color: backgroundColor,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: OverflowBox(
-                maxWidth: 200,
-                alignment: Alignment.centerLeft,
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(widget.icon, color: foregroundColor, size: 24),
-                    if (widget.expanded) ...[
-                      const SizedBox(width: 12),
-                      Text(
-                        widget.label,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: foregroundColor,
+        child: InkWell(
+          onTap: () {
+            widget.focusNode.requestFocus();
+            widget.onTap();
+          },
+          customBorder: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Stack(
+            fit: StackFit.passthrough,
+            children: [
+              Container(
+                height: 48,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                decoration: BoxDecoration(
+                  color: backgroundColor,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: OverflowBox(
+                  maxWidth: 200,
+                  alignment: Alignment.centerLeft,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(widget.icon, color: foregroundColor, size: 24),
+                      if (widget.expanded) ...[
+                        const SizedBox(width: 12),
+                        Text(
+                          widget.label,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: foregroundColor,
+                          ),
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
+                      ],
                     ],
-                  ],
+                  ),
                 ),
               ),
-            ),
-            Positioned.fill(
-              child: IgnorePointer(
-                child: AnimatedOpacity(
-                  opacity: _focused && !widget.selected ? 1.0 : 0.0,
-                  duration: const Duration(milliseconds: 150),
-                  child: CustomPaint(
-                    painter: GradientBorderPainter(
-                      borderRadius: const BorderRadius.all(Radius.circular(8)),
-                      width: 2.5,
-                      gradient: LinearGradient(
-                        begin: Alignment.topRight,
-                        end: Alignment.bottomLeft,
-                        colors: [
-                          colorScheme.primary,
-                          colorScheme.secondary,
-                        ],
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: AnimatedOpacity(
+                    opacity: (_focused || _hovered) && !widget.selected
+                        ? 1.0
+                        : 0.0,
+                    duration: const Duration(milliseconds: 150),
+                    child: CustomPaint(
+                      painter: GradientBorderPainter(
+                        borderRadius: const BorderRadius.all(
+                          Radius.circular(8),
+                        ),
+                        width: 2.5,
+                        gradient: LinearGradient(
+                          begin: Alignment.topRight,
+                          end: Alignment.bottomLeft,
+                          colors: [
+                            colorScheme.primary,
+                            colorScheme.secondary,
+                          ],
+                        ),
                       ),
                     ),
                   ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -556,11 +556,17 @@ class _EpisodeTile extends StatefulWidget {
 
 class _EpisodeTileState extends State<_EpisodeTile> {
   final FocusNode _focusNode = FocusNode();
+  bool _hovered = false;
 
   @override
   void dispose() {
     _focusNode.dispose();
     super.dispose();
+  }
+
+  void _setHovered(bool v) {
+    if (_hovered == v) return;
+    setState(() => _hovered = v);
   }
 
   @override
@@ -588,132 +594,146 @@ class _EpisodeTileState extends State<_EpisodeTile> {
       if (episode.releaseDate != null) episode.releaseDate!,
     ];
 
-    return DpadFocusable(
-      autofocus: autofocus,
-      focusNode: _focusNode,
-      onSelect: onTap,
-      effects: const [
-        GradientBorderEffect(
-          borderRadius: BorderRadius.all(Radius.circular(16)),
+    return MouseRegion(
+      onEnter: (_) => _setHovered(true),
+      onExit: (_) => _setHovered(false),
+      child: DpadFocusable(
+        autofocus: autofocus,
+        focusNode: _focusNode,
+        onSelect: onTap,
+        builder: (context, state, child) => DpadEffect.wrap(
+          context,
+          const [
+            GradientBorderEffect(
+              borderRadius: BorderRadius.all(Radius.circular(16)),
+            ),
+          ],
+          DpadFocusState(
+            focused: state.focused || _hovered,
+            pressed: state.pressed,
+          ),
+          child,
         ),
-      ],
-      child: Card(
-        clipBehavior: Clip.antiAlias,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            InkWell(
-              onTap: () {
-                _focusNode.requestFocus();
-                onTap();
-              },
-              child: Padding(
-                padding: const EdgeInsets.all(12),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    // Thumbnail or episode-number badge
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(6),
-                      child: SizedBox(
-                        width: 120,
-                        height: 68,
-                        child: hasThumbnail
-                            ? Image.network(
-                                episode.thumbnailUrl!,
-                                fit: BoxFit.cover,
-                                errorBuilder: (_, _, _) =>
-                                    _episodeNumberBadge(colorScheme),
-                              )
-                            : _episodeNumberBadge(colorScheme),
+        child: Card(
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              InkWell(
+                onTap: () {
+                  _focusNode.requestFocus();
+                  onTap();
+                },
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // Thumbnail or episode-number badge
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(6),
+                        child: SizedBox(
+                          width: 120,
+                          height: 68,
+                          child: hasThumbnail
+                              ? Image.network(
+                                  episode.thumbnailUrl!,
+                                  fit: BoxFit.cover,
+                                  errorBuilder: (_, _, _) =>
+                                      _episodeNumberBadge(colorScheme),
+                                )
+                              : _episodeNumberBadge(colorScheme),
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 12),
-                    // Title, meta chips, description
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            children: [
-                              Expanded(
-                                child: Text.rich(
-                                  TextSpan(
-                                    style: theme.textTheme.titleSmall,
-                                    children: [
-                                      TextSpan(
-                                        text: 'E${episode.episodeNumber} · ',
-                                        style: theme.textTheme.titleSmall
-                                            ?.copyWith(
-                                              color:
-                                                  colorScheme.onSurfaceVariant,
-                                            ),
-                                      ),
-                                      TextSpan(text: episode.title),
-                                    ],
-                                  ),
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                              ),
-                              const SizedBox(width: 8),
-                              const Icon(Icons.play_arrow, size: 20),
-                            ],
-                          ),
-                          if (metaChips.isNotEmpty) ...[
-                            const SizedBox(height: 6),
-                            Wrap(
-                              spacing: 6,
-                              runSpacing: 4,
-                              children: metaChips
-                                  .map(
-                                    (chip) => Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 8,
-                                        vertical: 2,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: colorScheme.surfaceBright,
-                                        borderRadius: BorderRadius.circular(4),
-                                      ),
-                                      child: Text(
-                                        chip,
-                                        style: theme.textTheme.labelSmall
-                                            ?.copyWith(
-                                              color: colorScheme.onPrimary,
-                                            ),
-                                      ),
+                      const SizedBox(width: 12),
+                      // Title, meta chips, description
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: Text.rich(
+                                    TextSpan(
+                                      style: theme.textTheme.titleSmall,
+                                      children: [
+                                        TextSpan(
+                                          text: 'E${episode.episodeNumber} · ',
+                                          style: theme.textTheme.titleSmall
+                                              ?.copyWith(
+                                                color: colorScheme
+                                                    .onSurfaceVariant,
+                                              ),
+                                        ),
+                                        TextSpan(text: episode.title),
+                                      ],
                                     ),
-                                  )
-                                  .toList(),
+                                    maxLines: 2,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                const Icon(Icons.play_arrow, size: 20),
+                              ],
                             ),
-                          ],
-                          if (episode.plot != null) ...[
-                            const SizedBox(height: 6),
-                            Text(
-                              episode.plot!,
-                              style: theme.textTheme.bodySmall?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
+                            if (metaChips.isNotEmpty) ...[
+                              const SizedBox(height: 6),
+                              Wrap(
+                                spacing: 6,
+                                runSpacing: 4,
+                                children: metaChips
+                                    .map(
+                                      (chip) => Container(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 8,
+                                          vertical: 2,
+                                        ),
+                                        decoration: BoxDecoration(
+                                          color: colorScheme.surfaceBright,
+                                          borderRadius: BorderRadius.circular(
+                                            4,
+                                          ),
+                                        ),
+                                        child: Text(
+                                          chip,
+                                          style: theme.textTheme.labelSmall
+                                              ?.copyWith(
+                                                color: colorScheme.onPrimary,
+                                              ),
+                                        ),
+                                      ),
+                                    )
+                                    .toList(),
                               ),
-                              maxLines: 2,
-                              overflow: TextOverflow.ellipsis,
-                            ),
+                            ],
+                            if (episode.plot != null) ...[
+                              const SizedBox(height: 6),
+                              Text(
+                                episode.plot!,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: colorScheme.onSurfaceVariant,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
                           ],
-                        ],
+                        ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
-            ),
-            if (progressValue != null)
-              LinearProgressIndicator(
-                value: progressValue,
-                minHeight: 3,
-                backgroundColor: colorScheme.surfaceContainerHighest,
-                valueColor: AlwaysStoppedAnimation(colorScheme.primary),
-              ),
-          ],
+              if (progressValue != null)
+                LinearProgressIndicator(
+                  value: progressValue,
+                  minHeight: 3,
+                  backgroundColor: colorScheme.surfaceContainerHighest,
+                  valueColor: AlwaysStoppedAnimation(colorScheme.primary),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/flutter_client/lib/shared/dpad_ink_well.dart
+++ b/flutter_client/lib/shared/dpad_ink_well.dart
@@ -46,6 +46,7 @@ class DpadInkWell extends StatefulWidget {
 
 class _DpadInkWellState extends State<DpadInkWell> {
   final FocusNode _focusNode = FocusNode();
+  bool _hovered = false;
 
   @override
   void dispose() {
@@ -56,6 +57,13 @@ class _DpadInkWellState extends State<DpadInkWell> {
   void _onTap() {
     _focusNode.requestFocus();
     widget.onTap?.call();
+  }
+
+  bool get _isInteractive => widget.onTap != null || widget.onLongTap != null;
+
+  void _setHovered(bool hovered) {
+    if (!_isInteractive || _hovered == hovered) return;
+    setState(() => _hovered = hovered);
   }
 
   @override
@@ -69,23 +77,35 @@ class _DpadInkWellState extends State<DpadInkWell> {
                 const BorderRadius.all(Radius.circular(8)),
           ),
         ];
-    return DpadFocusable(
-      focusNode: _focusNode,
-      onSelect: widget.onTap == null ? null : _onTap,
-      onLongSelect: widget.onLongTap,
-      effects: effects,
-      autofocus: widget.autofocus,
-      entry: widget.entry,
-      scrollPadding: widget.scrollPadding,
-      child: Material(
-        color: widget.color ?? Colors.transparent,
-        borderRadius: widget.borderRadius,
-        clipBehavior: widget.clipBehavior,
-        child: InkWell(
-          onTap: widget.onTap == null ? null : _onTap,
-          onLongPress: widget.onLongTap,
+    return MouseRegion(
+      onEnter: (_) => _setHovered(true),
+      onExit: (_) => _setHovered(false),
+      child: DpadFocusable(
+        focusNode: _focusNode,
+        onSelect: widget.onTap == null ? null : _onTap,
+        onLongSelect: widget.onLongTap,
+        builder: (context, state, child) => DpadEffect.wrap(
+          context,
+          effects,
+          DpadFocusState(
+            focused: state.focused || _hovered,
+            pressed: state.pressed,
+          ),
+          child,
+        ),
+        autofocus: widget.autofocus,
+        entry: widget.entry,
+        scrollPadding: widget.scrollPadding,
+        child: Material(
+          color: widget.color ?? Colors.transparent,
           borderRadius: widget.borderRadius,
-          child: widget.child,
+          clipBehavior: widget.clipBehavior,
+          child: InkWell(
+            onTap: widget.onTap == null ? null : _onTap,
+            onLongPress: widget.onLongTap,
+            borderRadius: widget.borderRadius,
+            child: widget.child,
+          ),
         ),
       ),
     );

--- a/flutter_client/lib/shared/dpad_ink_well.dart
+++ b/flutter_client/lib/shared/dpad_ink_well.dart
@@ -67,6 +67,12 @@ class _DpadInkWellState extends State<DpadInkWell> {
   }
 
   @override
+  void didUpdateWidget(DpadInkWell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_hovered && !_isInteractive) setState(() => _hovered = false);
+  }
+
+  @override
   Widget build(BuildContext context) {
     final effects =
         widget.effects ??

--- a/flutter_client/test/ui/shared/dpad_ink_well_test.dart
+++ b/flutter_client/test/ui/shared/dpad_ink_well_test.dart
@@ -1,0 +1,48 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
+
+void main() {
+  testWidgets('DpadInkWell shows focus border on hover without taking focus', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.dark(useMaterial3: true),
+        home: Scaffold(
+          body: Center(
+            child: DpadInkWell(
+              onTap: () {},
+              borderRadius: BorderRadius.circular(8),
+              child: const SizedBox(
+                width: 160,
+                height: 72,
+                child: Center(child: Text('Hover me')),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(_focusBorderOpacity(tester), 0.0);
+    final focusBeforeHover = FocusManager.instance.primaryFocus;
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: tester.getCenter(find.text('Hover me')));
+    addTearDown(gesture.removePointer);
+    await tester.pumpAndSettle();
+
+    expect(_focusBorderOpacity(tester), 1.0);
+    expect(FocusManager.instance.primaryFocus, same(focusBeforeHover));
+  });
+}
+
+double _focusBorderOpacity(WidgetTester tester) {
+  return tester
+      .widgetList<AnimatedOpacity>(find.byType(AnimatedOpacity))
+      .map((widget) => widget.opacity)
+      .single;
+}


### PR DESCRIPTION
## Summary
- Shows the shared gradient focus border when hovering interactive `DpadInkWell` widgets
- Keeps mouse hover visual-only so it does not move keyboard/D-pad focus or auto-scroll lists/grids
- Adds a widget regression for hover focus-border parity without focus changes

## Testing
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Fixes #46
