### PR TITLE
fix: improve Android player back navigation

### DIFF
--- a/flutter_client/android/app/src/main/AndroidManifest.xml
+++ b/flutter_client/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:enableOnBackInvokedCallback="true"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as

--- a/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/MainActivity.kt
+++ b/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/MainActivity.kt
@@ -4,6 +4,9 @@ import android.app.UiModeManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.os.Build
+import android.window.OnBackInvokedCallback
+import android.window.OnBackInvokedDispatcher
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -11,6 +14,8 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : FlutterActivity() {
     private var media3Plugin: Media3PlaybackPlugin? = null
     private var deviceInfoChannel: MethodChannel? = null
+    private var navigationChannel: MethodChannel? = null
+    private var backCallback: OnBackInvokedCallback? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -23,14 +28,42 @@ class MainActivity : FlutterActivity() {
                 }
             }
         }
+        navigationChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, NAVIGATION_CHANNEL)
+        registerSystemBackCallback()
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        dispatchSystemBackToFlutter()
     }
 
     override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        unregisterSystemBackCallback()
         media3Plugin?.dispose()
         media3Plugin = null
         deviceInfoChannel?.setMethodCallHandler(null)
         deviceInfoChannel = null
+        navigationChannel = null
         super.cleanUpFlutterEngine(flutterEngine)
