### PR TITLE
fix: polish Android playback issues

### DIFF
--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -17,7 +17,7 @@ enum _ViewMode { list, logoGrid, epgGrid }
 /// - All Channels + ★ Favorites pseudo-category + real categories
 /// - List view with EPG current/next info and progress bars
 /// - Toggle between list and grid view modes
-/// - Long-press to toggle favorites
+/// - Long-press context menu for favorites and recording actions
 /// - Lazy EPG loading for visible channels
 class LiveTvScreen extends StatefulWidget {
   const LiveTvScreen({
@@ -124,6 +124,67 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
       if (result != null) {
         _epgMap[channel.id] = result;
       }
+    }
+  }
+
+  Future<void> _toggleFavorite(Channel channel) async {
+    await widget.favoritesService.toggle(channel.id);
+    await _loadFavorites();
+  }
+
+  Future<void> _openChannelContextMenu(
+    BuildContext context,
+    Channel channel,
+    EpgCurrentNext? epg,
+  ) async {
+    final action = await showModalBottomSheet<_ChannelContextAction>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.tv),
+              title: Text(channel.name),
+              enabled: false,
+            ),
+            if (epg != null && widget.onScheduleProgram != null)
+              ListTile(
+                leading: const Icon(Icons.fiber_manual_record),
+                title: const Text('Record'),
+                subtitle: Text(epg.current.title),
+                onTap: () => Navigator.of(
+                  sheetContext,
+                ).pop(_ChannelContextAction.record),
+              ),
+            ListTile(
+              leading: Icon(
+                _favoriteIds.contains(channel.id)
+                    ? Icons.star
+                    : Icons.star_border,
+              ),
+              title: Text(
+                _favoriteIds.contains(channel.id)
+                    ? 'Remove favorite'
+                    : 'Favorite',
+              ),
+              onTap: () => Navigator.of(
+                sheetContext,
+              ).pop(_ChannelContextAction.toggleFavorite),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    switch (action) {
+      case _ChannelContextAction.record:
+        final current = epg?.current;
+        if (current != null) widget.onScheduleProgram?.call(channel, current);
+      case _ChannelContextAction.toggleFavorite:
+        await _toggleFavorite(channel);
+      case null:
+        break;
     }
   }
 
@@ -237,10 +298,8 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
             isFavorite: isFav,
             autofocus: index == 0,
             onTap: () => widget.onChannelSelect(channel),
-            onLongPress: () async {
-              await widget.favoritesService.toggle(channel.id);
-              await _loadFavorites();
-            },
+            onLongPress: () =>
+                unawaited(_openChannelContextMenu(context, channel, epg)),
             onScheduleProgram: widget.onScheduleProgram,
           );
         },
@@ -285,22 +344,23 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
         itemCount: channels.length,
         itemBuilder: (context, index) {
           final channel = channels[index];
+          final epg = _epgMap[channel.id];
           final isFav = _favoriteIds.contains(channel.id);
           return _ChannelGridItem(
             channel: channel,
             isFavorite: isFav,
             autofocus: index == 0,
             onTap: () => widget.onChannelSelect(channel),
-            onLongPress: () async {
-              await widget.favoritesService.toggle(channel.id);
-              await _loadFavorites();
-            },
+            onLongPress: () =>
+                unawaited(_openChannelContextMenu(context, channel, epg)),
           );
         },
       ),
     );
   }
 }
