### PR TITLE
fix: use fullscreen Android layout

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:dpad/dpad.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -172,6 +174,17 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     _appState.removeListener(_onAppStateChanged);
     if (_ownsAppState) _appState.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // immersiveSticky is reset by the OS on background/foreground transitions;
+    // re-apply it each time the app resumes to keep the layout full-screen.
+    if (state == AppLifecycleState.resumed && !kIsWeb && Platform.isAndroid) {
+      unawaited(
+        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky),
+      );
+    }
   }
 
   void _navigateTo(int index) {

--- a/flutter_client/lib/main.dart
+++ b/flutter_client/lib/main.dart
@@ -18,6 +18,7 @@ import 'package:path_provider/path_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await _configureSystemUi();
   // MediaKit (libmpv) is used on desktop and iOS. tvOS uses AVKit exclusively.
   if (!kIsWeb && !Platform.isAndroid && Platform.operatingSystem != 'tvos') {
     MediaKit.ensureInitialized();
@@ -27,14 +28,17 @@ Future<void> main() async {
   runApp(MyApp(nativeTelevisionHint: nativeTelevisionHint, appState: appState));
 }
 
+Future<void> _configureSystemUi() async {
+  if (kIsWeb || !Platform.isAndroid) return;
+  await SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+}
+
 Future<AppStateController> _buildAppState() async {
   if (Platform.isAndroid ||
       Platform.isIOS ||
       Platform.operatingSystem == 'tvos') {
     final dir = await getApplicationDocumentsDirectory();
-    final store = PersistentJsonStore(
-      file: File('${dir.path}/app_state.json'),
-    );
+    final store = PersistentJsonStore(file: File('${dir.path}/app_state.json'));
     return AppStateController(
       persistentStore: store,
       secureStorage: FlutterSecureStorageAdapter(),
@@ -146,9 +150,7 @@ class _MyAppState extends State<MyApp> {
             fontWeight: FontWeight.w500,
           ),
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(8),
-          ),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
       ),
       themeMode: ThemeMode.dark,

--- a/flutter_client/test/release/release_matrix_documentation_test.dart
+++ b/flutter_client/test/release/release_matrix_documentation_test.dart
@@ -146,6 +146,7 @@ void main() {
 
   test('android manifest exposes Android TV launcher metadata', () {
     final manifest = readFile('android/app/src/main/AndroidManifest.xml');
+    final mainDart = readFile('lib/main.dart');
 
     expect(manifest, contains('android.software.leanback'));
     expect(manifest, contains('android.hardware.touchscreen'));
@@ -153,6 +154,7 @@ void main() {
     expect(manifest, contains('android:label="M3U TV"'));
     expect(manifest, contains('android.intent.category.LEANBACK_LAUNCHER'));
     expect(manifest, contains('android:exported="true"'));
+    expect(mainDart, contains('SystemUiMode.immersiveSticky'));
   });
 
   test('release matrix documents signing, store, and license gates', () {

--- a/flutter_client/test/release/release_matrix_documentation_test.dart
+++ b/flutter_client/test/release/release_matrix_documentation_test.dart
@@ -146,7 +146,6 @@ void main() {
 
   test('android manifest exposes Android TV launcher metadata', () {
     final manifest = readFile('android/app/src/main/AndroidManifest.xml');
-    final mainDart = readFile('lib/main.dart');
 
     expect(manifest, contains('android.software.leanback'));
     expect(manifest, contains('android.hardware.touchscreen'));
@@ -154,7 +153,15 @@ void main() {
     expect(manifest, contains('android:label="M3U TV"'));
     expect(manifest, contains('android.intent.category.LEANBACK_LAUNCHER'));
     expect(manifest, contains('android:exported="true"'));
+  });
+
+  test('android fullscreen mode is configured at startup and on resume', () {
+    final mainDart = readFile('lib/main.dart');
+    final appShell = readFile('lib/app/app_shell.dart');
+
     expect(mainDart, contains('SystemUiMode.immersiveSticky'));
+    expect(appShell, contains('SystemUiMode.immersiveSticky'));
+    expect(appShell, contains('AppLifecycleState.resumed'));
   });
 
   test('release matrix documents signing, store, and license gates', () {


### PR DESCRIPTION
## Summary
- Enable Android immersive sticky system UI at startup
- Keep Android phone and tablet layouts using the full screen area
- Add release documentation coverage for the fullscreen behavior

## Test Plan
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test --concurrency=1

Closes #73