+    }
+
+    private fun dispatchSystemBackToFlutter() {
+        navigationChannel?.invokeMethod("systemBack", null)
+    }
+
+    private fun registerSystemBackCallback() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU || backCallback != null) return
+        backCallback = OnBackInvokedCallback { dispatchSystemBackToFlutter() }
+        onBackInvokedDispatcher.registerOnBackInvokedCallback(
+            OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+            backCallback!!,
+        )
+    }
+
+    private fun unregisterSystemBackCallback() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        backCallback?.let(onBackInvokedDispatcher::unregisterOnBackInvokedCallback)
+        backCallback = null
     }
 
     private fun isTelevisionDevice(): Boolean {
@@ -43,5 +76,6 @@ class MainActivity : FlutterActivity() {
 
     companion object {
         private const val DEVICE_INFO_CHANNEL = "m3u_tv/device_info"
+        private const val NAVIGATION_CHANNEL = "m3u_tv/navigation"
     }
 }

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -56,6 +56,10 @@ class AppShell extends StatefulWidget {
 }
 
 class AppShellState extends State<AppShell> {
+  static const MethodChannel _navigationChannel = MethodChannel(
+    'm3u_tv/navigation',
+  );
+
   bool _sidebarActive = false;
   late final AppStateController _appState;
   late final bool _ownsAppState;
@@ -97,6 +101,16 @@ class AppShellState extends State<AppShell> {
       unawaited(_appState.boot());
     }
     _initSidebarFocusNodes();
+    _navigationChannel.setMethodCallHandler(_handleNavigationMethodCall);
+  }
+
+  Future<Object?> _handleNavigationMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'systemBack':
+        return _handleSystemBackButton();
+      default:
+        throw MissingPluginException('No handler for ${call.method}');
+    }
   }
 
   Future<bool> _handleSystemBackButton() async {
@@ -106,7 +120,10 @@ class AppShellState extends State<AppShell> {
     final now = DateTime.now();
     final last = _lastBackPress;
     if (last != null && now.difference(last) < const Duration(seconds: 2)) {
-      return false;
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      await SystemNavigator.pop();
+
+      return true;
     }
     _lastBackPress = now;
     if (mounted) {
@@ -118,6 +135,19 @@ class AppShellState extends State<AppShell> {
       );
     }
     return true;
+  }
+
+  Widget _buildBackAwareShell(Widget child) {
+    return PopScope<void>(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop) unawaited(_handleSystemBackButton());
+      },
+      child: BackButtonListener(
+        onBackButtonPressed: _handleSystemBackButton,
+        child: child,
+      ),
+    );
   }
 
   void _onAppStateChanged() {
@@ -159,6 +189,7 @@ class AppShellState extends State<AppShell> {
 
   @override
   void dispose() {
+    _navigationChannel.setMethodCallHandler(null);
     _tvNotificationSub?.cancel().ignore();
     _playerOrchestrator?.dispose().ignore();
     for (final node in _sidebarFocusNodes) {
@@ -229,7 +260,7 @@ class AppShellState extends State<AppShell> {
   }
 
   // Stable method tearoff passed to ContentActions.onOpenPlayer.
-  // Must NOT be a local closure in build() — closures are always new instances,
+  // Must NOT be a local closure in build(). Closures are always new instances,
   // which makes ContentActions.updateShouldNotify return true on every rebuild
   // and cascade unnecessary rebuilds to all feature screens.
   void _openPlayerFromActions(PlayerArgs args) =>
@@ -647,17 +678,12 @@ class AppShellState extends State<AppShell> {
 
     final args = _playerArgs;
     final orch = _playerOrchestrator;
-    final backAwareShell = BackButtonListener(
-      onBackButtonPressed: _handleSystemBackButton,
-      child: shell,
-    );
-    if (args == null || orch == null) return backAwareShell;
+    if (args == null || orch == null) return _buildBackAwareShell(shell);
 
     final viewerId = _appState.activeViewer?.ulid ?? '';
 
-    return BackButtonListener(
-      onBackButtonPressed: _handleSystemBackButton,
-      child: Stack(
+    return _buildBackAwareShell(
+      Stack(
         children: [
           shell,
           Positioned.fill(

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -55,7 +55,7 @@ class AppShell extends StatefulWidget {
   State<AppShell> createState() => AppShellState();
 }
 
-class AppShellState extends State<AppShell> with WidgetsBindingObserver {
+class AppShellState extends State<AppShell> {
   bool _sidebarActive = false;
   late final AppStateController _appState;
   late final bool _ownsAppState;
@@ -89,7 +89,6 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
     _appState = widget.appState ?? AppStateController();
     _ownsAppState = widget.appState == null;
     _appState.addListener(_onAppStateChanged);
@@ -100,8 +99,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     _initSidebarFocusNodes();
   }
 
-  @override
-  Future<bool> didPopRoute() async {
+  Future<bool> _handleSystemBackButton() async {
     if (_handleBackPress()) return true;
 
     // Double-back to exit: require two back presses within 2 seconds.
@@ -162,7 +160,6 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
   @override
   void dispose() {
     _tvNotificationSub?.cancel().ignore();
-    WidgetsBinding.instance.removeObserver(this);
     _playerOrchestrator?.dispose().ignore();
     for (final node in _sidebarFocusNodes) {
       node.dispose();
@@ -650,94 +647,101 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
 
     final args = _playerArgs;
     final orch = _playerOrchestrator;
-    if (args == null || orch == null) return shell;
+    final backAwareShell = BackButtonListener(
+      onBackButtonPressed: _handleSystemBackButton,
+      child: shell,
+    );
+    if (args == null || orch == null) return backAwareShell;
 
     final viewerId = _appState.activeViewer?.ulid ?? '';
 
-    return Stack(
-      children: [
-        shell,
-        Positioned.fill(
-          child:
-              widget.playerRouteBuilder?.call(args) ??
-              PlayerScreen(
-                key: ValueKey(args.streamUrl),
-                args: args,
-                orchestrator: orch,
-                epgService: _appState.epgService,
-                xtreamService: _appState.xtreamService,
-                viewerId: viewerId,
-                progressReporter: (progress) {
-                  final existing = _appState.progressList.firstWhereOrNull(
-                    (p) =>
-                        p.contentType == progress.contentType &&
-                        p.streamId == progress.streamId,
-                  );
-                  final toSave = Progress(
-                    viewerId: progress.viewerId,
-                    contentType: progress.contentType,
-                    streamId: progress.streamId,
-                    positionSeconds: progress.positionSeconds,
-                    durationSeconds:
-                        progress.durationSeconds ?? existing?.durationSeconds,
-                    completed: progress.completed,
-                    seriesId: progress.seriesId ?? existing?.seriesId,
-                    seasonNumber:
-                        progress.seasonNumber ?? existing?.seasonNumber,
-                    episodeNumber:
-                        progress.episodeNumber ??
-                        (args.metadata['episode_number'] as int?) ??
-                        existing?.episodeNumber,
-                    title:
-                        progress.title ??
-                        args.metadata['title'] as String? ??
-                        args.title,
-                    episodeTitle:
-                        progress.episodeTitle ??
-                        args.metadata['episode_title'] as String? ??
-                        existing?.episodeTitle,
-                    seriesName:
-                        progress.seriesName ??
-                        args.metadata['series_name'] as String? ??
-                        existing?.seriesName,
-                    thumbnailUrl:
-                        progress.thumbnailUrl ??
-                        args.metadata['thumbnail_url'] as String? ??
-                        existing?.thumbnailUrl,
-                    backdropUrl:
-                        progress.backdropUrl ??
-                        args.metadata['backdrop_url'] as String? ??
-                        existing?.backdropUrl,
-                    rating:
-                        progress.rating ??
-                        args.metadata['rating'] as String? ??
-                        existing?.rating,
-                    runtime:
-                        progress.runtime ??
-                        args.metadata['duration'] as String? ??
-                        existing?.runtime,
-                    plot: progress.plot ?? existing?.plot,
-                    genre: progress.genre ?? existing?.genre,
-                    year: progress.year ?? existing?.year,
-                  );
-                  if (_appState.sourceType == AppSourceType.xtream) {
-                    unawaited(
-                      _appState.xtreamService
-                          .updateProgress(toSave)
-                          .catchError((_) {}),
+    return BackButtonListener(
+      onBackButtonPressed: _handleSystemBackButton,
+      child: Stack(
+        children: [
+          shell,
+          Positioned.fill(
+            child:
+                widget.playerRouteBuilder?.call(args) ??
+                PlayerScreen(
+                  key: ValueKey(args.streamUrl),
+                  args: args,
+                  orchestrator: orch,
+                  epgService: _appState.epgService,
+                  xtreamService: _appState.xtreamService,
+                  viewerId: viewerId,
+                  progressReporter: (progress) {
+                    final existing = _appState.progressList.firstWhereOrNull(
+                      (p) =>
+                          p.contentType == progress.contentType &&
+                          p.streamId == progress.streamId,
                     );
-                  }
-                  unawaited(
-                    _appState.resumeService.save(toSave).then((_) {
-                      if (mounted) _appState.updateProgressEntry(toSave);
-                    }),
-                  );
-                },
-                traktService: _appState.traktService,
-                onClose: _closePlayer,
-              ),
-        ),
-      ],
+                    final toSave = Progress(
+                      viewerId: progress.viewerId,
+                      contentType: progress.contentType,
+                      streamId: progress.streamId,
+                      positionSeconds: progress.positionSeconds,
+                      durationSeconds:
+                          progress.durationSeconds ?? existing?.durationSeconds,
+                      completed: progress.completed,
+                      seriesId: progress.seriesId ?? existing?.seriesId,
+                      seasonNumber:
+                          progress.seasonNumber ?? existing?.seasonNumber,
+                      episodeNumber:
+                          progress.episodeNumber ??
+                          (args.metadata['episode_number'] as int?) ??
+                          existing?.episodeNumber,
+                      title:
+                          progress.title ??
+                          args.metadata['title'] as String? ??
+                          args.title,
+                      episodeTitle:
+                          progress.episodeTitle ??
+                          args.metadata['episode_title'] as String? ??
+                          existing?.episodeTitle,
+                      seriesName:
+                          progress.seriesName ??
+                          args.metadata['series_name'] as String? ??
+                          existing?.seriesName,
+                      thumbnailUrl:
+                          progress.thumbnailUrl ??
+                          args.metadata['thumbnail_url'] as String? ??
+                          existing?.thumbnailUrl,
+                      backdropUrl:
+                          progress.backdropUrl ??
+                          args.metadata['backdrop_url'] as String? ??
+                          existing?.backdropUrl,
+                      rating:
+                          progress.rating ??
+                          args.metadata['rating'] as String? ??
+                          existing?.rating,
+                      runtime:
+                          progress.runtime ??
+                          args.metadata['duration'] as String? ??
+                          existing?.runtime,
+                      plot: progress.plot ?? existing?.plot,
+                      genre: progress.genre ?? existing?.genre,
+                      year: progress.year ?? existing?.year,
+                    );
+                    if (_appState.sourceType == AppSourceType.xtream) {
+                      unawaited(
+                        _appState.xtreamService
+                            .updateProgress(toSave)
+                            .catchError((_) {}),
+                      );
+                    }
+                    unawaited(
+                      _appState.resumeService.save(toSave).then((_) {
+                        if (mounted) _appState.updateProgressEntry(toSave);
+                      }),
+                    );
+                  },
+                  traktService: _appState.traktService,
+                  onClose: _closePlayer,
+                ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -101,7 +101,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     // widget already holds focus when the player opens via the AppShell Stack).
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        // Overlay is visible on open — focus the play/pause button directly
+        // Overlay is visible on open, so focus the play/pause button directly
         // so D-pad traversal works immediately. Falls back to _screenFocusNode
         // if somehow the overlay was already hidden.
         if (_overlayVisible) {
@@ -461,24 +461,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
     });
   }
 
-  void _hideOverlay() {
-    _overlayHideTimer?.cancel();
-    setState(() => _overlayVisible = false);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted && !_overlayVisible) _screenFocusNode.requestFocus();
-    });
-  }
-
   void _handleBack() {
-    if (_errorMessage != null) {
-      _goBack();
-      return;
-    }
-    if (_overlayVisible) {
-      _hideOverlay();
-    } else {
-      _goBack();
-    }
+    _goBack();
   }
 
   @override
@@ -491,7 +475,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
           LogicalKeySet(LogicalKeyboardKey.goBack): const _BackIntent(),
           LogicalKeySet(LogicalKeyboardKey.mediaPlayPause):
               const _PlayPauseIntent(),
-          // Only claim arrow keys when the overlay is hidden — when visible,
+          // Only claim arrow keys when the overlay is hidden. When visible,
           // let dpad's root Shortcuts handle them for spatial navigation.
           if (!_overlayVisible) ...{
             LogicalKeySet(LogicalKeyboardKey.arrowLeft):
@@ -518,10 +502,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
               if (event is KeyDownEvent &&
                   !_overlayVisible &&
                   _errorMessage == null) {
-                // Don't intercept back/escape — let the Shortcuts above handle
-                // it as a direct back action. Intercepting it here would set
-                // _overlayVisible = true, causing _handleBack() to call
-                // _hideOverlay() instead of _goBack(), making back a no-op.
+                // Don't intercept back/escape. Let the Shortcuts above handle
+                // it as a direct back action. Intercepting it here would show
+                // the overlay instead of closing the player.
                 final key = event.logicalKey;
                 final isBack =
                     key == LogicalKeyboardKey.escape ||
@@ -651,6 +634,13 @@ class _PlayerScreenState extends State<PlayerScreen> {
                       onTap: _showOverlay,
                       child: const SizedBox.expand(),
                     ),
+                  ),
+
+                if (_errorMessage == null)
+                  Positioned(
+                    top: 40,
+                    left: 40,
+                    child: _PlayerBackButton(onBack: _goBack),
                   ),
 
                 // EPG overlay (live only)
@@ -901,6 +891,40 @@ class _PlaybackDiagnosticsSnapshot {
       PlaybackBackend.serverTranscode => 'Server transcode fallback',
       null => 'Selecting backend',
     };
+  }
+}
+
+class _PlayerBackButton extends StatelessWidget {
+  const _PlayerBackButton({required this.onBack});
+
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    return DpadFocusable(
+      onSelect: onBack,
+      effects: const [
+        GradientBorderEffect(
+          borderRadius: BorderRadius.all(Radius.circular(50)),
+        ),
+      ],
+      child: GestureDetector(
+        key: const Key('player-back-button'),
+        onTap: onBack,
+        child: Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHighest,
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            Icons.arrow_back,
+            color: Theme.of(context).colorScheme.onSurface,
+            size: 24,
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -580,6 +580,86 @@ void main() {
     },
   );
 
+  testWidgets('Android system back exits app only on second root back press', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    final platformCalls = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        platformCalls.add(call);
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(deviceType: DeviceType.phone, appState: appState),
+    );
+    await _pumpAppFrame(tester);
+    platformCalls.clear();
+
+    final firstBackHandled = await tester.binding.handlePopRoute();
+    await tester.pump();
+
+    expect(firstBackHandled, isTrue);
+    expect(find.text('Press back again to exit'), findsOneWidget);
+    expect(platformCalls, isEmpty);
+
+    final secondBackHandled = await tester.binding.handlePopRoute();
+    await tester.pump();
+
+    expect(secondBackHandled, isTrue);
+    expect(
+      platformCalls.map((call) => call.method),
+      contains('SystemNavigator.pop'),
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Android predictive back is intercepted by the app shell', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(deviceType: DeviceType.phone, appState: appState),
+    );
+    await _pumpAppFrame(tester);
+
+    final hasBlockingPopScope = tester
+        .widgetList(find.byType(PopScope<void>))
+        .any(
+          (widget) => widget is PopScope<void> && !widget.canPop,
+        );
+
+    expect(hasBlockingPopScope, isTrue);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
   testWidgets('Android system back closes player overlay before app exit', (
     tester,
   ) async {
@@ -611,6 +691,289 @@ void main() {
     expect(find.text('Player route: Route News'), findsNothing);
     expect(find.text('Route News'), findsWidgets);
     expect(find.text('Press back again to exit'), findsNothing);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Android live player keeps a visible touch back button', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.phone,
+        appState: appState,
+        useProductionPlayer: true,
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(find.text('Route News').last);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 9));
+
+    expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+
+    await tester.tap(find.byKey(const Key('player-back-button')));
+    await _pumpAppFrame(tester);
+
+    expect(find.byIcon(Icons.arrow_back), findsNothing);
+    expect(find.text('Route News'), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Android native back channel closes live player', (tester) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.phone,
+        appState: appState,
+        playerRouteBuilder: _testPlayerRoute,
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(find.text('Route News').last);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Player route: Route News'), findsOneWidget);
+
+    await _sendNativeSystemBack(tester);
+    await _pumpAppFrame(tester);
+
+    expect(find.text('Player route: Route News'), findsNothing);
+    expect(find.text('Route News'), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Android native back channel closes movie player from overview', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.phone,
+        appState: appState,
+        playerRouteBuilder: _testPlayerRoute,
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(BottomNavigationBar),
+        matching: find.text('Movies'),
+      ),
+    );
+    await _pumpAppFrame(tester);
+    await tester.tap(find.text('Route Movie').last);
+    await _pumpAppFrame(tester);
+    await tester.tap(find.text('Play movie'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Player route: Route Movie'), findsOneWidget);
+
+    await _sendNativeSystemBack(tester);
+    await _pumpAppFrame(tester);
+
+    expect(find.text('Player route: Route Movie'), findsNothing);
+    expect(find.text('Route Movie'), findsWidgets);
+    expect(find.text('Play movie'), findsOneWidget);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Android native back channel closes series player from details', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.phone,
+        appState: appState,
+        playerRouteBuilder: _testPlayerRoute,
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(BottomNavigationBar),
+        matching: find.text('Series'),
+      ),
+    );
+    await _pumpAppFrame(tester);
+    await tester.tap(find.text('Route Series').last);
+    await _pumpAppFrame(tester);
+    await tester.tap(find.textContaining('Pilot'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Player route: Pilot'), findsOneWidget);
+
+    await _sendNativeSystemBack(tester);
+    await _pumpAppFrame(tester);
+
+    expect(find.text('Player route: Pilot'), findsNothing);
+    expect(find.text('Season 1'), findsOneWidget);
+    expect(find.textContaining('Pilot'), findsOneWidget);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Android system back closes live player after controls hide', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    final platformCalls = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        platformCalls.add(call);
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.phone,
+        appState: appState,
+        useProductionPlayer: true,
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(find.text('Route News').last);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 9));
+    platformCalls.clear();
+
+    final handled = await tester.binding.handlePopRoute();
+    await _pumpAppFrame(tester);
+
+    expect(handled, isTrue);
+    expect(find.byIcon(Icons.arrow_back), findsNothing);
+    expect(find.text('Route News'), findsWidgets);
+    expect(
+      platformCalls.map((call) => call.method),
+      isNot(contains('SystemNavigator.pop')),
+    );
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('Android system back closes movie player after controls hide', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    final platformCalls = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        platformCalls.add(call);
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.phone,
+        appState: appState,
+        useProductionPlayer: true,
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(BottomNavigationBar),
+        matching: find.text('Movies'),
+      ),
+    );
+    await _pumpAppFrame(tester);
+    await tester.tap(find.text('Route Movie').last);
+    await _pumpAppFrame(tester);
+    await tester.tap(find.text('Play movie'));
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 9));
+    platformCalls.clear();
+
+    expect(find.byKey(const Key('player-back-button')), findsOneWidget);
+
+    final handled = await tester.binding.handlePopRoute();
+    await _pumpAppFrame(tester);
+
+    expect(handled, isTrue);
+    expect(find.byKey(const Key('player-back-button')), findsNothing);
+    expect(find.text('Route Movie'), findsWidgets);
+    expect(
+      platformCalls.map((call) => call.method),
+      isNot(contains('SystemNavigator.pop')),
+    );
     await tester.pumpWidget(const SizedBox.shrink());
   });
 
@@ -1077,6 +1440,17 @@ Future<void> _pumpAppFrame(WidgetTester tester) async {
   await tester.pump();
 }
 
+Future<void> _sendNativeSystemBack(WidgetTester tester) async {
+  final message = const StandardMethodCodec().encodeMethodCall(
+    const MethodCall('systemBack'),
+  );
+  await tester.binding.defaultBinaryMessenger.handlePlatformMessage(
+    'm3u_tv/navigation',
+    message,
+    (_) {},
+  );
+}
+
 Future<void> _waitForText(WidgetTester tester, String text) async {
   final finder = find.text(text);
   for (var i = 0; i < 60; i += 1) {
@@ -1092,11 +1466,13 @@ class _TestApp extends StatefulWidget {
     required this.deviceType,
     this.appState,
     this.playerRouteBuilder,
+    this.useProductionPlayer = false,
   });
 
   final DeviceType deviceType;
   final AppStateController? appState;
   final Widget Function(PlayerArgs args)? playerRouteBuilder;
+  final bool useProductionPlayer;
 
   @override
   State<_TestApp> createState() => _TestAppState();
@@ -1111,7 +1487,9 @@ class _TestAppState extends State<_TestApp> {
     nativeTelevisionHint: false,
     deviceTypeOverride: widget.deviceType,
     playbackOrchestratorBuilder: _testPlaybackOrchestrator,
-    playerRouteBuilder: widget.playerRouteBuilder ?? _testPlayerRoute,
+    playerRouteBuilder: widget.useProductionPlayer
+        ? null
+        : widget.playerRouteBuilder ?? _testPlayerRoute,
   );
 
   @override

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -580,6 +580,40 @@ void main() {
     },
   );
 
+  testWidgets('Android system back closes player overlay before app exit', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(deviceType: DeviceType.tv, appState: appState),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(find.text('Route News').last);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Player route: Route News'), findsOneWidget);
+
+    final handled = await tester.binding.handlePopRoute();
+    await _pumpAppFrame(tester);
+
+    expect(handled, isTrue);
+    expect(find.text('Player route: Route News'), findsNothing);
+    expect(find.text('Route News'), findsWidgets);
+    expect(find.text('Press back again to exit'), findsNothing);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
   testWidgets(
     'open movie details updates to continue when progress changes behind route',
     (tester) async {


### PR DESCRIPTION
## Summary
- Route Android system and gesture back through the app shell before Flutter or Android can pop the activity
- Close the active player consistently for live TV, movie details, and series details
- Require a second Android root back press before the app exits
- Keep the visible touch back button in the player for phone and portrait layouts

## Test plan
- dart format --output=none --set-exit-if-changed lib/app/app_shell.dart test/ui/navigation/navigation_test.dart
- flutter analyze
- flutter test test/ui/navigation/navigation_test.dart
- flutter test --concurrency=1
- flutter build apk --release --dart-define=TRAKT_CLIENT_ID= --dart-define=TRAKT_CLIENT_SECRET=
