### PR TITLE
fix: use Flutter back handling for Android player

### DIFF
--- a/flutter_client/android/app/src/main/AndroidManifest.xml
+++ b/flutter_client/android/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:enableOnBackInvokedCallback="true"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as

--- a/flutter_client/test/release/release_matrix_documentation_test.dart
+++ b/flutter_client/test/release/release_matrix_documentation_test.dart
@@ -137,7 +137,7 @@ void main() {
     final settingsGradle = readFile('android/settings.gradle.kts');
 
     // builtInKotlin=false keeps Flutter's own bundled packages (e.g. integration_test)
-    // working — they still declare org.jetbrains.kotlin.android explicitly and break
+    // working because they still declare org.jetbrains.kotlin.android explicitly and break
     // when AGP 9 enforces builtInKotlin=true.
     expect(gradleProperties, contains('android.builtInKotlin=false'));
     expect(gradleProperties, contains('android.newDsl=false'));
@@ -152,6 +152,7 @@ void main() {
     expect(manifest, contains('android:banner="@mipmap/ic_launcher"'));
     expect(manifest, contains('android:label="M3U TV"'));
     expect(manifest, contains('android.intent.category.LEANBACK_LAUNCHER'));
+    expect(manifest, contains('android:enableOnBackInvokedCallback="true"'));
     expect(manifest, contains('android:exported="true"'));
   });
 

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:m3u_tv/app/app_shell.dart';
+import 'package:m3u_tv/features/player/playback_controls.dart';
+import 'package:m3u_tv/features/player/player_screen.dart';
 import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/navigation/go_router_config.dart';
 import 'package:m3u_tv/playback/playback_capabilities.dart';
@@ -580,6 +582,82 @@ void main() {
     },
   );
 
+  testWidgets('Android system back closes live player through didPopRoute', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(deviceType: DeviceType.phone, appState: appState),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(find.text('Route News').last);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Player route: Route News'), findsOneWidget);
+
+    final handled = await tester.binding.handlePopRoute();
+    await _pumpAppFrame(tester);
+
+    expect(handled, isTrue);
+    expect(find.text('Player route: Route News'), findsNothing);
+    expect(find.text('Route News'), findsWidgets);
+    expect(find.text('Press back again to exit'), findsNothing);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('TV back dismisses player controls before closing player', (
+    tester,
+  ) async {
+    final appState = _testAppState(xtreamService: _NavigationXtreamService());
+    addTearDown(appState.dispose);
+    await appState.connectXtream(
+      const UserCredentials(
+        server: 'http://example.com',
+        username: 'user',
+        password: 'pass',
+      ),
+    );
+
+    await tester.pumpWidget(
+      _TestApp(
+        deviceType: DeviceType.tv,
+        appState: appState,
+        useProductionPlayer: true,
+      ),
+    );
+    await _pumpAppFrame(tester);
+
+    await tester.tap(find.text('Route News').last);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byType(PlaybackControls), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await _pumpAppFrame(tester);
+
+    expect(find.byType(PlaybackControls), findsNothing);
+    expect(find.byType(PlayerScreen), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await _pumpAppFrame(tester);
+
+    expect(find.byType(PlayerScreen), findsNothing);
+    expect(find.text('Route News'), findsWidgets);
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+
   testWidgets(
     'open movie details updates to continue when progress changes behind route',
     (tester) async {
@@ -1058,11 +1136,13 @@ class _TestApp extends StatefulWidget {
     required this.deviceType,
     this.appState,
     this.playerRouteBuilder,
+    this.useProductionPlayer = false,
   });
 
   final DeviceType deviceType;
   final AppStateController? appState;
   final Widget Function(PlayerArgs args)? playerRouteBuilder;
+  final bool useProductionPlayer;
 
   @override
   State<_TestApp> createState() => _TestAppState();
@@ -1077,7 +1157,9 @@ class _TestAppState extends State<_TestApp> {
     nativeTelevisionHint: false,
     deviceTypeOverride: widget.deviceType,
     playbackOrchestratorBuilder: _testPlaybackOrchestrator,
-    playerRouteBuilder: widget.playerRouteBuilder ?? _testPlayerRoute,
+    playerRouteBuilder: widget.useProductionPlayer
+        ? null
+        : widget.playerRouteBuilder ?? _testPlayerRoute,
   );
 
   @override


### PR DESCRIPTION
## Summary
- Enable Android predictive back via the existing activity manifest flag
- Keep Android back handling on the existing Flutter didPopRoute and Shortcuts/Actions path
- Add regression coverage for system back closing the player and TV back dismissing controls first

## Test Plan
- flutter pub get
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test --concurrency=1
