### PR TITLE
fix: hide player diagnostics by default

### DIFF
--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -17,6 +17,10 @@ import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:media_kit_video/media_kit_video.dart' as mkv;
 
+const bool _showPlaybackDiagnostics = bool.fromEnvironment(
+  'M3U_TV_SHOW_PLAYBACK_DIAGNOSTICS',
+);
+
 /// Full-screen player screen with playback controls, EPG overlay,
 /// resume prompt, backend fallback display, and progress reporting.
 class PlayerScreen extends StatefulWidget {
@@ -629,11 +633,15 @@ class _PlayerScreenState extends State<PlayerScreen> {
                     selectedSubtitleTrackId: _selectedSubtitleTrackId,
                     onAudioTrackSelected: _handleAudioTrackSelected,
                     onSubtitleTrackSelected: _handleSubtitleTrackSelected,
-                    fallbackReason: _fallbackReason,
+                    fallbackReason: _showPlaybackDiagnostics
+                        ? _fallbackReason
+                        : null,
                     playPauseFocusNode: _controlsFocusNode,
                   ),
 
-                if (_overlayVisible && _errorMessage == null)
+                if (_showPlaybackDiagnostics &&
+                    _overlayVisible &&
+                    _errorMessage == null)
                   Positioned(
                     top: 40,
                     right: 40,

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -17,7 +17,7 @@ import 'package:m3u_tv/transcoding/transcoding.dart';
 void main() {
   group('production backend policy', () {
     testWidgets(
-      'unsupported_codec: Android uses Media3 then server transcode and renders diagnostics',
+      'unsupported_codec: Android uses Media3 then server transcode without player diagnostics',
       (tester) async {
         final media3 = _PolicyPlayerAdapter(
           capabilities: PlaybackCapabilities.androidExoPlayer,
@@ -88,17 +88,17 @@ void main() {
           contains('active-backend:serverTranscode:ready'),
         );
 
-        expect(find.text('Backend'), findsOneWidget);
-        expect(find.text('Server transcode fallback'), findsWidgets);
-        expect(find.text('Fallback'), findsOneWidget);
+        expect(find.text('Backend'), findsNothing);
+        expect(find.text('Server transcode fallback'), findsNothing);
+        expect(find.text('Fallback'), findsNothing);
         expect(
           find.textContaining('Unsupported codec hevc/aac'),
-          findsOneWidget,
+          findsNothing,
         );
-        expect(find.text('Transcode'), findsOneWidget);
-        expect(find.textContaining('unsupported-session'), findsOneWidget);
-        expect(find.text('Android mpv/libmpv'), findsOneWidget);
-        expect(find.textContaining('disabled'), findsOneWidget);
+        expect(find.text('Transcode'), findsNothing);
+        expect(find.textContaining('unsupported-session'), findsNothing);
+        expect(find.text('Android mpv/libmpv'), findsNothing);
+        expect(find.textContaining('disabled'), findsNothing);
 
         await tester.pumpWidget(const SizedBox.shrink());
       },


### PR DESCRIPTION
## Summary
- Hide playback backend diagnostics in the player by default
- Keep backend and fallback diagnostics available internally for tests and troubleshooting
- Update production backend policy coverage so normal playback no longer renders diagnostic badges

## Test Plan
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test --concurrency=1

Closes #71
