### PR TITLE
fix: scale Android adaptive icon foreground

### DIFF
--- a/flutter_client/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
+++ b/flutter_client/android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml
@@ -4,6 +4,6 @@
   <foreground>
       <inset
           android:drawable="@drawable/ic_launcher_foreground"
-          android:inset="16%" />
+          android:inset="0%" />
   </foreground>
 </adaptive-icon>

--- a/flutter_client/flutter_launcher_icons.yaml
+++ b/flutter_client/flutter_launcher_icons.yaml
@@ -1,11 +1,14 @@
 flutter_launcher_icons:
-  # Source icon — 1024×1024 PNG generated from logo.svg by generate-icons.sh
+  # Source icon, 1024x1024 PNG generated from logo.svg by scripts/setup-icons.sh
   image_path: "assets/icons/icon.png"
 
   android: "launcher_icon"
-  # Adaptive icon (Android 8+): dark background + centred foreground logo
+  # Adaptive icon (Android 8+): dark background + centred foreground logo.
+  # Keep the foreground inset at 0 so the logo fills Android's adaptive safe zone
+  # instead of being double-shrunk by the generated icon XML.
   adaptive_icon_background: "#0a0a0f"
   adaptive_icon_foreground: "assets/icons/adaptive-icon.png"
+  adaptive_icon_foreground_inset: 0
   min_sdk_android: 21
 
   ios: true

--- a/flutter_client/test/release/release_matrix_documentation_test.dart
+++ b/flutter_client/test/release/release_matrix_documentation_test.dart
@@ -137,7 +137,7 @@ void main() {
     final settingsGradle = readFile('android/settings.gradle.kts');
 
     // builtInKotlin=false keeps Flutter's own bundled packages (e.g. integration_test)
-    // working — they still declare org.jetbrains.kotlin.android explicitly and break
+    // working because they still declare org.jetbrains.kotlin.android explicitly and break
     // when AGP 9 enforces builtInKotlin=true.
     expect(gradleProperties, contains('android.builtInKotlin=false'));
     expect(gradleProperties, contains('android.newDsl=false'));
@@ -149,10 +149,18 @@ void main() {
 
     expect(manifest, contains('android.software.leanback'));
     expect(manifest, contains('android.hardware.touchscreen'));
+    final launcherIcon = readFile(
+      'android/app/src/main/res/mipmap-anydpi-v26/launcher_icon.xml',
+    );
+    final launcherIconConfig = readFile('flutter_launcher_icons.yaml');
+
     expect(manifest, contains('android:banner="@mipmap/ic_launcher"'));
     expect(manifest, contains('android:label="M3U TV"'));
     expect(manifest, contains('android.intent.category.LEANBACK_LAUNCHER'));
     expect(manifest, contains('android:exported="true"'));
+    expect(launcherIconConfig, contains('adaptive_icon_foreground_inset: 0'));
+    expect(launcherIcon, contains('android:inset="0%"'));
+    expect(launcherIcon, isNot(contains('android:inset="16%"')));
   });
 
   test('release matrix documents signing, store, and license gates', () {


### PR DESCRIPTION
## Summary
- Removes the generated Android adaptive icon foreground inset so the app logo fills the safe area better.
- Pins `adaptive_icon_foreground_inset: 0` in the launcher icon config so regeneration keeps the fix.
- Extends the release metadata test to catch the old 16 percent inset regression.

## Test plan
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test --concurrency=1`
- `flutter test test/release/release_matrix_documentation_test.dart --plain-name 'android manifest exposes Android TV launcher metadata'`

Closes #79
