### PR TITLE
fix: load continue watching from cached boot

### DIFF
--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -116,7 +116,6 @@ class AppStateController extends ChangeNotifier {
   List<VodItem> _vodItems = const <VodItem>[];
   List<Series> _seriesList = const <Series>[];
   List<Progress> _progressList = const <Progress>[];
-  final Stopwatch _bootStopwatch = Stopwatch();
   Future<List<Progress>>? _recentlyWatchedRefresh;
   String? _recentlyWatchedRefreshViewerId;
 
@@ -141,10 +140,6 @@ class AppStateController extends ChangeNotifier {
   };
 
   Future<void> boot() async {
-    _bootStopwatch
-      ..reset()
-      ..start();
-    _debugBoot('boot:start');
     _isBootstrapping = true;
     _error = null;
     notifyListeners();
@@ -159,25 +154,15 @@ class AppStateController extends ChangeNotifier {
     }
 
     final savedSource = await _readSavedSourceType();
-    _debugBoot('boot:savedSource=$savedSource');
     if (savedSource == AppSourceType.xtream ||
         savedSource == AppSourceType.none) {
       final restored = await authNotifier.loadSavedCredentials();
-      _debugBoot('boot:credentialsRestored=$restored');
       if (restored) {
         if (await _hydrateCachedXtreamContent()) {
           _isBootstrapping = false;
           notifyListeners();
-          unawaited(
-            _refreshRecentlyWatchedForActiveViewer(
-              source: 'cached-boot',
-            ),
-          );
-          unawaited(
-            _replaceWithXtreamContent(
-              clearCache: false,
-            ).then((_) => notifyListeners()),
-          );
+          unawaited(_refreshRecentlyWatchedForActiveViewer());
+          unawaited(_replaceWithXtreamContent(clearCache: false));
           return;
         }
         await _replaceWithXtreamContent(clearCache: false);
@@ -187,9 +172,6 @@ class AppStateController extends ChangeNotifier {
     }
 
     _isBootstrapping = false;
-    _debugBoot(
-      'boot:complete source=$_sourceType progress=${_progressList.length}',
-    );
     notifyListeners();
   }
 
@@ -343,7 +325,6 @@ class AppStateController extends ChangeNotifier {
 
   Future<bool> _replaceWithXtreamContent({required bool clearCache}) async {
     try {
-      _debugBoot('xtream-refresh:start clearCache=$clearCache');
       final liveCategoriesFuture = xtreamService.getLiveCategories();
       final vodCategoriesFuture = xtreamService.getVodCategories();
       final seriesCategoriesFuture = xtreamService.getSeriesCategories();
@@ -371,14 +352,13 @@ class AppStateController extends ChangeNotifier {
       final seriesList = results[5] as List<Series>;
 
       final activeViewer = await viewerService.resolveActiveViewer(viewers);
-      final progress = activeViewer == null
+      final fetched = activeViewer == null
           ? const <Progress>[]
           : await _loadRecentlyWatchedDeduped(activeViewer.ulid);
-      _debugBoot(
-        'xtream-refresh:remote-ready viewers=${viewers.length} '
-        'progress=${progress.length} live=${channels.length} vod=${vodItems.length} '
-        'series=${seriesList.length}',
-      );
+      // Keep local progress if the server returned nothing (e.g. sync lag).
+      final progress = fetched.isEmpty && _progressList.isNotEmpty
+          ? _progressList
+          : fetched;
 
       _sourceType = AppSourceType.xtream;
       _liveCategories = liveCategories;
@@ -408,15 +388,6 @@ class AppStateController extends ChangeNotifier {
         _sourceKey,
         jsonEncode(<String, Object?>{'type': 'xtream'}),
       );
-      _debugBoot(
-        'xtream-refresh:cache-written progress=${_progressList.length}',
-      );
-
-      _viewers = viewers;
-      _activeViewer = activeViewer;
-      _progressList = progress;
-      _error = null;
-      notifyListeners();
       return true;
     } on Object catch (error) {
       _error = _redact(userFacingXtreamError(error), xtreamService.credentials);
@@ -449,11 +420,6 @@ class AppStateController extends ChangeNotifier {
     final viewers =
         (await cacheService.get<List<Viewer>>('viewers'))?.data ??
         const <Viewer>[];
-    _debugBoot(
-      'cache-hydrate:read live=${channels.length} vod=${vodItems.length} '
-      'series=${seriesList.length} viewers=${viewers.length}',
-    );
-
     final hasContent =
         liveCategories.isNotEmpty ||
         vodCategories.isNotEmpty ||
@@ -477,38 +443,18 @@ class AppStateController extends ChangeNotifier {
         ? const <Progress>[]
         : await resumeService.all(activeViewer.ulid);
     _error = null;
-    _debugBoot(
-      'cache-hydrate:applied activeViewer=${activeViewer?.ulid ?? 'none'} '
-      'localProgress=${_progressList.length}',
-    );
     return true;
   }
 
-  Future<void> _refreshRecentlyWatchedForActiveViewer({
-    required String source,
-  }) async {
+  Future<void> _refreshRecentlyWatchedForActiveViewer() async {
     final viewer = _activeViewer;
-    if (viewer == null) {
-      _debugBoot('recently-watched:$source skipped no-active-viewer');
-      return;
-    }
+    if (viewer == null) return;
     try {
-      _debugBoot('recently-watched:$source start viewer=${viewer.ulid}');
       final progress = await _loadRecentlyWatchedDeduped(viewer.ulid);
-      if (progress.isEmpty && _progressList.isNotEmpty) {
-        _debugBoot(
-          'recently-watched:$source kept local progress after empty remote',
-        );
-        return;
-      }
+      if (progress.isEmpty && _progressList.isNotEmpty) return;
       _progressList = progress;
-      _debugBoot(
-        'recently-watched:$source applied progress=${progress.length}',
-      );
       notifyListeners();
-    } on Object catch (error) {
-      _debugBoot('recently-watched:$source failed $error');
-    }
+    } on Object catch (_) {}
   }
 
   Future<List<Progress>> _loadRecentlyWatchedDeduped(String viewerId) {
@@ -587,14 +533,6 @@ class AppStateController extends ChangeNotifier {
     }
 
     return result;
-  }
-
-  void _debugBoot(String message) {
-    if (!kDebugMode) return;
-    final elapsed = _bootStopwatch.isRunning
-        ? _bootStopwatch.elapsedMilliseconds
-        : 0;
-    debugPrint('[startup-debug][+${elapsed}ms] $message');
   }
 
   Future<void> _loadXtreamEpg(List<Channel> channels) async {

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -116,6 +116,9 @@ class AppStateController extends ChangeNotifier {
   List<VodItem> _vodItems = const <VodItem>[];
   List<Series> _seriesList = const <Series>[];
   List<Progress> _progressList = const <Progress>[];
+  final Stopwatch _bootStopwatch = Stopwatch();
+  Future<List<Progress>>? _recentlyWatchedRefresh;
+  String? _recentlyWatchedRefreshViewerId;
 
   AppSourceType get sourceType => _sourceType;
   bool get isBootstrapping => _isBootstrapping;
@@ -138,6 +141,10 @@ class AppStateController extends ChangeNotifier {
   };
 
   Future<void> boot() async {
+    _bootStopwatch
+      ..reset()
+      ..start();
+    _debugBoot('boot:start');
     _isBootstrapping = true;
     _error = null;
     notifyListeners();
@@ -152,13 +159,20 @@ class AppStateController extends ChangeNotifier {
     }
 
     final savedSource = await _readSavedSourceType();
+    _debugBoot('boot:savedSource=$savedSource');
     if (savedSource == AppSourceType.xtream ||
         savedSource == AppSourceType.none) {
       final restored = await authNotifier.loadSavedCredentials();
+      _debugBoot('boot:credentialsRestored=$restored');
       if (restored) {
         if (await _hydrateCachedXtreamContent()) {
           _isBootstrapping = false;
           notifyListeners();
+          unawaited(
+            _refreshRecentlyWatchedForActiveViewer(
+              source: 'cached-boot',
+            ),
+          );
           unawaited(
             _replaceWithXtreamContent(
               clearCache: false,
@@ -173,6 +187,9 @@ class AppStateController extends ChangeNotifier {
     }
 
     _isBootstrapping = false;
+    _debugBoot(
+      'boot:complete source=$_sourceType progress=${_progressList.length}',
+    );
     notifyListeners();
   }
 
@@ -326,6 +343,7 @@ class AppStateController extends ChangeNotifier {
 
   Future<bool> _replaceWithXtreamContent({required bool clearCache}) async {
     try {
+      _debugBoot('xtream-refresh:start clearCache=$clearCache');
       final liveCategoriesFuture = xtreamService.getLiveCategories();
       final vodCategoriesFuture = xtreamService.getVodCategories();
       final seriesCategoriesFuture = xtreamService.getSeriesCategories();
@@ -355,7 +373,12 @@ class AppStateController extends ChangeNotifier {
       final activeViewer = await viewerService.resolveActiveViewer(viewers);
       final progress = activeViewer == null
           ? const <Progress>[]
-          : await _loadRecentlyWatched(activeViewer.ulid);
+          : await _loadRecentlyWatchedDeduped(activeViewer.ulid);
+      _debugBoot(
+        'xtream-refresh:remote-ready viewers=${viewers.length} '
+        'progress=${progress.length} live=${channels.length} vod=${vodItems.length} '
+        'series=${seriesList.length}',
+      );
 
       _sourceType = AppSourceType.xtream;
       _liveCategories = liveCategories;
@@ -380,9 +403,13 @@ class AppStateController extends ChangeNotifier {
       await cacheService.set('liveStreams', channels);
       await cacheService.set('vodStreams', vodItems);
       await cacheService.set('seriesStreams', seriesList);
+      await cacheService.set('viewers', viewers);
       await secureStorage.write(
         _sourceKey,
         jsonEncode(<String, Object?>{'type': 'xtream'}),
+      );
+      _debugBoot(
+        'xtream-refresh:cache-written progress=${_progressList.length}',
       );
 
       _viewers = viewers;
@@ -419,6 +446,13 @@ class AppStateController extends ChangeNotifier {
     final seriesList =
         (await cacheService.get<List<Series>>('seriesStreams'))?.data ??
         const <Series>[];
+    final viewers =
+        (await cacheService.get<List<Viewer>>('viewers'))?.data ??
+        const <Viewer>[];
+    _debugBoot(
+      'cache-hydrate:read live=${channels.length} vod=${vodItems.length} '
+      'series=${seriesList.length} viewers=${viewers.length}',
+    );
 
     final hasContent =
         liveCategories.isNotEmpty ||
@@ -436,8 +470,62 @@ class AppStateController extends ChangeNotifier {
     _channels = channels;
     _vodItems = vodItems;
     _seriesList = seriesList;
+    _viewers = viewers;
+    _activeViewer = await viewerService.resolveActiveViewer(viewers);
+    final activeViewer = _activeViewer;
+    _progressList = activeViewer == null
+        ? const <Progress>[]
+        : await resumeService.all(activeViewer.ulid);
     _error = null;
+    _debugBoot(
+      'cache-hydrate:applied activeViewer=${activeViewer?.ulid ?? 'none'} '
+      'localProgress=${_progressList.length}',
+    );
     return true;
+  }
+
+  Future<void> _refreshRecentlyWatchedForActiveViewer({
+    required String source,
+  }) async {
+    final viewer = _activeViewer;
+    if (viewer == null) {
+      _debugBoot('recently-watched:$source skipped no-active-viewer');
+      return;
+    }
+    try {
+      _debugBoot('recently-watched:$source start viewer=${viewer.ulid}');
+      final progress = await _loadRecentlyWatchedDeduped(viewer.ulid);
+      if (progress.isEmpty && _progressList.isNotEmpty) {
+        _debugBoot(
+          'recently-watched:$source kept local progress after empty remote',
+        );
+        return;
+      }
+      _progressList = progress;
+      _debugBoot(
+        'recently-watched:$source applied progress=${progress.length}',
+      );
+      notifyListeners();
+    } on Object catch (error) {
+      _debugBoot('recently-watched:$source failed $error');
+    }
+  }
+
+  Future<List<Progress>> _loadRecentlyWatchedDeduped(String viewerId) {
+    final inFlight = _recentlyWatchedRefresh;
+    if (inFlight != null && _recentlyWatchedRefreshViewerId == viewerId) {
+      return inFlight;
+    }
+    late final Future<List<Progress>> future;
+    _recentlyWatchedRefreshViewerId = viewerId;
+    future = _loadRecentlyWatched(viewerId).whenComplete(() {
+      if (identical(_recentlyWatchedRefresh, future)) {
+        _recentlyWatchedRefresh = null;
+        _recentlyWatchedRefreshViewerId = null;
+      }
+    });
+    _recentlyWatchedRefresh = future;
+    return future;
   }
 
   Future<List<Progress>> _loadRecentlyWatched(String viewerId) async {
@@ -499,6 +587,14 @@ class AppStateController extends ChangeNotifier {
     }
 
     return result;
+  }
+
+  void _debugBoot(String message) {
+    if (!kDebugMode) return;
+    final elapsed = _bootStopwatch.isRunning
+        ? _bootStopwatch.elapsedMilliseconds
+        : 0;
+    debugPrint('[startup-debug][+${elapsed}ms] $message');
   }
 
   Future<void> _loadXtreamEpg(List<Channel> channels) async {

--- a/flutter_client/lib/services/cache_service.dart
+++ b/flutter_client/lib/services/cache_service.dart
@@ -73,6 +73,9 @@ Object? _encodeCacheData(String key, Object? data) {
   if (data is List<Series>) {
     return data.map(_seriesToJson).toList(growable: false);
   }
+  if (data is List<Viewer>) {
+    return data.map((viewer) => viewer.toJson()).toList(growable: false);
+  }
   if (data is String || data is num || data is bool || data == null) {
     return data;
   }
@@ -134,6 +137,12 @@ Object? _decodeCacheData(String key, Object? raw) {
       list
           ?.map((item) => Series.fromXtream(_asMap(item)))
           .toList(growable: false),
+    'viewers' =>
+      list
+          ?.map((item) => Viewer.fromJson(_asMap(item)))
+          .toList(
+            growable: false,
+          ),
     _ => raw,
   };
 }

--- a/flutter_client/lib/services/persistent_store.dart
+++ b/flutter_client/lib/services/persistent_store.dart
@@ -6,35 +6,51 @@ class PersistentJsonStore {
 
   final File _file;
   Map<String, Object?>? _cache;
+  Future<void> _pendingWrite = Future<void>.value();
 
   Future<Object?> read(String key) async {
-    final data = await _readAll();
+    await _pendingWrite;
+    final data = await _readAllUnlocked();
     return data[key];
   }
 
   Future<void> write(String key, Object? value) async {
-    final data = await _readAll();
-    data[key] = value;
-    await _writeAll(data);
+    await _queueWrite(() async {
+      final data = await _readAllUnlocked();
+      data[key] = value;
+      await _writeAll(data);
+    });
   }
 
   Future<void> delete(String key) async {
-    final data = await _readAll();
-    data.remove(key);
-    await _writeAll(data);
+    await _queueWrite(() async {
+      final data = await _readAllUnlocked();
+      data.remove(key);
+      await _writeAll(data);
+    });
   }
 
   Future<Map<String, Object?>> snapshot() async {
-    return Map<String, Object?>.from(await _readAll());
+    await _pendingWrite;
+    return Map<String, Object?>.from(await _readAllUnlocked());
   }
 
   Future<void> removeWhere(bool Function(String key) test) async {
-    final data = await _readAll();
-    data.removeWhere((key, value) => test(key));
-    await _writeAll(data);
+    await _queueWrite(() async {
+      final data = await _readAllUnlocked();
+      data.removeWhere((key, value) => test(key));
+      await _writeAll(data);
+    });
   }
 
-  Future<Map<String, Object?>> _readAll() async {
+  Future<void> _queueWrite(Future<void> Function() operation) {
+    final previous = _pendingWrite;
+    final next = previous.then((_) => operation(), onError: (_) => operation());
+    _pendingWrite = next.catchError((_) {});
+    return next;
+  }
+
+  Future<Map<String, Object?>> _readAllUnlocked() async {
     final cached = _cache;
     if (cached != null) return cached;
     if (!await _file.exists()) {

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -22,6 +22,7 @@ void main() {
       () async {
         final storage = InMemorySecureStorage();
         final cacheMemory = <String, Object?>{};
+        final localMemory = <String, Object?>{};
         final catalogGate = Completer<Object?>();
         await storage.write(
           'm3ue_tv_credentials',
@@ -61,10 +62,24 @@ void main() {
         await cache.set('seriesStreams', const <Series>[
           Series(id: 903, name: 'Cached Show'),
         ]);
+        await cache.set('viewers', const <Viewer>[
+          Viewer(id: 1, ulid: 'viewer-admin', name: 'Admin', isAdmin: true),
+        ]);
+        await ResumeService(memory: localMemory).save(
+          const Progress(
+            viewerId: 'viewer-admin',
+            contentType: ContentType.vod,
+            streamId: 902,
+            positionSeconds: 91,
+            durationSeconds: 600,
+            title: 'Cached Movie',
+          ),
+        );
 
         final controller = _controller(
           storage: storage,
           cacheMemory: cacheMemory,
+          localMemory: localMemory,
           transport: _FakeXtreamTransport.success()
               .withResponse('get_live_categories', catalogGate.future)
               .call,
@@ -80,6 +95,9 @@ void main() {
         expect(controller.channels.single.name, 'Cached BBC');
         expect(controller.vodItems.single.name, 'Cached Movie');
         expect(controller.seriesList.single.name, 'Cached Show');
+        expect(controller.activeViewer?.ulid, 'viewer-admin');
+        expect(controller.progressList.single.streamId, 902);
+        expect(controller.progressList.single.title, 'Cached Movie');
         await boot;
 
         catalogGate.complete(
@@ -91,6 +109,82 @@ void main() {
 
         expect(controller.liveCategories.single.name, 'News');
         expect(controller.channels.single.name, 'BBC One');
+      },
+    );
+
+    test(
+      'cached Xtream boot refreshes remote progress before catalog refresh finishes',
+      () async {
+        final storage = InMemorySecureStorage();
+        final cacheMemory = <String, Object?>{};
+        final catalogGate = Completer<Object?>();
+        final recentlyWatchedGate = Completer<Object?>();
+        await storage.write(
+          'm3ue_tv_credentials',
+          jsonEncode(<String, String>{
+            'server': 'https://fixture.example',
+            'username': 'fixture-user',
+            'password': 'fixture-password',
+          }),
+        );
+        await storage.write(
+          'm3ue_tv_source',
+          jsonEncode(<String, String>{'type': 'xtream'}),
+        );
+
+        final cache = CacheService(memory: cacheMemory);
+        await cache.set('sourceType', 'xtream');
+        await cache.set('liveStreams', const <Channel>[
+          Channel(id: 901, name: 'Cached BBC', streamUrl: 'cached-live-url'),
+        ]);
+        await cache.set('vodStreams', const <VodItem>[
+          VodItem(
+            id: 902,
+            name: 'Cached Movie',
+            streamUrl: 'cached-vod-url',
+            containerExtension: 'mp4',
+          ),
+        ]);
+        await cache.set('viewers', const <Viewer>[
+          Viewer(id: 1, ulid: 'viewer-admin', name: 'Admin', isAdmin: true),
+        ]);
+
+        final controller = _controller(
+          storage: storage,
+          cacheMemory: cacheMemory,
+          transport: _FakeXtreamTransport.success()
+              .withResponse('get_live_categories', catalogGate.future)
+              .withResponse('get_recently_watched', recentlyWatchedGate.future)
+              .call,
+        );
+
+        final boot = controller.boot();
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        expect(controller.channels.single.name, 'Cached BBC');
+        expect(controller.progressList, isEmpty);
+
+        recentlyWatchedGate.complete(<Map<String, Object?>>[
+          <String, Object?>{
+            'content_type': 'vod',
+            'stream_id': 902,
+            'position_seconds': 121,
+            'duration_seconds': 600,
+            'title': 'Remote Cached Movie',
+          },
+        ]);
+        for (var pumpCount = 0; pumpCount < 5; pumpCount += 1) {
+          await Future<void>.delayed(Duration.zero);
+        }
+
+        expect(controller.progressList.single.streamId, 902);
+        expect(controller.progressList.single.title, 'Remote Cached Movie');
+        expect(controller.channels.single.name, 'Cached BBC');
+
+        await boot;
+        catalogGate.complete(
+          _FakeXtreamTransport.success().responses['get_live_categories'],
+        );
       },
     );
 


### PR DESCRIPTION
## Summary
- Cache Xtream viewers with the catalog data so cached startup can resolve the active viewer immediately
- Load local resume progress during cached Xtream hydration before slow remote refreshes finish
- Start an early server-side `get_recently_watched` refresh after cached hydration, so Continue Watching can appear before the full catalog refresh completes
- Add temporary `[startup-debug]` logs around boot, cache hydration, catalog refresh, viewer resolution, and progress counts for live tracing
- Serialize persistent JSON store writes to avoid concurrent startup refresh `.tmp` rename races
- Extend app-state boot regressions for early cached/local and server-side Continue Watching data

## Testing
- `/tmp/flutter/bin/dart format lib/services/app_state_controller.dart lib/services/persistent_store.dart test/integration/app_state_boot_test.dart`
- `/tmp/flutter/bin/flutter test test/integration/app_state_boot_test.dart`
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Fixes #52
