### PR TITLE
fix: keep configured state during offline startup

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1076,6 +1076,37 @@ class _ContentNavigator extends StatelessWidget {
   }
 }
 
+class _OfflineBanner extends StatelessWidget {
+  const _OfflineBanner({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      color: theme.colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Icon(Icons.cloud_off, color: theme.colorScheme.onErrorContainer),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                message,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: theme.colorScheme.onErrorContainer,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _HomeScreen extends StatefulWidget {
   const _HomeScreen({
     required this.appState,
@@ -1218,6 +1249,10 @@ class _HomeScreenState extends State<_HomeScreen> {
           Text('Home', style: Theme.of(context).textTheme.headlineMedium),
           const SizedBox(height: MediaBrowsingMetrics.chipGap),
           Text('Connected source: ${appState.sourceLabel}'),
+          if (appState.error != null && appState.error!.isNotEmpty) ...[
+            const SizedBox(height: MediaBrowsingMetrics.chipGap),
+            _OfflineBanner(message: appState.error!),
+          ],
           const SizedBox(height: MediaBrowsingMetrics.pagePadding),
           if (continueWatchingItems.isNotEmpty) continueWatchingSection,
           liveSection,

--- a/flutter_client/lib/features/settings/settings_screen.dart
+++ b/flutter_client/lib/features/settings/settings_screen.dart
@@ -477,29 +477,31 @@ class _ConnectedViewState extends State<_ConnectedView> {
                   valueColor: theme.colorScheme.error,
                 ),
                 const SizedBox(height: 12),
-                Wrap(
-                  spacing: 12,
-                  runSpacing: 8,
-                  children: [
-                    DpadFocusable(
-                      onSelect: widget.onClearCache,
-                      effects: _kStadiumEffect,
-                      child: FilledButton.tonalIcon(
-                        onPressed: widget.onClearCache,
-                        icon: const Icon(Icons.refresh),
-                        label: const Text('Retry connection'),
-                      ),
+                SizedBox(
+                  width: double.infinity,
+                  child: DpadFocusable(
+                    autofocus: true,
+                    onSelect: widget.onClearCache,
+                    effects: _kStadiumEffect,
+                    child: FilledButton.tonalIcon(
+                      onPressed: widget.onClearCache,
+                      icon: const Icon(Icons.refresh),
+                      label: const Text('Retry connection'),
                     ),
-                    DpadFocusable(
-                      onSelect: _handleDisconnect,
-                      effects: _kStadiumEffect,
-                      child: FilledButton.tonalIcon(
-                        onPressed: _handleDisconnect,
-                        icon: const Icon(Icons.settings),
-                        label: const Text('Edit server settings'),
-                      ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: DpadFocusable(
+                    onSelect: _handleDisconnect,
+                    effects: _kStadiumEffect,
+                    child: FilledButton.tonalIcon(
+                      onPressed: _handleDisconnect,
+                      icon: const Icon(Icons.settings),
+                      label: const Text('Edit server settings'),
                     ),
-                  ],
+                  ),
                 ),
               ],
             ],

--- a/flutter_client/lib/features/settings/settings_screen.dart
+++ b/flutter_client/lib/features/settings/settings_screen.dart
@@ -446,10 +446,16 @@ class _ConnectedViewState extends State<_ConnectedView> {
           title: 'Connection',
           child: Column(
             children: [
-              const _StatusRow(
+              _StatusRow(
                 label: 'Status',
-                value: 'Connected',
-                valueColor: Colors.green,
+                value:
+                    widget.sourceError != null && widget.sourceError!.isNotEmpty
+                    ? 'Unavailable'
+                    : 'Connected',
+                valueColor:
+                    widget.sourceError != null && widget.sourceError!.isNotEmpty
+                    ? Colors.orange
+                    : Colors.green,
               ),
               if (widget.sourceLabel != null) ...[
                 const Divider(),
@@ -485,10 +491,10 @@ class _ConnectedViewState extends State<_ConnectedView> {
                       ),
                     ),
                     DpadFocusable(
-                      onSelect: widget.onDisconnect,
+                      onSelect: _handleDisconnect,
                       effects: _kStadiumEffect,
                       child: FilledButton.tonalIcon(
-                        onPressed: widget.onDisconnect,
+                        onPressed: _handleDisconnect,
                         icon: const Icon(Icons.settings),
                         label: const Text('Edit server settings'),
                       ),

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -167,6 +167,10 @@ class AppStateController extends ChangeNotifier {
           return;
         }
         await _replaceWithXtreamContent(clearCache: false);
+      } else if (savedSource == AppSourceType.xtream &&
+          authNotifier.error != null) {
+        _sourceType = AppSourceType.xtream;
+        _error = authNotifier.error;
       }
     } else if (savedSource == AppSourceType.m3u) {
       await _loadSavedM3uSource();
@@ -277,6 +281,11 @@ class AppStateController extends ChangeNotifier {
     _isLoadingContent = true;
     _error = null;
     notifyListeners();
+    if (_sourceType == AppSourceType.xtream && !authNotifier.isConfigured) {
+      _isLoadingContent = false;
+      await boot();
+      return;
+    }
     await _replaceWithXtreamContent(clearCache: true);
     _isLoadingContent = false;
     notifyListeners();

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -136,6 +136,61 @@ void main() {
     });
 
     testWidgets(
+      'saved_source offline boot keeps configured shell and outage actions',
+      (tester) async {
+        final storage = InMemorySecureStorage();
+        await storage.write(
+          'm3ue_tv_credentials',
+          jsonEncode(<String, String>{
+            'server': 'https://fixture.example',
+            'username': 'fixture-user',
+            'password': 'fixture-password',
+          }),
+        );
+        await storage.write(
+          'm3ue_tv_source',
+          jsonEncode(<String, String>{'type': 'xtream'}),
+        );
+
+        final controller = _controller(
+          storage: storage,
+          transport: (request) async {
+            throw XtreamHttpException(
+              statusCode: 503,
+              method: request.method,
+              uri: Uri.parse('${request.credentials.server}/player_api.php'),
+              reasonPhrase: 'Service Unavailable',
+            );
+          },
+        );
+
+        await tester.pumpWidget(_TestApp(controller: controller));
+        await _pumpAppState(tester);
+
+        expect(controller.sourceType, AppSourceType.xtream);
+        expect(controller.isConfigured, isTrue);
+        expect(
+          _visibleText(tester),
+          contains('Server is currently unavailable.'),
+        );
+        expect(_visibleText(tester), contains('Connected source: Xtream'));
+        expect(
+          _visibleText(tester),
+          isNot(contains('Please connect to your service in Settings')),
+        );
+        expect(_sidebarDestination('Settings'), findsOneWidget);
+
+        await _tapSidebarDestination(tester, 'Settings');
+        await _pumpAppState(tester);
+
+        expect(find.text('Server is currently unavailable.'), findsWidgets);
+        expect(find.text('Retry connection'), findsOneWidget);
+        expect(find.text('Edit server settings'), findsOneWidget);
+        expect(find.text('Server URL'), findsNothing);
+      },
+    );
+
+    testWidgets(
       'saved_source boots connected app state without constructor fixtures',
       (tester) async {
         final storage = InMemorySecureStorage();

--- a/flutter_client/test/ui/settings/settings_test.dart
+++ b/flutter_client/test/ui/settings/settings_test.dart
@@ -535,6 +535,14 @@ void main() {
 
       await tester.tap(find.text('Edit server settings'));
       await tester.pumpAndSettle();
+      expect(find.text('Disconnect?'), findsOneWidget);
+      await tester.tap(
+        find.descendant(
+          of: find.byType(Dialog),
+          matching: find.text('Disconnect'),
+        ),
+      );
+      await tester.pumpAndSettle();
       expect(edited, isTrue);
     });
 


### PR DESCRIPTION
## Summary
- Keeps a saved Xtream profile in configured state when startup auth fails because the server is unavailable
- Shows a Home outage banner with the friendly unavailable-server message instead of falling back to first-run setup copy
- Keeps Settings on the configured outage path with Retry connection and Edit server settings actions
- Routes retry through saved-credential restore when auth failed before runtime credentials were available

## Testing
- `/tmp/flutter/bin/flutter test test/integration/app_state_boot_test.dart --plain-name 'saved_source offline boot keeps configured shell and outage actions'`
- `/tmp/flutter/bin/flutter test test/integration/app_state_boot_test.dart`
- `/tmp/flutter/bin/dart format --output=none --set-exit-if-changed .`
- `/tmp/flutter/bin/flutter analyze`
- `/tmp/flutter/bin/flutter test`

Fixes #53
