### PR TITLE
fix: add live TV context menu

### DIFF
--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -137,43 +137,57 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
     Channel channel,
     EpgCurrentNext? epg,
   ) async {
-    final action = await showModalBottomSheet<_ChannelContextAction>(
+    final hasRecord = epg != null && widget.onScheduleProgram != null;
+    final isFavorite = _favoriteIds.contains(channel.id);
+
+    final action = await showDialog<_ChannelContextAction>(
       context: context,
-      builder: (sheetContext) => SafeArea(
-        child: ListView(
-          shrinkWrap: true,
+      builder: (dialogContext) => SimpleDialog(
+        title: Row(
           children: [
-            ListTile(
-              leading: const Icon(Icons.tv),
-              title: Text(channel.name),
-              enabled: false,
-            ),
-            if (epg != null && widget.onScheduleProgram != null)
-              ListTile(
-                leading: const Icon(Icons.fiber_manual_record),
-                title: const Text('Record'),
-                subtitle: Text(epg.current.title),
-                onTap: () => Navigator.of(
-                  sheetContext,
-                ).pop(_ChannelContextAction.record),
+            const Icon(Icons.tv, size: 18),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                channel.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
-            ListTile(
-              leading: Icon(
-                _favoriteIds.contains(channel.id)
-                    ? Icons.star
-                    : Icons.star_border,
-              ),
-              title: Text(
-                _favoriteIds.contains(channel.id)
-                    ? 'Remove favorite'
-                    : 'Favorite',
-              ),
-              onTap: () => Navigator.of(
-                sheetContext,
-              ).pop(_ChannelContextAction.toggleFavorite),
             ),
           ],
         ),
+        children: [
+          DpadRegion(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (hasRecord)
+                  _ContextMenuOption(
+                    icon: Icons.fiber_manual_record,
+                    label: 'Record',
+                    subtitle: epg.current.title,
+                    autofocus: true,
+                    onTap: () => Navigator.of(
+                      dialogContext,
+                    ).pop(_ChannelContextAction.record),
+                  ),
+                _ContextMenuOption(
+                  icon: isFavorite ? Icons.star : Icons.star_border,
+                  label: isFavorite ? 'Remove favorite' : 'Favorite',
+                  autofocus: !hasRecord,
+                  onTap: () => Navigator.of(
+                    dialogContext,
+                  ).pop(_ChannelContextAction.toggleFavorite),
+                ),
+                _ContextMenuOption(
+                  icon: Icons.close,
+                  label: 'Cancel',
+                  onTap: () => Navigator.of(dialogContext).pop(),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
 
@@ -300,7 +314,6 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
             onTap: () => widget.onChannelSelect(channel),
             onLongPress: () =>
                 unawaited(_openChannelContextMenu(context, channel, epg)),
-            onScheduleProgram: widget.onScheduleProgram,
           );
         },
       ),
@@ -362,6 +375,55 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
 
 enum _ChannelContextAction { record, toggleFavorite }
 
+class _ContextMenuOption extends StatelessWidget {
+  const _ContextMenuOption({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.subtitle,
+    this.autofocus = false,
+  });
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final String? subtitle;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    return DpadInkWell(
+      autofocus: autofocus,
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 24),
+        child: Row(
+          children: [
+            Icon(icon, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: subtitle != null
+                  ? Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(label),
+                        Text(
+                          subtitle!,
+                          style: Theme.of(context).textTheme.bodySmall,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ],
+                    )
+                  : Text(label),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _ChannelRow extends StatelessWidget {
   const _ChannelRow({
     required this.channel,
@@ -370,7 +432,6 @@ class _ChannelRow extends StatelessWidget {
     required this.autofocus,
     required this.onTap,
     required this.onLongPress,
-    this.onScheduleProgram,
   });
 
   final Channel channel;
@@ -379,7 +440,6 @@ class _ChannelRow extends StatelessWidget {
   final bool autofocus;
   final VoidCallback onTap;
   final VoidCallback onLongPress;
-  final void Function(Channel, EpgProgram)? onScheduleProgram;
 
   @override
   Widget build(BuildContext context) {
@@ -457,16 +517,6 @@ class _ChannelRow extends StatelessWidget {
                       Icons.star,
                       color: colorScheme.tertiary,
                       size: 20,
-                    ),
-                  ),
-                if (epg != null && onScheduleProgram != null)
-                  Padding(
-                    padding: const EdgeInsets.only(left: 8),
-                    child: FilledButton.tonalIcon(
-                      onPressed: () =>
-                          onScheduleProgram!(channel, epg!.current),
-                      icon: const Icon(Icons.fiber_manual_record, size: 16),
-                      label: const Text('Record'),
                     ),
                   ),
                 // Next program

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -17,7 +17,7 @@ enum _ViewMode { list, logoGrid, epgGrid }
 /// - All Channels + ★ Favorites pseudo-category + real categories
 /// - List view with EPG current/next info and progress bars
 /// - Toggle between list and grid view modes
-/// - Long-press to toggle favorites
+/// - Long-press context menu for favorites and recording actions
 /// - Lazy EPG loading for visible channels
 class LiveTvScreen extends StatefulWidget {
   const LiveTvScreen({
@@ -124,6 +124,67 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
       if (result != null) {
         _epgMap[channel.id] = result;
       }
+    }
+  }
+
+  Future<void> _toggleFavorite(Channel channel) async {
+    await widget.favoritesService.toggle(channel.id);
+    await _loadFavorites();
+  }
+
+  Future<void> _openChannelContextMenu(
+    BuildContext context,
+    Channel channel,
+    EpgCurrentNext? epg,
+  ) async {
+    final action = await showModalBottomSheet<_ChannelContextAction>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.tv),
+              title: Text(channel.name),
+              enabled: false,
+            ),
+            if (epg != null && widget.onScheduleProgram != null)
+              ListTile(
+                leading: const Icon(Icons.fiber_manual_record),
+                title: const Text('Record'),
+                subtitle: Text(epg.current.title),
+                onTap: () => Navigator.of(
+                  sheetContext,
+                ).pop(_ChannelContextAction.record),
+              ),
+            ListTile(
+              leading: Icon(
+                _favoriteIds.contains(channel.id)
+                    ? Icons.star
+                    : Icons.star_border,
+              ),
+              title: Text(
+                _favoriteIds.contains(channel.id)
+                    ? 'Remove favorite'
+                    : 'Favorite',
+              ),
+              onTap: () => Navigator.of(
+                sheetContext,
+              ).pop(_ChannelContextAction.toggleFavorite),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    switch (action) {
+      case _ChannelContextAction.record:
+        final current = epg?.current;
+        if (current != null) widget.onScheduleProgram?.call(channel, current);
+      case _ChannelContextAction.toggleFavorite:
+        await _toggleFavorite(channel);
+      case null:
+        break;
     }
   }
 
@@ -237,10 +298,8 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
             isFavorite: isFav,
             autofocus: index == 0,
             onTap: () => widget.onChannelSelect(channel),
-            onLongPress: () async {
-              await widget.favoritesService.toggle(channel.id);
-              await _loadFavorites();
-            },
+            onLongPress: () =>
+                unawaited(_openChannelContextMenu(context, channel, epg)),
             onScheduleProgram: widget.onScheduleProgram,
           );
         },
@@ -285,22 +344,23 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
         itemCount: channels.length,
         itemBuilder: (context, index) {
           final channel = channels[index];
+          final epg = _epgMap[channel.id];
           final isFav = _favoriteIds.contains(channel.id);
           return _ChannelGridItem(
             channel: channel,
             isFavorite: isFav,
             autofocus: index == 0,
             onTap: () => widget.onChannelSelect(channel),
-            onLongPress: () async {
-              await widget.favoritesService.toggle(channel.id);
-              await _loadFavorites();
-            },
+            onLongPress: () =>
+                unawaited(_openChannelContextMenu(context, channel, epg)),
           );
         },
       ),
     );
   }
 }
+
+enum _ChannelContextAction { record, toggleFavorite }
 
 class _ChannelRow extends StatelessWidget {
   const _ChannelRow({
@@ -365,9 +425,7 @@ class _ChannelRow extends StatelessWidget {
                         Text(
                           epg!.current.title,
                           style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -422,16 +480,12 @@ class _ChannelRow extends StatelessWidget {
                         Text(
                           'NEXT',
                           style: Theme.of(context).textTheme.labelSmall
-                              ?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
                         ),
                         Text(
                           epg!.next!.title,
                           style: Theme.of(context).textTheme.bodySmall
-                              ?.copyWith(
-                                color: colorScheme.onSurfaceVariant,
-                              ),
+                              ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           textAlign: TextAlign.right,

--- a/flutter_client/test/ui/features/live_tv_screen_test.dart
+++ b/flutter_client/test/ui/features/live_tv_screen_test.dart
@@ -278,6 +278,9 @@ void main() {
         );
         await tester.pumpAndSettle();
 
+        await tester.longPress(find.text('BBC One'));
+        await tester.pumpAndSettle();
+
         expect(find.text('Record'), findsOneWidget);
         await tester.tap(find.text('Record'));
         await tester.pumpAndSettle();

--- a/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
+++ b/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/live_tv/live_tv_screen.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
+
+void main() {
+  testWidgets('long press opens channel menu and favorites explicitly', (
+    tester,
+  ) async {
+    final favorites = FavoritesService(memory: <String, Object?>{});
+    final epg = EpgService(clock: () => DateTime.utc(2026, 1, 1, 12));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: LiveTvScreen(
+          channels: const [
+            Channel(
+              id: 101,
+              name: 'Route News',
+              streamUrl: 'https://example.com/news.m3u8',
+            ),
+          ],
+          categories: const [],
+          isLoading: false,
+          isConfigured: true,
+          favoritesService: favorites,
+          epgService: epg,
+          onChannelSelect: (_) {},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.longPress(find.text('Route News'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Route News'), findsWidgets);
+    expect(find.text('Favorite'), findsOneWidget);
+    expect(await favorites.isFavorite(101), isFalse);
+
+    await tester.tap(find.text('Favorite'));
+    await tester.pumpAndSettle();
+
+    expect(await favorites.isFavorite(101), isTrue);
+  });
+
+  testWidgets(
+    'long press menu exposes record when DVR scheduling is available',
+    (tester) async {
+      final favorites = FavoritesService(memory: <String, Object?>{});
+      final now = DateTime.utc(2026, 1, 1, 12);
+      final epg = EpgService(clock: () => now)
+        ..loadPrograms([
+          EpgProgram(
+            channelId: 'news.epg',
+            title: 'Noon News',
+            description: 'News',
+            start: now.subtract(const Duration(minutes: 30)),
+            end: now.add(const Duration(minutes: 30)),
+          ),
+        ]);
+      Channel? recordedChannel;
+      EpgProgram? recordedProgram;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: LiveTvScreen(
+            channels: const [
+              Channel(
+                id: 101,
+                name: 'Route News',
+                streamUrl: 'https://example.com/news.m3u8',
+                epgChannelId: 'news.epg',
+              ),
+            ],
+            categories: const [],
+            isLoading: false,
+            isConfigured: true,
+            favoritesService: favorites,
+            epgService: epg,
+            onChannelSelect: (_) {},
+            onScheduleProgram: (channel, program) {
+              recordedChannel = channel;
+              recordedProgram = program;
+            },
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.text('Route News'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Record'), findsWidgets);
+      expect(find.text('Noon News'), findsWidgets);
+
+      await tester.tap(find.text('Record').last);
+      await tester.pumpAndSettle();
+
+      expect(recordedChannel?.id, 101);
+      expect(recordedProgram?.title, 'Noon News');
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- Replace the live TV long press shortcut with an explicit context menu
- Keep favorite toggling available as a menu action
- Add a Record action when current EPG data and DVR scheduling are available

## Test Plan
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test --concurrency=1

Closes #72