+
+enum _ChannelContextAction { record, toggleFavorite }
 
 class _ChannelRow extends StatelessWidget {
   const _ChannelRow({
@@ -365,9 +425,7 @@ class _ChannelRow extends StatelessWidget {
                         Text(
                           epg!.current.title,
                           style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -422,16 +480,12 @@ class _ChannelRow extends StatelessWidget {
                         Text(
                           'NEXT',
                           style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
                         ),
                         Text(
                           epg!.next!.title,
                           style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           textAlign: TextAlign.right,

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -17,6 +17,10 @@ import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:media_kit_video/media_kit_video.dart' as mkv;
 
+const bool _showPlaybackDiagnostics = bool.fromEnvironment(
+  'M3U_TV_SHOW_PLAYBACK_DIAGNOSTICS',
+);
+
 /// Full-screen player screen with playback controls, EPG overlay,
 /// resume prompt, backend fallback display, and progress reporting.
 class PlayerScreen extends StatefulWidget {
@@ -629,11 +633,15 @@ class _PlayerScreenState extends State<PlayerScreen> {
                     selectedSubtitleTrackId: _selectedSubtitleTrackId,
                     onAudioTrackSelected: _handleAudioTrackSelected,
                     onSubtitleTrackSelected: _handleSubtitleTrackSelected,
-                    fallbackReason: _fallbackReason,
+                    fallbackReason: _showPlaybackDiagnostics
+                        ? _fallbackReason
+                        : null,
                     playPauseFocusNode: _controlsFocusNode,
                   ),
 
-                if (_overlayVisible && _errorMessage == null)
+                if (_showPlaybackDiagnostics &&
+                    _overlayVisible &&
+                    _errorMessage == null)
                   Positioned(
                     top: 40,
                     right: 40,

--- a/flutter_client/lib/main.dart
+++ b/flutter_client/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:path_provider/path_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await _configureSystemUi();
   // MediaKit (libmpv) is used on desktop and iOS. tvOS uses AVKit exclusively.
   if (!kIsWeb && !Platform.isAndroid && Platform.operatingSystem != 'tvos') {
     MediaKit.ensureInitialized();
@@ -27,14 +28,17 @@ Future<void> main() async {
   runApp(MyApp(nativeTelevisionHint: nativeTelevisionHint, appState: appState));
 }
 
+Future<void> _configureSystemUi() async {
+  if (kIsWeb || !Platform.isAndroid) return;
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+}
+
 Future<AppStateController> _buildAppState() async {
   if (Platform.isAndroid ||
       Platform.isIOS ||
       Platform.operatingSystem == 'tvos') {
     final dir = await getApplicationDocumentsDirectory();
-    final store = PersistentJsonStore(
-      file: File('${dir.path}/app_state.json'),
-    );
+    final store = PersistentJsonStore(file: File('${dir.path}/app_state.json'));
     return AppStateController(
       persistentStore: store,
       secureStorage: FlutterSecureStorageAdapter(),
@@ -146,9 +150,7 @@ class _MyAppState extends State<MyApp> {
             fontWeight: FontWeight.w500,
           ),
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
       ),
       themeMode: ThemeMode.dark,

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -17,7 +17,7 @@ import 'package:m3u_tv/transcoding/transcoding.dart';
 void main() {
   group('production backend policy', () {
     testWidgets(
-      'unsupported_codec: Android uses Media3 then server transcode and renders diagnostics',
+      'unsupported_codec: Android uses Media3 then server transcode without player diagnostics',
       (tester) async {
         final media3 = _PolicyPlayerAdapter(
           capabilities: PlaybackCapabilities.androidExoPlayer,
@@ -88,17 +88,17 @@ void main() {
           contains('active-backend:serverTranscode:ready'),
         );
 
-        expect(find.text('Backend'), findsOneWidget);
-        expect(find.text('Server transcode fallback'), findsWidgets);
-        expect(find.text('Fallback'), findsOneWidget);
+        expect(find.text('Backend'), findsNothing);
+        expect(find.text('Server transcode fallback'), findsNothing);
+        expect(find.text('Fallback'), findsNothing);
         expect(
           find.textContaining('Unsupported codec hevc/aac'),
-          findsOneWidget,
+          findsNothing,
         );
-        expect(find.text('Transcode'), findsOneWidget);
-        expect(find.textContaining('unsupported-session'), findsOneWidget);
-        expect(find.text('Android mpv/libmpv'), findsOneWidget);
-        expect(find.textContaining('disabled'), findsOneWidget);
+        expect(find.text('Transcode'), findsNothing);
+        expect(find.textContaining('unsupported-session'), findsNothing);
+        expect(find.text('Android mpv/libmpv'), findsNothing);
+        expect(find.textContaining('disabled'), findsNothing);
 
         await tester.pumpWidget(const SizedBox.shrink());
       },

--- a/flutter_client/test/release/release_matrix_documentation_test.dart
+++ b/flutter_client/test/release/release_matrix_documentation_test.dart
@@ -146,6 +146,7 @@ void main() {
 
   test('android manifest exposes Android TV launcher metadata', () {
     final manifest = readFile('android/app/src/main/AndroidManifest.xml');
+    final mainDart = readFile('lib/main.dart');
 
     expect(manifest, contains('android.software.leanback'));
     expect(manifest, contains('android.hardware.touchscreen'));
@@ -153,6 +154,7 @@ void main() {
     expect(manifest, contains('android:label="M3U TV"'));
     expect(manifest, contains('android.intent.category.LEANBACK_LAUNCHER'));
     expect(manifest, contains('android:exported="true"'));
+    expect(mainDart, contains('SystemUiMode.immersiveSticky'));
   });
 
   test('release matrix documents signing, store, and license gates', () {

--- a/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
+++ b/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/live_tv/live_tv_screen.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
+
+void main() {
+  testWidgets('long press opens channel menu and favorites explicitly', (
+    tester,
+  ) async {
+    final favorites = FavoritesService(memory: <String, Object?>{});
+    final epg = EpgService(clock: () => DateTime.utc(2026, 1, 1, 12));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiveTvScreen(
+          channels: const [
+            Channel(
+              id: 101,
+              name: 'Route News',
+              streamUrl: 'https://example.com/news.m3u8',
+            ),
+          ],
+          categories: const [],
+          isLoading: false,
+          isConfigured: true,
+          favoritesService: favorites,
+          epgService: epg,
+          onChannelSelect: (_) {},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.longPress(find.text('Route News'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Route News'), findsWidgets);
+    expect(find.text('Favorite'), findsOneWidget);
+    expect(await favorites.isFavorite(101), isFalse);
+
+    await tester.tap(find.text('Favorite'));
+    await tester.pumpAndSettle();
+
+    expect(await favorites.isFavorite(101), isTrue);
+  });
+
+  testWidgets(
+    'long press menu exposes record when DVR scheduling is available',
+    (tester) async {
+      final favorites = FavoritesService(memory: <String, Object?>{});
+      final now = DateTime.utc(2026, 1, 1, 12);
+      final epg = EpgService(clock: () => now)
+        ..loadPrograms([
+          EpgProgram(
+            channelId: 'news.epg',
+            title: 'Noon News',
+            description: 'News',
+            start: now.subtract(const Duration(minutes: 30)),
+            end: now.add(const Duration(minutes: 30)),
+          ),
+        ]);
+      Channel? recordedChannel;
+      EpgProgram? recordedProgram;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: LiveTvScreen(
+            channels: const [
+              Channel(
+                id: 101,
+                name: 'Route News',
+                streamUrl: 'https://example.com/news.m3u8',
+                epgChannelId: 'news.epg',
+              ),
+            ],
+            categories: const [],
+            isLoading: false,
+            isConfigured: true,
+            favoritesService: favorites,
+            epgService: epg,
+            onChannelSelect: (_) {},
+            onScheduleProgram: (channel, program) {
+              recordedChannel = channel;
+              recordedProgram = program;
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.text('Route News'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Record'), findsWidgets);
+      expect(find.text('Noon News'), findsWidgets);
+
+      await tester.tap(find.text('Record').last);
+      await tester.pumpAndSettle();
+
+      expect(recordedChannel?.id, 101);
+      expect(recordedProgram?.title, 'Noon News');
+    },
+  );
+}

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -226,9 +226,7 @@ void main() {
 
     testWidgets(
       'stacks track selectors below transport controls on narrow portrait screens',
-      (
-        tester,
-      ) async {
+      (tester) async {
         await tester.binding.setSurfaceSize(const Size(430, 932));
         addTearDown(() => tester.binding.setSurfaceSize(null));
 
@@ -277,9 +275,7 @@ void main() {
 
     testWidgets(
       'keeps audio and subtitle selectors visible without transport overlap in landscape',
-      (
-        tester,
-      ) async {
+      (tester) async {
         await tester.binding.setSurfaceSize(const Size(932, 430));
         addTearDown(() => tester.binding.setSurfaceSize(null));
 
@@ -325,9 +321,7 @@ void main() {
       },
     );
 
-    testWidgets('labels track controls by type only', (
-      tester,
-    ) async {
+    testWidgets('labels track controls by type only', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: PlaybackControls(
@@ -375,9 +369,7 @@ void main() {
 
     testWidgets(
       'marks first audio track active while selected track is unknown',
-      (
-        tester,
-      ) async {
+      (tester) async {
         await tester.pumpWidget(
           MaterialApp(
             home: PlaybackControls(
@@ -629,9 +621,7 @@ void main() {
         MaterialApp(
           home: TrackSelector(
             audioTracks: const [],
-            subtitleTracks: const [
-              PlaybackTrack(id: '1', label: 'English'),
-            ],
+            subtitleTracks: const [PlaybackTrack(id: '1', label: 'English')],
             selectedAudioTrackId: null,
             selectedSubtitleTrackId: null,
             onAudioTrackSelected: (_) {},
@@ -719,10 +709,7 @@ void main() {
           home: TrackSelector(
             audioTracks: List<PlaybackTrack>.generate(
               12,
-              (index) => PlaybackTrack(
-                id: '$index',
-                label: 'Language $index',
-              ),
+              (index) => PlaybackTrack(id: '$index', label: 'Language $index'),
             ),
             subtitleTracks: const [],
             selectedAudioTrackId: '0',
@@ -790,10 +777,7 @@ void main() {
     testWidgets('hides next title when null', (tester) async {
       await tester.pumpWidget(
         const MaterialApp(
-          home: EpgOverlay(
-            currentTitle: 'Current Show',
-            currentProgress: 0.3,
-          ),
+          home: EpgOverlay(currentTitle: 'Current Show', currentProgress: 0.3),
         ),
       );
       expect(find.byType(EpgOverlay), findsOneWidget);
@@ -906,6 +890,8 @@ void main() {
 
       final texture = tester.widget<Texture>(find.byType(Texture));
       expect(texture.textureId, 42);
+      expect(find.text('Backend'), findsNothing);
+      expect(find.text('Desktop libmpv'), findsNothing);
     });
 
     testWidgets('seeks to resume position after backend load', (tester) async {
@@ -1002,9 +988,7 @@ void main() {
 
     testWidgets(
       'preserves reported source aspect ratio for the video surface',
-      (
-        tester,
-      ) async {
+      (tester) async {
         final adapter = FakePlayerAdapter(
           capabilities: PlaybackCapabilities.desktopLibmpv,
           textureId: 42,
@@ -1067,17 +1051,15 @@ void main() {
       );
       addTearDown(orchestrator.dispose);
       final epgService = EpgService(clock: () => now)
-        ..loadPrograms(
-          <EpgProgram>[
-            EpgProgram(
-              channelId: 'bbc.one',
-              title: 'Current News',
-              description: 'Fixture bulletin',
-              start: now.subtract(const Duration(minutes: 10)),
-              end: now.add(const Duration(minutes: 20)),
-            ),
-          ],
-        );
+        ..loadPrograms(<EpgProgram>[
+          EpgProgram(
+            channelId: 'bbc.one',
+            title: 'Current News',
+            description: 'Fixture bulletin',
+            start: now.subtract(const Duration(minutes: 10)),
+            end: now.add(const Duration(minutes: 20)),
+          ),
+        ]);
 
       await tester.pumpWidget(
         MaterialApp(


### PR DESCRIPTION
## Summary
- Hide playback backend diagnostics by default during normal player use
- Add a live TV long press menu with explicit favorite and record actions
- Enable Android immersive sticky system UI so the app uses the full screen area

## Test Plan
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test --concurrency=1
- flutter build apk --release --dart-define=TRAKT_CLIENT_ID= --dart-define=TRAKT_CLIENT_SECRET=
- apksigner verify --verbose m3u-tv-issues-71-73-94cbed4-release.apk

Closes #71
Closes #72
Closes #73
