### PR TITLE
feat: send client playback capabilities to transcode

### DIFF
--- a/flutter_client/lib/playback/playback_orchestrator.dart
+++ b/flutter_client/lib/playback/playback_orchestrator.dart
@@ -340,6 +340,38 @@ class PlaybackOrchestrator {
       videoCodec: source.videoCodec,
       audioCodec: source.audioCodec,
       sessionId: source.metadata['transcode_session_id'] as String?,
+      clientCapabilities: _clientCapabilitiesForTranscode(),
+    );
+  }
+
+  ClientPlaybackCapabilities? _clientCapabilitiesForTranscode() {
+    for (final backend in _nativeBackends()) {
+      final capabilities = _adapters[backend]?.capabilities;
+      if (capabilities != null) {
+        return _clientCapabilitiesFromPlayback(capabilities);
+      }
+    }
+    return null;
+  }
+
+  ClientPlaybackCapabilities _clientCapabilitiesFromPlayback(
+    PlaybackCapabilities capabilities,
+  ) {
+    return ClientPlaybackCapabilities(
+      profile: capabilities.backend.name,
+      platform: capabilities.platform.name,
+      backend: capabilities.backend.name,
+      videoCodecs: capabilities.supportsAdvancedCodecs
+          ? const <String>['h264', 'h265', 'hevc', 'mpeg2video', 'vp9', 'av1']
+          : const <String>['h264'],
+      audioCodecs: capabilities.supportsAdvancedCodecs
+          ? const <String>['aac', 'mp3', 'ac3', 'eac3', 'dts', 'opus']
+          : const <String>['aac', 'mp3', 'ac3'],
+      containers: <String>[
+        if (capabilities.supportsHls) 'hls',
+        if (capabilities.supportsMpegTs) 'mpegts',
+        if (capabilities.supportsMp4) 'mp4',
+      ],
     );
   }
 

--- a/flutter_client/lib/transcoding/transcoding.dart
+++ b/flutter_client/lib/transcoding/transcoding.dart
@@ -37,6 +37,44 @@ enum BroadcastStatus {
   }
 }
 
+class ClientPlaybackCapabilities {
+  const ClientPlaybackCapabilities({
+    required this.profile,
+    required this.platform,
+    required this.backend,
+    this.videoCodecs = const <String>[],
+    this.audioCodecs = const <String>[],
+    this.containers = const <String>[],
+    this.maxHeight,
+    this.maxBitrateKbps,
+    this.hdr,
+  });
+
+  final String profile;
+  final String platform;
+  final String backend;
+  final List<String> videoCodecs;
+  final List<String> audioCodecs;
+  final List<String> containers;
+  final int? maxHeight;
+  final int? maxBitrateKbps;
+  final bool? hdr;
+
+  Map<String, Object?> toJson() {
+    return _withoutNulls(<String, Object?>{
+      'profile': profile,
+      'platform': platform,
+      'backend': backend,
+      'video_codecs': videoCodecs.isEmpty ? null : videoCodecs,
+      'audio_codecs': audioCodecs.isEmpty ? null : audioCodecs,
+      'containers': containers.isEmpty ? null : containers,
+      'max_height': maxHeight,
+      'max_bitrate_kbps': maxBitrateKbps,
+      'hdr': hdr,
+    });
+  }
+}
+
 class StreamRequest {
   const StreamRequest({
     required this.url,
@@ -52,6 +90,7 @@ class StreamRequest {
     this.videoCodec,
     this.audioCodec,
     this.sessionId,
+    this.clientCapabilities,
   });
 
   final String url;
@@ -67,6 +106,7 @@ class StreamRequest {
   final String? videoCodec;
   final String? audioCodec;
   final String? sessionId;
+  final ClientPlaybackCapabilities? clientCapabilities;
 
   Map<String, Object?> toJson() {
     return _withoutNulls(<String, Object?>{
@@ -83,6 +123,7 @@ class StreamRequest {
       'video_codec': videoCodec,
       'audio_codec': audioCodec,
       'session_id': sessionId,
+      'client_capabilities': clientCapabilities?.toJson(),
     });
   }
 }

--- a/flutter_client/test/playback/playback_orchestrator_test.dart
+++ b/flutter_client/test/playback/playback_orchestrator_test.dart
@@ -124,6 +124,17 @@ void main() {
 
         expect(transcode.startedServerRequests.single.videoCodec, 'hevc');
         expect(
+          transcode.startedServerRequests.single.clientCapabilities?.toJson(),
+          <String, Object?>{
+            'profile': 'androidExoPlayer',
+            'platform': 'android',
+            'backend': 'androidExoPlayer',
+            'video_codecs': <String>['h264'],
+            'audio_codecs': <String>['aac', 'mp3', 'ac3'],
+            'containers': <String>['hls', 'mpegts', 'mp4'],
+          },
+        );
+        expect(
           transcode.startedServerRequests.single.mode,
           TranscodeMode.server,
         );

--- a/flutter_client/test/transcoding/transcoding_contract_test.dart
+++ b/flutter_client/test/transcoding/transcoding_contract_test.dart
@@ -28,6 +28,14 @@ void main() {
         profile: 'h264-aac-720p',
         videoCodec: 'h264',
         audioCodec: 'aac',
+        clientCapabilities: ClientPlaybackCapabilities(
+          profile: 'android-tv-safe',
+          platform: 'android',
+          backend: 'androidExoPlayer',
+          videoCodecs: <String>['h264'],
+          audioCodecs: <String>['aac', 'ac3'],
+          containers: <String>['hls', 'mpegts'],
+        ),
       );
 
       expect(request.toJson(), <String, Object?>{
@@ -42,6 +50,14 @@ void main() {
         'profile': 'h264-aac-720p',
         'video_codec': 'h264',
         'audio_codec': 'aac',
+        'client_capabilities': <String, Object?>{
+          'profile': 'android-tv-safe',
+          'platform': 'android',
+          'backend': 'androidExoPlayer',
+          'video_codecs': <String>['h264'],
+          'audio_codecs': <String>['aac', 'ac3'],
+          'containers': <String>['hls', 'mpegts'],
+        },
       });
     });
 


### PR DESCRIPTION
## Summary
- Adds a `ClientPlaybackCapabilities` contract to transcode requests.
- Sends the current native playback backend profile, platform, supported video codecs, audio codecs, and containers when m3u-tv falls back to m3u-editor server transcode.
- Covers the serialized contract and the orchestrator handoff to the transcode gateway.

## Test plan
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test test/transcoding/transcoding_contract_test.dart test/playback/playback_orchestrator_test.dart`
- `flutter test --concurrency=1`

Closes #81

Backend companion: m3ue/m3u-editor#1241
