### PR TITLE
fix: adapt desktop media browsing density

### DIFF
--- a/flutter_client/lib/features/series/series_screen.dart
+++ b/flutter_client/lib/features/series/series_screen.dart
@@ -40,7 +40,7 @@ class SeriesScreen extends StatefulWidget {
 
 class _SeriesScreenState extends State<SeriesScreen> {
   static const double _minPosterCardWidth = 120;
-  static const int _desktopPosterColumns = 5;
+  static const double _maxPosterCardWidth = 220;
   static const _kFavoritesCategoryId = '__FAVORITES__';
 
   String? _selectedCategory;
@@ -158,11 +158,7 @@ class _SeriesScreenState extends State<SeriesScreen> {
       builder: (context, constraints) {
         final availableWidth =
             constraints.maxWidth - MediaBrowsingMetrics.contentPadding * 2;
-        final columnCount =
-            ((availableWidth + MediaBrowsingMetrics.itemGap) /
-                    (_minPosterCardWidth + MediaBrowsingMetrics.itemGap))
-                .floor()
-                .clamp(1, _desktopPosterColumns);
+        final columnCount = _posterColumnCount(availableWidth);
 
         return DpadRegion(
           memoryKey: 'series/grid',
@@ -199,6 +195,18 @@ class _SeriesScreenState extends State<SeriesScreen> {
         );
       },
     );
+  }
+
+  int _posterColumnCount(double availableWidth) {
+    final minimumColumns =
+        ((availableWidth + MediaBrowsingMetrics.itemGap) /
+                (_maxPosterCardWidth + MediaBrowsingMetrics.itemGap))
+            .ceil();
+    final maximumColumns =
+        ((availableWidth + MediaBrowsingMetrics.itemGap) /
+                (_minPosterCardWidth + MediaBrowsingMetrics.itemGap))
+            .floor();
+    return minimumColumns.clamp(1, maximumColumns.clamp(1, 100));
   }
 }
 

--- a/flutter_client/lib/features/vod/vod_screen.dart
+++ b/flutter_client/lib/features/vod/vod_screen.dart
@@ -39,7 +39,7 @@ class VodScreen extends StatefulWidget {
 
 class _VodScreenState extends State<VodScreen> {
   static const double _minPosterCardWidth = 120;
-  static const int _desktopPosterColumns = 5;
+  static const double _maxPosterCardWidth = 220;
   static const _kFavoritesCategoryId = '__FAVORITES__';
 
   String? _selectedCategory;
@@ -157,11 +157,7 @@ class _VodScreenState extends State<VodScreen> {
       builder: (context, constraints) {
         final availableWidth =
             constraints.maxWidth - MediaBrowsingMetrics.contentPadding * 2;
-        final columnCount =
-            ((availableWidth + MediaBrowsingMetrics.itemGap) /
-                    (_minPosterCardWidth + MediaBrowsingMetrics.itemGap))
-                .floor()
-                .clamp(1, _desktopPosterColumns);
+        final columnCount = _posterColumnCount(availableWidth);
 
         return DpadRegion(
           memoryKey: 'vod/grid',
@@ -198,6 +194,18 @@ class _VodScreenState extends State<VodScreen> {
         );
       },
     );
+  }
+
+  int _posterColumnCount(double availableWidth) {
+    final minimumColumns =
+        ((availableWidth + MediaBrowsingMetrics.itemGap) /
+                (_maxPosterCardWidth + MediaBrowsingMetrics.itemGap))
+            .ceil();
+    final maximumColumns =
+        ((availableWidth + MediaBrowsingMetrics.itemGap) /
+                (_minPosterCardWidth + MediaBrowsingMetrics.itemGap))
+            .floor();
+    return minimumColumns.clamp(1, maximumColumns.clamp(1, 100));
   }
 }
 

--- a/flutter_client/lib/shared/media_browsing_widgets.dart
+++ b/flutter_client/lib/shared/media_browsing_widgets.dart
@@ -492,7 +492,7 @@ class MediaPreviewItem {
   final EdgeInsets imagePadding;
   final Color? imageBackgroundColor;
 
-  /// 0.0–1.0 progress shown as a bar along the bottom of the image.
+  /// 0.0-1.0 progress shown as a bar along the bottom of the image.
   final double? progressFraction;
 
   /// Short text labels rendered as chips overlaid on the image (right-aligned).
@@ -538,10 +538,6 @@ class _MediaPreviewSectionState extends State<MediaPreviewSection> {
     final visibleItems = widget.items.take(12).toList(growable: false);
     return LayoutBuilder(
       builder: (context, constraints) {
-        // Scale card dimensions proportionally on wide TV screens (e.g. tvOS
-        // logical 1920px → scale 1.5). Clamped to 1.0 minimum so mobile and
-        // standard-density Android TV are unaffected.
-        final scale = (constraints.maxWidth / 1280.0).clamp(1.0, 2.0);
         final double baseWidth;
         final double baseHeight;
         if (widget.landscapeStyle) {
@@ -554,6 +550,7 @@ class _MediaPreviewSectionState extends State<MediaPreviewSection> {
           baseWidth = MediaBrowsingMetrics.previewCardWidth;
           baseHeight = MediaBrowsingMetrics.previewCardHeight;
         }
+        final scale = _previewCardScale(constraints.maxWidth);
         final cardWidth = baseWidth * scale;
         final cardHeight = baseHeight * scale;
 
@@ -614,6 +611,11 @@ class _MediaPreviewSectionState extends State<MediaPreviewSection> {
         );
       },
     );
+  }
+
+  double _previewCardScale(double availableWidth) {
+    if (availableWidth >= 1600) return 1;
+    return (availableWidth / 1280.0).clamp(1.0, 1.15);
   }
 }
 

--- a/flutter_client/test/ui/features/series_screen_test.dart
+++ b/flutter_client/test/ui/features/series_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/series/series_screen.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
 void main() {
   group('SeriesScreen', () {
@@ -50,6 +51,43 @@ void main() {
       expect(find.text('All Series'), findsOneWidget);
       expect(find.text('Thriller'), findsOneWidget);
       expect(find.text('Sci-Fi'), findsOneWidget);
+    });
+
+    testWidgets('large desktop grids keep series cards comfortably sized', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final manySeries = List<Series>.generate(
+        40,
+        (index) => Series(
+          id: index,
+          name: 'Desktop Series $index',
+          coverUrl: 'http://example.com/$index.jpg',
+          categoryId: '30',
+        ),
+      );
+
+      for (final viewport in [
+        const Size(1440, 900),
+        const Size(1920, 1080),
+        const Size(2560, 1440),
+      ]) {
+        tester.view.physicalSize = viewport;
+        await tester.pumpWidget(
+          _TestApp(seriesList: manySeries, categories: testCategories),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        final firstSeriesCard = find.ancestor(
+          of: find.text('Desktop Series 0'),
+          matching: find.byType(DpadInkWell),
+        );
+        expect(firstSeriesCard, findsOneWidget);
+        expect(tester.getSize(firstSeriesCard).width, lessThanOrEqualTo(220));
+      }
     });
 
     testWidgets('tapping category tab filters series', (tester) async {

--- a/flutter_client/test/ui/features/vod_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/vod/vod_screen.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
 void main() {
   group('VodScreen', () {
@@ -69,6 +70,44 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text('Big Buck Bunny'), findsOneWidget);
       expect(find.text('★ 4.5'), findsOneWidget);
+    });
+
+    testWidgets('large desktop grids keep movie cards comfortably sized', (
+      tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      final manyMovies = List<VodItem>.generate(
+        40,
+        (index) => VodItem(
+          id: index,
+          name: 'Desktop Movie $index',
+          streamUrl: 'http://example.com/$index.mp4',
+          containerExtension: 'mp4',
+          categoryId: '20',
+        ),
+      );
+
+      for (final viewport in [
+        const Size(1440, 900),
+        const Size(1920, 1080),
+        const Size(2560, 1440),
+      ]) {
+        tester.view.physicalSize = viewport;
+        await tester.pumpWidget(
+          _TestApp(vodItems: manyMovies, categories: testCategories),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+        final firstMovieCard = find.ancestor(
+          of: find.text('Desktop Movie 0'),
+          matching: find.byType(DpadInkWell),
+        );
+        expect(firstMovieCard, findsOneWidget);
+        expect(tester.getSize(firstMovieCard).width, lessThanOrEqualTo(220));
+      }
     });
 
     testWidgets('renders All Movies and category tabs', (tester) async {

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -38,6 +38,84 @@ void main() {
       );
     });
 
+    testWidgets(
+      'large desktop Home rows keep preview cards comfortably sized',
+      (
+        tester,
+      ) async {
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        for (final viewport in [
+          const Size(1440, 900),
+          const Size(1920, 1080),
+          const Size(2560, 1440),
+        ]) {
+          tester.view.physicalSize = viewport;
+          final appState = _testAppState(
+            xtreamService: _NavigationXtreamService(
+              liveChannels: List<Channel>.generate(
+                16,
+                (index) => Channel(
+                  id: 100 + index,
+                  name: 'Desktop Channel $index',
+                  streamUrl: 'http://example.com/live/$index.m3u8',
+                  categoryId: 'live',
+                ),
+              ),
+              vodItems: List<VodItem>.generate(
+                16,
+                (index) => VodItem(
+                  id: 200 + index,
+                  name: 'Desktop Movie $index',
+                  streamUrl: 'http://example.com/movie/$index.mp4',
+                  containerExtension: 'mp4',
+                  categoryId: 'vod',
+                ),
+              ),
+              seriesList: List<Series>.generate(
+                16,
+                (index) => Series(
+                  id: 300 + index,
+                  name: 'Desktop Series $index',
+                  categoryId: 'series',
+                ),
+              ),
+            ),
+          );
+          addTearDown(appState.dispose);
+          await appState.connectXtream(
+            const UserCredentials(
+              server: 'http://example.com',
+              username: 'user',
+              password: 'pass',
+            ),
+          );
+
+          await tester.pumpWidget(
+            _TestApp(deviceType: DeviceType.desktop, appState: appState),
+          );
+          await _pumpAppFrame(tester);
+
+          expect(tester.takeException(), isNull);
+          final firstMovieCard = find.byWidgetPredicate(
+            (widget) =>
+                widget is MediaPreviewCard &&
+                widget.item.title == 'Desktop Movie 0',
+          );
+          final firstSeriesCard = find.byWidgetPredicate(
+            (widget) =>
+                widget is MediaPreviewCard &&
+                widget.item.title == 'Desktop Series 0',
+          );
+          expect(firstMovieCard, findsOneWidget);
+          expect(firstSeriesCard, findsOneWidget);
+          expect(tester.getSize(firstMovieCard).width, lessThanOrEqualTo(190));
+          expect(tester.getSize(firstSeriesCard).width, lessThanOrEqualTo(190));
+        }
+      },
+    );
+
     testWidgets('navigating to LiveTV shows Live TV screen', (tester) async {
       await tester.pumpWidget(const _TestApp(deviceType: DeviceType.tv));
       await tester.pumpAndSettle();
@@ -1018,8 +1096,38 @@ class _NavigationTranscodeGateway implements PlaybackTranscodeGateway {
 }
 
 class _NavigationXtreamService extends XtreamService {
-  _NavigationXtreamService({this.recentlyWatched = const <Progress>[]});
+  _NavigationXtreamService({
+    this.liveChannels = const <Channel>[
+      Channel(
+        id: 101,
+        name: 'Route News',
+        streamUrl: 'http://example.com/live/101.m3u8',
+        categoryId: 'live',
+      ),
+    ],
+    this.vodItems = const <VodItem>[
+      VodItem(
+        id: 201,
+        name: 'Route Movie',
+        streamUrl: 'http://example.com/movie/201.mp4',
+        containerExtension: 'mp4',
+        categoryId: 'vod',
+      ),
+    ],
+    this.seriesList = const <Series>[
+      Series(
+        id: 301,
+        name: 'Route Series',
+        categoryId: 'series',
+        plot: 'Route series plot',
+      ),
+    ],
+    this.recentlyWatched = const <Progress>[],
+  });
 
+  final List<Channel> liveChannels;
+  final List<VodItem> vodItems;
+  final List<Series> seriesList;
   final List<Progress> recentlyWatched;
 
   @override
@@ -1048,36 +1156,13 @@ class _NavigationXtreamService extends XtreamService {
 
   @override
   Future<List<Channel>> getLiveStreams({String? categoryId}) async =>
-      const <Channel>[
-        Channel(
-          id: 101,
-          name: 'Route News',
-          streamUrl: 'http://example.com/live/101.m3u8',
-          categoryId: 'live',
-        ),
-      ];
+      liveChannels;
 
   @override
-  Future<List<VodItem>> getVodStreams({String? categoryId}) async =>
-      const <VodItem>[
-        VodItem(
-          id: 201,
-          name: 'Route Movie',
-          streamUrl: 'http://example.com/movie/201.mp4',
-          containerExtension: 'mp4',
-          categoryId: 'vod',
-        ),
-      ];
+  Future<List<VodItem>> getVodStreams({String? categoryId}) async => vodItems;
 
   @override
-  Future<List<Series>> getSeries({String? categoryId}) async => const <Series>[
-    Series(
-      id: 301,
-      name: 'Route Series',
-      categoryId: 'series',
-      plot: 'Route series plot',
-    ),
-  ];
+  Future<List<Series>> getSeries({String? categoryId}) async => seriesList;
 
   @override
   Future<VodInfo> getVodInfo(int vodId) async => const VodInfo(


### PR DESCRIPTION
## Summary
- Adapts Home preview row sizing so desktop and large viewport cards stay compact.
- Replaces fixed VOD and Series desktop grid caps with adaptive column counts that keep poster cards comfortably sized.
- Adds large viewport widget coverage for Home, VOD, and Series while keeping existing TV focus traversal tests in the suite.

## Test Plan
- /tmp/flutter/bin/flutter test test/ui/features/series_screen_test.dart test/ui/features/vod_screen_test.dart test/ui/navigation/navigation_test.dart
- /tmp/flutter/bin/dart format --output=none --set-exit-if-changed .
- /tmp/flutter/bin/flutter analyze
- /tmp/flutter/bin/flutter test

Closes #27
