### PR TITLE
feat: show favorite channels on home

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -21,6 +21,7 @@ import 'package:m3u_tv/navigation/route_names.dart';
 import 'package:m3u_tv/playback/playback_orchestrator.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/services/tv_notification_service.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
@@ -1265,6 +1266,7 @@ class _HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<_HomeScreen> {
+  Set<int> _favoriteChannelIds = {};
   Set<int> _favoriteVodIds = {};
   Set<int> _favoriteSeriesIds = {};
 
@@ -1275,15 +1277,21 @@ class _HomeScreenState extends State<_HomeScreen> {
   }
 
   Future<void> _loadFavorites() async {
-    final appState = widget.appState;
-    final vod = await appState.vodFavoritesService.all();
-    final series = await appState.seriesFavoritesService.all();
-    if (mounted) {
-      setState(() {
-        _favoriteVodIds = vod;
-        _favoriteSeriesIds = series;
-      });
+    Future<Set<int>> readFavorites(FavoritesService service) async {
+      try {
+        return await service.all();
+      } on Object catch (_) {
+        return <int>{};
+      }
     }
+
+    final appState = widget.appState;
+    final channels = await readFavorites(appState.favoritesService);
+    if (mounted) setState(() => _favoriteChannelIds = channels);
+    final vod = await readFavorites(appState.vodFavoritesService);
+    if (mounted) setState(() => _favoriteVodIds = vod);
+    final series = await readFavorites(appState.seriesFavoritesService);
+    if (mounted) setState(() => _favoriteSeriesIds = series);
   }
 
   @override
@@ -1307,28 +1315,35 @@ class _HomeScreenState extends State<_HomeScreen> {
       landscapeStyle: true,
       onSidebarActivate: widget.onSidebarActivate,
     );
+    MediaPreviewItem liveChannelItem(Channel channel) => MediaPreviewItem(
+      title: channel.name,
+      imageUrl: channel.logoUrl,
+      subtitle:
+          appState.epgService.lookupForChannel(channel)?.current.title ??
+          channel.groupTitle ??
+          'Live channel',
+      fallbackIcon: Icons.live_tv,
+      imageFit: BoxFit.contain,
+      imagePadding: const EdgeInsets.all(10),
+      imageBackgroundColor: Colors.transparent,
+      isFavorite: _favoriteChannelIds.contains(channel.id),
+      onTap: () => widget.onChannelSelect(channel),
+      onLongTap: () async {
+        await appState.favoritesService.toggle(channel.id);
+        await _loadFavorites();
+      },
+    );
+
+    final favoriteChannels = appState.channels
+        .where((channel) => _favoriteChannelIds.contains(channel.id))
+        .toList(growable: false);
     final liveSection = MediaPreviewSection(
-      title: 'Live TV',
-      emptyLabel: 'No Live TV available',
-      items: appState.channels
-          .map(
-            (channel) => MediaPreviewItem(
-              title: channel.name,
-              imageUrl: channel.logoUrl,
-              subtitle:
-                  appState.epgService
-                      .lookupForChannel(channel)
-                      ?.current
-                      .title ??
-                  channel.groupTitle ??
-                  'Live channel',
-              fallbackIcon: Icons.live_tv,
-              imageFit: BoxFit.contain,
-              imagePadding: const EdgeInsets.all(10),
-              imageBackgroundColor: Colors.transparent,
-              onTap: () => widget.onChannelSelect(channel),
-            ),
-          )
+      title: favoriteChannels.isEmpty ? 'Live TV' : 'Favorite Channels',
+      emptyLabel: favoriteChannels.isEmpty
+          ? 'No Live TV available'
+          : 'No favorite channels available',
+      items: (favoriteChannels.isEmpty ? appState.channels : favoriteChannels)
+          .map(liveChannelItem)
           .toList(growable: false),
       onSidebarActivate: widget.onSidebarActivate,
     );

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1328,18 +1328,12 @@ class _HomeScreenState extends State<_HomeScreen> {
 
   Future<void> _loadFavorites() async {
     final appState = widget.appState;
-    final results = await Future.wait([
-      appState.favoritesService.all(),
-      appState.vodFavoritesService.all(),
-      appState.seriesFavoritesService.all(),
-    ]);
-    if (mounted) {
-      setState(() {
-        _favoriteChannelIds = results[0];
-        _favoriteVodIds = results[1];
-        _favoriteSeriesIds = results[2];
-      });
-    }
+    final channels = await appState.favoritesService.all();
+    if (mounted) setState(() => _favoriteChannelIds = channels);
+    final vod = await appState.vodFavoritesService.all();
+    if (mounted) setState(() => _favoriteVodIds = vod);
+    final series = await appState.seriesFavoritesService.all();
+    if (mounted) setState(() => _favoriteSeriesIds = series);
   }
 
   @override

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -61,7 +61,18 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
   @override
   void initState() {
     super.initState();
+    widget.favoritesService.addListener(_onFavoritesChanged);
     unawaited(_initCategory());
+  }
+
+  @override
+  void dispose() {
+    widget.favoritesService.removeListener(_onFavoritesChanged);
+    super.dispose();
+  }
+
+  void _onFavoritesChanged() {
+    unawaited(_loadFavorites());
   }
 
   Future<void> _initCategory() async {

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -115,6 +115,8 @@
   "homeContinueWatching": "Weiterschauen",
   "homeNoContinueWatching": "Nichts zum Weiterschauen",
   "homeNoLiveTv": "Kein Live-TV verfügbar",
+  "homeFavoriteChannels": "Lieblingssender",
+  "homeNoFavoriteChannels": "Keine Lieblingssender verfügbar",
   "homeNoMovies": "Keine Filme verfügbar",
   "homeLiveChannel": "Live-Sender",
   "homeMovie": "Film",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -115,6 +115,8 @@
   "homeContinueWatching": "Continue Watching",
   "homeNoContinueWatching": "No Continue Watching available",
   "homeNoLiveTv": "No Live TV available",
+  "homeFavoriteChannels": "Favorite Channels",
+  "homeNoFavoriteChannels": "No favorite channels available",
   "homeNoMovies": "No Movies available",
   "homeLiveChannel": "Live channel",
   "homeMovie": "Movie",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -115,6 +115,8 @@
   "homeContinueWatching": "Continuar viendo",
   "homeNoContinueWatching": "Nada para continuar viendo",
   "homeNoLiveTv": "No hay Televisión en vivo disponible",
+  "homeFavoriteChannels": "Canales favoritos",
+  "homeNoFavoriteChannels": "No hay canales favoritos disponibles",
   "homeNoMovies": "No hay cine disponible",
   "homeLiveChannel": "Canal en vivo",
   "homeMovie": "Película",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -115,6 +115,8 @@
   "homeContinueWatching": "Reprendre",
   "homeNoContinueWatching": "Rien à reprendre",
   "homeNoLiveTv": "Pas de Télévision en direct disponible",
+  "homeFavoriteChannels": "Chaînes favorites",
+  "homeNoFavoriteChannels": "Aucune chaîne favorite disponible",
   "homeNoMovies": "Pas de films disponibles",
   "homeLiveChannel": "Chaîne en direct",
   "homeMovie": "Film",

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -584,6 +584,18 @@ abstract class AppLocalizations {
   /// **'No Live TV available'**
   String get homeNoLiveTv;
 
+  /// No description provided for @homeFavoriteChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite Channels'**
+  String get homeFavoriteChannels;
+
+  /// No description provided for @homeNoFavoriteChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'No favorite channels available'**
+  String get homeNoFavoriteChannels;
+
   /// No description provided for @homeNoMovies.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -264,6 +264,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get homeNoLiveTv => 'Kein Live-TV verfügbar';
 
   @override
+  String get homeFavoriteChannels => 'Lieblingssender';
+
+  @override
+  String get homeNoFavoriteChannels => 'Keine Lieblingssender verfügbar';
+
+  @override
   String get homeNoMovies => 'Keine Filme verfügbar';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -263,6 +263,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeNoLiveTv => 'No Live TV available';
 
   @override
+  String get homeFavoriteChannels => 'Favorite Channels';
+
+  @override
+  String get homeNoFavoriteChannels => 'No favorite channels available';
+
+  @override
   String get homeNoMovies => 'No Movies available';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -263,6 +263,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get homeNoLiveTv => 'No hay Televisión en vivo disponible';
 
   @override
+  String get homeFavoriteChannels => 'Canales favoritos';
+
+  @override
+  String get homeNoFavoriteChannels => 'No hay canales favoritos disponibles';
+
+  @override
   String get homeNoMovies => 'No hay cine disponible';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -263,6 +263,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get homeNoLiveTv => 'Pas de Télévision en direct disponible';
 
   @override
+  String get homeFavoriteChannels => 'Chaînes favorites';
+
+  @override
+  String get homeNoFavoriteChannels => 'Aucune chaîne favorite disponible';
+
+  @override
   String get homeNoMovies => 'Pas de films disponibles';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -259,6 +259,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get homeNoLiveTv => '暂无直播电视';
 
   @override
+  String get homeFavoriteChannels => '收藏频道';
+
+  @override
+  String get homeNoFavoriteChannels => '暂无收藏频道';
+
+  @override
   String get homeNoMovies => '暂无电影';
 
   @override

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -115,6 +115,8 @@
   "homeContinueWatching": "继续观看",
   "homeNoContinueWatching": "暂无可继续观看的内容",
   "homeNoLiveTv": "暂无直播电视",
+  "homeFavoriteChannels": "收藏频道",
+  "homeNoFavoriteChannels": "暂无收藏频道",
   "homeNoMovies": "暂无电影",
   "homeLiveChannel": "直播频道",
   "homeMovie": "电影",

--- a/flutter_client/lib/services/favorites_service.dart
+++ b/flutter_client/lib/services/favorites_service.dart
@@ -1,8 +1,9 @@
 // ignore_for_file: prefer_initializing_formals
 
+import 'package:flutter/foundation.dart';
 import 'package:m3u_tv/services/persistent_store.dart';
 
-class FavoritesService {
+class FavoritesService extends ChangeNotifier {
   FavoritesService({
     Map<String, Object?>? memory,
     PersistentJsonStore? store,
@@ -24,6 +25,7 @@ class FavoritesService {
     final ids = await all();
     ids.add(streamId);
     await _write(_favoritesKey, ids.toList()..sort());
+    notifyListeners();
     return true;
   }
 
@@ -31,6 +33,7 @@ class FavoritesService {
     final ids = await all();
     ids.remove(streamId);
     await _write(_favoritesKey, ids.toList()..sort());
+    notifyListeners();
     return false;
   }
 

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -115,6 +115,93 @@ void main() {
       },
     );
 
+    testWidgets('Home shows favorite live channels before full Live TV', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1600, 1800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final appState = _testAppState(
+        xtreamService: _NavigationXtreamService(
+          liveChannels: const <Channel>[
+            Channel(
+              id: 101,
+              name: 'Favorite Route News',
+              streamUrl: 'http://example.com/live/101.m3u8',
+              categoryId: 'live',
+            ),
+            Channel(
+              id: 102,
+              name: 'Regular Route Sports',
+              streamUrl: 'http://example.com/live/102.m3u8',
+              categoryId: 'live',
+            ),
+          ],
+        ),
+      );
+      addTearDown(appState.dispose);
+      await appState.connectXtream(
+        const UserCredentials(
+          server: 'http://example.com',
+          username: 'user',
+          password: 'pass',
+        ),
+      );
+      await appState.favoritesService.add(101);
+      expect(await appState.favoritesService.all(), contains(101));
+
+      await tester.pumpWidget(
+        _TestApp(deviceType: DeviceType.tv, appState: appState),
+      );
+      await _pumpAppFrame(tester);
+      await _waitForText(tester, 'Favorite Channels');
+
+      expect(find.text('Favorite Channels'), findsOneWidget);
+      expect(find.text('Favorite Route News'), findsOneWidget);
+      expect(find.text('Regular Route Sports'), findsNothing);
+    });
+
+    testWidgets('Home keeps full Live TV section when no favorites exist', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1600, 1800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final appState = _testAppState(
+        xtreamService: _NavigationXtreamService(
+          liveChannels: const <Channel>[
+            Channel(
+              id: 101,
+              name: 'Route News',
+              streamUrl: 'http://example.com/live/101.m3u8',
+              categoryId: 'live',
+            ),
+            Channel(
+              id: 102,
+              name: 'Route Sports',
+              streamUrl: 'http://example.com/live/102.m3u8',
+              categoryId: 'live',
+            ),
+          ],
+        ),
+      );
+      addTearDown(appState.dispose);
+      await appState.connectXtream(
+        const UserCredentials(
+          server: 'http://example.com',
+          username: 'user',
+          password: 'pass',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _TestApp(deviceType: DeviceType.tv, appState: appState),
+      );
+      await _pumpAppFrame(tester);
+
+      expect(find.text('Live TV'), findsAtLeast(1));
+      expect(find.text('Route News'), findsOneWidget);
+      expect(find.text('Route Sports'), findsOneWidget);
+    });
+
     testWidgets('navigating to LiveTV shows Live TV screen', (tester) async {
       await tester.pumpWidget(const _TestApp(deviceType: DeviceType.tv));
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- Shows favorite live channels as the primary Home live row when channel favorites exist.
- Keeps the existing full Live TV overview reachable from the Live TV navigation tab.
- Falls back to the current Live TV Home row when no channel favorites are set.
- Adds Home navigation regression coverage for both favorite and no-favorite states.

## Test plan
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test test/ui/navigation/navigation_test.dart --plain-name 'Home shows favorite live channels before full Live TV'`
- `flutter test test/ui/navigation/navigation_test.dart --plain-name 'Home keeps full Live TV section when no favorites exist'`
- `flutter test --concurrency=1`

Closes #82
