### PR TITLE
feat: add app notification service

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -16,6 +16,7 @@ import 'package:m3u_tv/navigation/route_names.dart';
 import 'package:m3u_tv/playback/playback_orchestrator.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/notification_service.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
@@ -53,6 +54,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
   final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
   late final AppStateController _appState;
   late final bool _ownsAppState;
+  StreamSubscription<List<AppNotification>>? _notificationSubscription;
 
   DateTime? _lastBackPress;
 
@@ -74,6 +76,10 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     _appState = widget.appState ?? AppStateController();
     _ownsAppState = widget.appState == null;
     _appState.addListener(_onAppStateChanged);
+    _notificationSubscription = _appState
+        .notificationService
+        .notificationsStream
+        .listen(_showNotifications);
     if (!_appState.isConfigured) {
       unawaited(_appState.boot());
     }
@@ -123,6 +129,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     _contentFocusNode.dispose();
     _sidebarScopeNode.dispose();
     _appState.removeListener(_onAppStateChanged);
+    unawaited(_notificationSubscription?.cancel());
     if (_ownsAppState) _appState.dispose();
     super.dispose();
   }
@@ -145,6 +152,24 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
         }),
       );
     }
+  }
+
+  void _showNotifications(List<AppNotification> notifications) {
+    if (!mounted || notifications.isEmpty) return;
+    final notification = notifications.last;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(notification.title),
+            Text(notification.message),
+          ],
+        ),
+      ),
+    );
+    _appState.notificationService.dismiss(notification.id);
   }
 
   void _activateSidebar() {
@@ -1065,6 +1090,7 @@ class _ContentNavigator extends StatelessWidget {
                 unawaited(appState.switchViewer(viewer)),
             onCreateViewer: appState.createViewer,
             onClearCache: () => unawaited(appState.clearAndRefresh()),
+            notificationService: appState.notificationService,
             onEpgIntervalChanged: (d) =>
                 unawaited(appState.setEpgRefreshInterval(d)),
             onConnected: onConnected,

--- a/flutter_client/lib/features/settings/settings_screen.dart
+++ b/flutter_client/lib/features/settings/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:m3u_tv/services/auth_notifier.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/notification_service.dart';
 import 'package:m3u_tv/services/trakt_service.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
@@ -33,6 +34,7 @@ class SettingsScreen extends StatefulWidget {
     this.onSwitchViewer,
     this.onCreateViewer,
     this.onClearCache,
+    this.notificationService,
     this.onEpgIntervalChanged,
     this.onConnected,
   });
@@ -51,6 +53,7 @@ class SettingsScreen extends StatefulWidget {
   final Duration? epgRefreshInterval;
   final List<Duration> epgRefreshOptions;
   final VoidCallback? onClearCache;
+  final AppNotificationService? notificationService;
   final void Function(Duration interval)? onEpgIntervalChanged;
 
   /// Called after a successful connection so the parent can navigate to Home.
@@ -133,6 +136,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         onSwitchViewer: widget.onSwitchViewer,
         onCreateViewer: widget.onCreateViewer,
         onClearCache: widget.onClearCache,
+        notificationService: widget.notificationService,
         onEpgIntervalChanged: widget.onEpgIntervalChanged,
       ),
     );
@@ -319,6 +323,7 @@ class _ConnectedView extends StatefulWidget {
     this.onSwitchViewer,
     this.onCreateViewer,
     this.onClearCache,
+    this.notificationService,
     this.onEpgIntervalChanged,
   });
 
@@ -334,6 +339,7 @@ class _ConnectedView extends StatefulWidget {
   final void Function(Viewer viewer)? onSwitchViewer;
   final Future<Viewer?> Function(String name)? onCreateViewer;
   final VoidCallback? onClearCache;
+  final AppNotificationService? notificationService;
   final void Function(Duration interval)? onEpgIntervalChanged;
 
   @override
@@ -370,12 +376,12 @@ class _ConnectedViewState extends State<_ConnectedView> {
     if (!confirmed || !mounted) return;
     widget.onClearCache?.call();
     if (!mounted) return;
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text(
-          'Cache cleared — content is refreshing in the background.',
-        ),
-      ),
+    widget.notificationService?.publish(
+      severity: AppNotificationSeverity.success,
+      title: 'Cache cleared',
+      message: 'Content is refreshing in the background.',
+      source: 'settings',
+      category: 'cache',
     );
   }
 

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -9,6 +9,7 @@ import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/services/m3u_parser.dart';
+import 'package:m3u_tv/services/notification_service.dart';
 import 'package:m3u_tv/services/persistent_store.dart';
 import 'package:m3u_tv/services/resume_service.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
