### PR TITLE
fix: show Windows app during startup

### DIFF
--- a/flutter_client/pubspec.lock
+++ b/flutter_client/pubspec.lock
@@ -558,6 +558,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.4"
+  media_kit_libs_windows_video:
+    dependency: "direct main"
+    description:
+      name: media_kit_libs_windows_video
+      sha256: dff76da2778729ab650229e6b4ec6ec111eb5151431002cbd7ea304ff1f112ab
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   media_kit_video:
     dependency: "direct main"
     description:

--- a/flutter_client/pubspec.yaml
+++ b/flutter_client/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   media_kit_libs_ios_video: ^1.1.4
   media_kit_libs_linux: ^1.2.1
   media_kit_libs_macos_video: ^1.1.4
+  media_kit_libs_windows_video: ^1.0.11
   media_kit_video: ^2.0.1
   path_provider: ^2.1.0
   path_provider_tvos: ^0.0.1

--- a/flutter_client/test/release/license_notices_test.dart
+++ b/flutter_client/test/release/license_notices_test.dart
@@ -198,4 +198,37 @@ void main() {
       }
     },
   );
+
+  test('Windows runner shows the shell before waiting for first frame', () {
+    final flutterWindow = readFile('windows/runner/flutter_window.cpp');
+    final attachViewIndex = flutterWindow.indexOf(
+      'SetChildContent(flutter_controller_->view()->GetNativeWindow());',
+    );
+    final immediateShowIndex = flutterWindow.indexOf(
+      'this->Show();',
+      attachViewIndex,
+    );
+    final firstFrameIndex = flutterWindow.indexOf(
+      'SetNextFrameCallback',
+      attachViewIndex,
+    );
+
+    expect(attachViewIndex, isNonNegative);
+    expect(immediateShowIndex, isNonNegative);
+    expect(firstFrameIndex, isNonNegative);
+    expect(
+      immediateShowIndex,
+      lessThan(firstFrameIndex),
+      reason:
+          'Windows startup must expose a window even if Dart delays frame 1',
+    );
+  });
+
+  test('Windows bundles MediaKit native video libraries', () {
+    final pubspec = readFile('pubspec.yaml');
+    final windowsPlugins = readFile('windows/flutter/generated_plugins.cmake');
+
+    expect(pubspec, contains('media_kit_libs_windows_video:'));
+    expect(windowsPlugins, contains('media_kit_libs_windows_video'));
+  });
 }

--- a/flutter_client/windows/flutter/generated_plugin_registrant.cc
+++ b/flutter_client/windows/flutter/generated_plugin_registrant.cc
@@ -7,12 +7,15 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <media_kit_libs_windows_video/media_kit_libs_windows_video_plugin_c_api.h>
 #include <media_kit_video/media_kit_video_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  MediaKitLibsWindowsVideoPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("MediaKitLibsWindowsVideoPluginCApi"));
   MediaKitVideoPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("MediaKitVideoPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/flutter_client/windows/flutter/generated_plugins.cmake
+++ b/flutter_client/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
+  media_kit_libs_windows_video
   media_kit_video
   url_launcher_windows
 )

--- a/flutter_client/windows/runner/flutter_window.cpp
+++ b/flutter_client/windows/runner/flutter_window.cpp
@@ -33,6 +33,10 @@ bool FlutterWindow::OnCreate() {
   RegisterDesktopLibmpvBackend(registrar, GetHandle());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
+  // Show the shell immediately so Windows users are never left with only a
+  // background process if Dart startup work delays the first Flutter frame.
+  this->Show();
+
   flutter_controller_->engine()->SetNextFrameCallback([&]() {
     this->Show();
   });


### PR DESCRIPTION
## Summary
- Show the Windows runner immediately after attaching the Flutter view so the app does not stay invisible while waiting for the first Flutter frame.
- Add the Windows MediaKit native video library package so libmpv-2.dll is bundled for Windows startup.
- Add release regression checks for Windows startup visibility and bundled MediaKit Windows libraries.

## Test plan
- `git diff --check HEAD~1..HEAD`
- `grep -rP "[\\x{2013}\\x{2014}]"` on changed files and commit message
- Static Windows library check via Python
- Manual Windows test by Max: `flutter run -d windows` starts successfully and app works

Closes #68