@@ -31,6 +32,7 @@ class AppStateController extends ChangeNotifier {
     ViewerService? viewerService,
     EpgService? epgService,
     M3UParser? m3uParser,
+    AppNotificationService? notificationService,
     PersistentJsonStore? persistentStore,
   }) {
     final store = persistentStore ?? PersistentJsonStore();
@@ -62,6 +64,7 @@ class AppStateController extends ChangeNotifier {
       viewerService: viewerService ?? ViewerService(store: store),
       epgService: epgService ?? EpgService(),
       m3uParser: m3uParser ?? M3UParser(),
+      notificationService: notificationService ?? AppNotificationService(),
       traktService: TraktService(storage: resolvedSecureStorage),
     );
   }
@@ -78,6 +81,7 @@ class AppStateController extends ChangeNotifier {
     required this.viewerService,
     required this.epgService,
     required this.m3uParser,
+    required this.notificationService,
     required this.traktService,
   });
 
@@ -101,6 +105,7 @@ class AppStateController extends ChangeNotifier {
   final ViewerService viewerService;
   final EpgService epgService;
   final M3UParser m3uParser;
+  final AppNotificationService notificationService;
   final TraktService traktService;
 
   AppSourceType _sourceType = AppSourceType.none;

--- a/flutter_client/lib/services/notification_service.dart
+++ b/flutter_client/lib/services/notification_service.dart
@@ -1,0 +1,96 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+enum AppNotificationSeverity { info, success, warning, error }
+
+class AppNotificationAction {
+  const AppNotificationAction({required this.label, required this.deepLink});
+
+  final String label;
+  final String deepLink;
+}
+
+class AppNotification {
+  const AppNotification({
+    required this.id,
+    required this.severity,
+    required this.title,
+    required this.message,
+    required this.source,
+    required this.timestamp,
+    this.category,
+    this.action,
+  });
+
+  final String id;
+  final AppNotificationSeverity severity;
+  final String title;
+  final String message;
+  final String source;
+  final String? category;
+  final DateTime timestamp;
+  final AppNotificationAction? action;
+}
+
+class AppNotificationService extends ChangeNotifier {
+  AppNotificationService({DateTime Function()? clock})
+    : _clock = clock ?? DateTime.now;
+
+  final DateTime Function() _clock;
+  final _controller = StreamController<List<AppNotification>>.broadcast();
+  final List<AppNotification> _notifications = <AppNotification>[];
+  var _nextId = 0;
+
+  List<AppNotification> get notifications => List.unmodifiable(_notifications);
+
+  Stream<List<AppNotification>> get notificationsStream => _controller.stream;
+
+  AppNotification publish({
+    required AppNotificationSeverity severity,
+    required String title,
+    required String message,
+    required String source,
+    String? category,
+    AppNotificationAction? action,
+  }) {
+    _nextId += 1;
+    final notification = AppNotification(
+      id: 'notification-$_nextId',
+      severity: severity,
+      title: title,
+      message: message,
+      source: source,
+      category: category,
+      timestamp: _clock(),
+      action: action,
+    );
+    _notifications.add(notification);
+    _emit();
+    return notification;
+  }
+
+  void dismiss(String id) {
+    final before = _notifications.length;
+    _notifications.removeWhere((notification) => notification.id == id);
+    if (_notifications.length != before) _emit();
+  }
+
+  void clear() {
+    if (_notifications.isEmpty) return;
+    _notifications.clear();
+    _emit();
+  }
+
+  void _emit() {
+    final snapshot = notifications;
+    _controller.add(snapshot);
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    unawaited(_controller.close());
+    super.dispose();
+  }
+}

--- a/flutter_client/test/services/notification_service_test.dart
+++ b/flutter_client/test/services/notification_service_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/notification_service.dart';
+
+void main() {
+  group('AppNotificationService', () {
+    test('publish stores metadata and notifies listeners', () async {
+      final service = AppNotificationService(clock: () => DateTime(2026));
+      addTearDown(service.dispose);
+
+      final updates = <List<AppNotification>>[];
+      final subscription = service.notificationsStream.listen(updates.add);
+      addTearDown(subscription.cancel);
+
+      final notification = service.publish(
+        severity: AppNotificationSeverity.success,
+        title: 'Cache cleared',
+        message: 'Content is refreshing in the background.',
+        source: 'settings',
+        category: 'cache',
+        action: const AppNotificationAction(
+          label: 'Open settings',
+          deepLink: '/settings',
+        ),
+      );
+
+      await pumpEventQueue();
+
+      expect(service.notifications, [notification]);
+      expect(updates.single, [notification]);
+      expect(notification.severity, AppNotificationSeverity.success);
+      expect(notification.title, 'Cache cleared');
+      expect(notification.message, 'Content is refreshing in the background.');
+      expect(notification.source, 'settings');
+      expect(notification.category, 'cache');
+      expect(notification.timestamp, DateTime(2026));
+      expect(notification.action?.label, 'Open settings');
+      expect(notification.action?.deepLink, '/settings');
+    });
+
+    test(
+      'dismiss removes one notification and emits the updated store',
+      () async {
+        final service = AppNotificationService(clock: () => DateTime(2026));
+        addTearDown(service.dispose);
+        final updates = <List<AppNotification>>[];
+        final subscription = service.notificationsStream.listen(updates.add);
+        addTearDown(subscription.cancel);
+
+        final first = service.publish(
+          severity: AppNotificationSeverity.info,
+          title: 'First',
+          message: 'One',
+          source: 'test',
+        );
+        final second = service.publish(
+          severity: AppNotificationSeverity.warning,
+          title: 'Second',
+          message: 'Two',
+          source: 'test',
+        );
+
+        service.dismiss(first.id);
+        await pumpEventQueue();
+
+        expect(service.notifications, [second]);
+        expect(updates.last, [second]);
+      },
+    );
+
+    test('clear removes every notification and emits an empty store', () async {
+      final service = AppNotificationService(clock: () => DateTime(2026));
+      addTearDown(service.dispose);
+      final updates = <List<AppNotification>>[];
+      final subscription = service.notificationsStream.listen(updates.add);
+      addTearDown(subscription.cancel);
+
+      service
+        ..publish(
+          severity: AppNotificationSeverity.info,
+          title: 'First',
+          message: 'One',
+          source: 'test',
+        )
+        ..publish(
+          severity: AppNotificationSeverity.error,
+          title: 'Second',
+          message: 'Two',
+          source: 'test',
+        )
+        ..clear();
+      await pumpEventQueue();
+
+      expect(service.notifications, isEmpty);
+      expect(updates.last, isEmpty);
+    });
+  });
+}

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -15,6 +15,7 @@ import 'package:m3u_tv/services/cache_service.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
+import 'package:m3u_tv/services/notification_service.dart';
 import 'package:m3u_tv/services/resume_service.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
 import 'package:m3u_tv/services/viewer_service.dart';
@@ -99,6 +100,39 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Server URL'), findsOneWidget);
+    });
+
+    testWidgets('renders published app notifications through the shell', (
+      tester,
+    ) async {
+      final notificationService = AppNotificationService(
+        clock: () => DateTime(2026),
+      );
+      addTearDown(notificationService.dispose);
+      final appState = _testAppState(
+        xtreamService: _NavigationXtreamService(),
+        notificationService: notificationService,
+      );
+      addTearDown(appState.dispose);
+
+      await tester.pumpWidget(
+        _TestApp(deviceType: DeviceType.tv, appState: appState),
+      );
+      await tester.pumpAndSettle();
+
+      notificationService.publish(
+        severity: AppNotificationSeverity.warning,
+        title: 'Cache warning',
+        message: 'The cache needs attention.',
+        source: 'settings',
+        category: 'cache',
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+
+      expect(find.text('Cache warning'), findsOneWidget);
+      expect(find.text('The cache needs attention.'), findsOneWidget);
+      expect(notificationService.notifications, isEmpty);
     });
 
     testWidgets('sidebar labels remain visible after selecting a route', (
@@ -916,7 +950,10 @@ class _TestAppState extends State<_TestApp> {
   }
 }
 
-AppStateController _testAppState({required XtreamService xtreamService}) {
+AppStateController _testAppState({
+  required XtreamService xtreamService,
+  AppNotificationService? notificationService,
+}) {
   final memory = <String, Object?>{};
   return AppStateController(
     xtreamService: xtreamService,
@@ -925,6 +962,7 @@ AppStateController _testAppState({required XtreamService xtreamService}) {
     favoritesService: FavoritesService(memory: memory),
     resumeService: ResumeService(memory: memory),
     viewerService: ViewerService(memory: memory),
+    notificationService: notificationService,
   );
 }
 

--- a/flutter_client/test/ui/settings/settings_test.dart
+++ b/flutter_client/test/ui/settings/settings_test.dart
@@ -8,6 +8,7 @@ import 'package:m3u_tv/features/settings/viewer_selector.dart';
 import 'package:m3u_tv/services/auth_notifier.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/m3u_parser.dart';
+import 'package:m3u_tv/services/notification_service.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
 import 'package:m3u_tv/services/trakt_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
@@ -590,6 +591,46 @@ void main() {
       expect(find.text('Content Cache'), findsOneWidget);
     });
 
+    testWidgets('clear cache publishes a decoupled notification', (
+      tester,
+    ) async {
+      var cleared = false;
+      final service = AppNotificationService(clock: () => DateTime(2026));
+      addTearDown(service.dispose);
+      final notifier = AuthNotifier(
+        xtreamService: XtreamService(transport: _FakeTransport({}).call),
+        secureStorage: InMemorySecureStorage(),
+      );
+
+      await tester.pumpWidget(
+        _settingsApp(
+          notifier,
+          isConfiguredOverride: true,
+          notificationService: service,
+          onClearCache: () => cleared = true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Clear Cache & Refresh'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Clear & Refresh'));
+      await tester.pumpAndSettle();
+
+      expect(cleared, isTrue);
+      expect(service.notifications, hasLength(1));
+      final notification = service.notifications.single;
+      expect(notification.severity, AppNotificationSeverity.success);
+      expect(notification.title, 'Cache cleared');
+      expect(
+        notification.message,
+        'Content is refreshing in the background.',
+      );
+      expect(notification.source, 'settings');
+      expect(notification.category, 'cache');
+      expect(find.byType(SnackBar), findsNothing);
+    });
+
     testWidgets('shows viewer section when m3u-editor and viewer available', (
       tester,
     ) async {
@@ -856,6 +897,7 @@ Widget _settingsApp(
   Viewer? activeViewer,
   String? sourceError,
   bool? isConfiguredOverride,
+  AppNotificationService? notificationService,
   VoidCallback? onClearCache,
   VoidCallback? onDisconnect,
 }) {
@@ -868,6 +910,7 @@ Widget _settingsApp(
         activeViewer: activeViewer,
         sourceError: sourceError,
         isConfiguredOverride: isConfiguredOverride,
+        notificationService: notificationService,
         onClearCache: onClearCache,
         onDisconnect: onDisconnect ?? () => notifier.disconnect(),
       ),


### PR DESCRIPTION
## Summary
- Add a reusable app notification service with severity, source, category, timestamp, and optional actions.
- Wire AppStateController and AppShell to render published notifications consistently through snackbars.
- Use Settings cache clearing as the first feature integration example.

## Test Plan
- /tmp/flutter/bin/flutter test test/services/notification_service_test.dart test/ui/navigation/navigation_test.dart test/ui/settings/settings_test.dart
- /tmp/flutter/bin/dart format --output=none --set-exit-if-changed .
- /tmp/flutter/bin/flutter analyze
- /tmp/flutter/bin/flutter test

Closes #39
