### PR TITLE
feat: Riverpod migration — all feature screens read via providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This is the TV frontend for the `m3u-editor` system. It focuses on video playbac
 ## Architecture
 
 - **Navigation**: `dpad` package v3 (Shortcuts + Actions based spatial traversal) + `Navigator` for in-content routing.
-- **State**: `ChangeNotifier` / `ListenableBuilder` via `AppStateController`.
+- **State**: Riverpod 2 (`flutter_riverpod`). Providers live in `lib/providers/app_providers.dart`. `AppStateController` is the underlying orchestrator — Riverpod owns a thin `_AppStateProxy` wrapper so widgets never reference `AppStateController` directly.
 - **Player**: `video_player` / platform player via `PlaybackOrchestrator`.
 - **UI**: Material 3, `DpadFocusable` for all interactive items, `DpadRegion` for focus grouping.
 
@@ -36,6 +36,49 @@ The app uses Flutter `gen_l10n`. All user-visible strings **must** be localized 
 - **Import order**: `package:m3u_tv/l10n/app_localizations.dart` sorts under `l10n/` — place it after all `features/` imports and before `navigation/` imports.
 - **Tests**: Every `MaterialApp` that renders a localized widget must include `localizationsDelegates: AppLocalizations.localizationsDelegates` and `supportedLocales: AppLocalizations.supportedLocales`.
 - **New keys**: Add to all five ARBs before running gen-l10n. Keys follow the `<screen><Concept>` pattern (e.g. `settingsAccount`, `liveTvRecord`).
+
+### State Management (Riverpod — mandatory for new features)
+
+The app uses Riverpod 2 for reactive UI state. All new feature screens must follow this pattern:
+
+**Reading data — always use providers, never `AppStateController` directly:**
+```dart
+class MyScreen extends ConsumerStatefulWidget { ... }
+class _MyScreenState extends ConsumerState<MyScreen> {
+  @override
+  Widget build(BuildContext context) {
+    final channels = ref.watch(liveChannelsProvider);   // ✓
+    // NOT: widget.appState.channels                    // ✗
+  }
+}
+```
+
+**Existing providers** (all in `lib/providers/app_providers.dart`):
+- Data: `liveChannelsProvider`, `liveCategoriesProvider`, `vodItemsProvider`, `vodCategoriesProvider`, `seriesListProvider`, `seriesCategoriesProvider`
+- Status: `isConfiguredProvider`, `isBootstrappingProvider`, `isLoadingContentProvider`
+- Services (stable, use `ref.read`): `epgServiceProvider`, `liveFavoritesServiceProvider`, `vodFavoritesServiceProvider`, `seriesFavoritesServiceProvider`
+- Home extras: `progressListProvider`, `dvrRecordingsProvider`, `sourceLabelProvider`, `sourceErrorProvider`, `hasDvrFeatureProvider`
+- Shell: `unreadNotificationCountProvider`
+
+**Adding a new provider** — add it to `app_providers.dart` using `ref.watch(appStateControllerProvider)` so it reacts to `AppStateController.notifyListeners()`:
+```dart
+final myNewProvider = Provider<MyType>((ref) {
+  return ref.watch(appStateControllerProvider).appState.myNewField;
+});
+```
+
+**Actions / mutations** still go through `AppStateController` directly (passed as callbacks from `AppShell`). Screens receive action callbacks as constructor params — they do not call `ref.read(appStateControllerProvider).appState.doSomething()`.
+
+**Tests** — wrap with `ProviderScope` and override only the providers the screen watches:
+```dart
+ProviderScope(
+  overrides: [
+    isConfiguredProvider.overrideWith((_) => true),
+    liveChannelsProvider.overrideWith((_) => fakeChannels),
+  ],
+  child: MaterialApp(home: MyScreen(...)),
+)
+```
 
 ### Style
 - Material 3 throughout. No `OutlinedButton` — use `FilledButton`, `FilledButton.tonal`, `FilledButton.icon`, or `FilledButton.tonalIcon`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,6 @@ class _MyScreenState extends ConsumerState<MyScreen> {
 - Status: `isConfiguredProvider`, `isBootstrappingProvider`, `isLoadingContentProvider`
 - Services (stable, use `ref.read`): `epgServiceProvider`, `liveFavoritesServiceProvider`, `vodFavoritesServiceProvider`, `seriesFavoritesServiceProvider`
 - Home extras: `progressListProvider`, `dvrRecordingsProvider`, `sourceLabelProvider`, `sourceErrorProvider`, `hasDvrFeatureProvider`
-- Shell: `unreadNotificationCountProvider`
 
 **Adding a new provider** — add it to `app_providers.dart` using `ref.watch(appStateControllerProvider)` so it reacts to `AppStateController.notifyListeners()`:
 ```dart

--- a/flutter_client/README.md
+++ b/flutter_client/README.md
@@ -208,7 +208,8 @@ lib/
   l10n/           ARB source files + generated AppLocalizations
   navigation/     Router, route names, PlayerArgs
   playback/       Platform playback adapters and orchestrator
-  services/       Domain models, Xtream API, EPG, state controller
+  providers/      Riverpod providers (app_providers.dart — single source of truth)
+  services/       Domain models, Xtream API, EPG, AppStateController
   shared/         Reusable UI widgets
 tvos/             Apple TV (tvOS) Xcode runner
 ios/              iOS Xcode runner
@@ -216,6 +217,20 @@ android/          Android Gradle project
 packages/         Local Flutter packages (flutter_secure_storage_tvos, …)
 test/             Unit and widget tests
 ```
+
+## State architecture
+
+State is managed with **Riverpod 2**. The key split:
+
+| Concern | Who handles it |
+|---|---|
+| Reactive data reads (channels, isConfigured, etc.) | Riverpod providers in `lib/providers/app_providers.dart` |
+| Business logic / mutations (connect, disconnect, etc.) | `AppStateController` — called via callbacks passed from `AppShell` |
+| Service instances (EPG, favorites, etc.) | `AppStateController` owns them; providers expose stable refs via `ref.read` |
+
+**The rule:** feature screens extend `ConsumerStatefulWidget` and read all display data via `ref.watch(someProvider)`. They never hold or accept an `AppStateController` reference. Actions arrive as typed callbacks in the constructor.
+
+See `CLAUDE.md` for the full provider list and the test pattern.
 
 ## Localization
 

--- a/flutter_client/android/app/src/main/AndroidManifest.xml
+++ b/flutter_client/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,13 @@
     <uses-feature android:name="android.software.leanback" android:required="false"/>
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
 
+    <supports-screens
+        android:smallScreens="true"
+        android:normalScreens="true"
+        android:largeScreens="true"
+        android:xlargeScreens="true"
+        android:anyDensity="true" />
+
     <application
         android:label="M3U TV"
         android:name="${applicationName}"

--- a/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/MainActivity.kt
+++ b/flutter_client/android/app/src/main/kotlin/dev/sparkison/tv/MainActivity.kt
@@ -4,6 +4,7 @@ import android.app.UiModeManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.util.DisplayMetrics
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -11,6 +12,34 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : FlutterActivity() {
     private var media3Plugin: Media3PlaybackPlugin? = null
     private var deviceInfoChannel: MethodChannel? = null
+
+    override fun attachBaseContext(newBase: Context) {
+        val uiModeManager = newBase.getSystemService(Context.UI_MODE_SERVICE) as? UiModeManager
+        val isTV = uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION ||
+            newBase.packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+
+        val override = if (isTV) {
+            val res = newBase.resources.configuration
+            // Recover physical pixel width from dp + current density (safe in attachBaseContext).
+            val physicalWidth = maxOf(
+                (res.screenWidthDp * res.densityDpi / 160f).toInt(),
+                (res.screenHeightDp * res.densityDpi / 160f).toInt(),
+            )
+            // Target 1920 logical pixels wide (standard 1080p TV layout target).
+            // For 1080p physical this gives 1:1 (160dpi); for 4K it gives 2:1 (320dpi).
+            val targetDensityDpi = if (physicalWidth > 0) {
+                ((physicalWidth / 1920f) * 160).toInt().coerceIn(160, 640)
+            } else {
+                DisplayMetrics.DENSITY_TV
+            }
+            val config = Configuration(res)
+            config.densityDpi = targetDensityDpi
+            newBase.createConfigurationContext(config)
+        } else {
+            newBase
+        }
+        super.attachBaseContext(override)
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)

--- a/flutter_client/android/app/src/main/res/values-night-v31/styles.xml
+++ b/flutter_client/android/app/src/main/res/values-night-v31/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="LaunchTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <item name="android:forceDarkAllowed">false</item>
         <item name="android:windowFullscreen">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">false</item>
@@ -16,7 +16,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="NormalTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/flutter_client/android/app/src/main/res/values-night/styles.xml
+++ b/flutter_client/android/app/src/main/res/values-night/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is on -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="LaunchTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
@@ -16,7 +16,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="NormalTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/flutter_client/android/app/src/main/res/values-v31/styles.xml
+++ b/flutter_client/android/app/src/main/res/values-v31/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="LaunchTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <item name="android:forceDarkAllowed">false</item>
         <item name="android:windowFullscreen">false</item>
         <item name="android:windowDrawsSystemBarBackgrounds">false</item>
@@ -16,7 +16,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/flutter_client/android/app/src/main/res/values/styles.xml
+++ b/flutter_client/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting when the OS's Dark Mode setting is off -->
-    <style name="LaunchTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="LaunchTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <!-- Show a splash screen on the activity. Automatically removed when
              the Flutter engine draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
@@ -16,7 +16,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -673,6 +673,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    _syncSidebarFocusNodes();
     final useSidebar = shouldUseSidebar(widget.deviceType);
 
     final contentShell = ContentActions(

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -28,6 +28,7 @@ import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/aiostreams_api_service.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/services/tv_notification_service.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
@@ -79,7 +80,8 @@ class AppShell extends ConsumerStatefulWidget {
   ConsumerState<AppShell> createState() => AppShellState();
 }
 
-class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver {
+class AppShellState extends ConsumerState<AppShell>
+    with WidgetsBindingObserver {
   bool _sidebarActive = false;
   late final AppStateController _appState;
   late final bool _ownsAppState;
@@ -548,138 +550,120 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
   }
 
   Widget _buildTabScreen(String routeName) {
-    return ListenableBuilder(
-      listenable: _appState,
-      builder: (context, _) {
-        if (_appState.isBootstrapping) {
-          return const Scaffold(
-            body: Center(child: CircularProgressIndicator()),
-          );
-        }
-        return switch (routeName) {
-          RouteNames.home => _HomeScreen(
-            appState: _appState,
-            onChannelSelect: _openChannel,
-            onVodSelect: _openVod,
-            onSeriesSelect: _openSeries,
-            onProgressSelect: _openProgress,
-            onRecordingsSelect: () => _navigateToRoute(RouteNames.dvr),
-            onAioStreamsItemSelect: (item, integrationId) => unawaited(
-              _pushDetail(
-                RouteNames.aiostreamsDetailsFor(
-                  integrationId,
-                  item.type,
-                  item.id,
-                ),
-                extra: item,
-              ),
+    return switch (routeName) {
+      RouteNames.home => _HomeScreen(
+        onChannelSelect: _openChannel,
+        onVodSelect: _openVod,
+        onSeriesSelect: _openSeries,
+        onProgressSelect: _openProgress,
+        onRecordingsSelect: () => _navigateToRoute(RouteNames.dvr),
+        onAioStreamsItemSelect: (item, integrationId) => unawaited(
+          _pushDetail(
+            RouteNames.aiostreamsDetailsFor(
+              integrationId,
+              item.type,
+              item.id,
             ),
-            onSidebarActivate: _activateSidebar,
+            extra: item,
           ),
-          RouteNames.search => SearchScreen(
-            channels: _appState.channels,
-            vodItems: _appState.vodItems,
-            seriesList: _appState.seriesList,
-            isConfigured: _appState.isConfigured,
-            onChannelSelect: _openChannel,
-            onVodSelect: _openVod,
-            onSeriesSelect: _openSeries,
-            onSidebarActivate: _activateSidebar,
-          ),
-          RouteNames.liveTv => LiveTvScreen(
-            channels: _appState.channels,
-            categories: _appState.liveCategories,
-            isLoading: _appState.isLoadingContent,
-            isConfigured: _appState.isConfigured,
-            favoritesService: _appState.favoritesService,
-            epgService: _appState.epgService,
-            onChannelSelect: _openChannel,
-            onCatchupProgramSelect: _openCatchupProgram,
-            onSidebarActivate: _activateSidebar,
-            onScheduleProgram: (channel, program) =>
-                unawaited(_scheduleDvr(context, channel, program)),
-          ),
-          RouteNames.vod => VodScreen(
-            vodItems: _appState.vodItems,
-            categories: _appState.vodCategories,
-            isLoading: _appState.isLoadingContent,
-            isConfigured: _appState.isConfigured,
-            onVodSelect: _openVod,
-            favoritesService: _appState.vodFavoritesService,
-            onSidebarActivate: _activateSidebar,
-          ),
-          RouteNames.series => SeriesScreen(
-            seriesList: _appState.seriesList,
-            categories: _appState.seriesCategories,
-            isLoading: _appState.isLoadingContent,
-            isConfigured: _appState.isConfigured,
-            onSeriesSelect: _openSeries,
-            favoritesService: _appState.seriesFavoritesService,
-            onSidebarActivate: _activateSidebar,
-          ),
-          RouteNames.aiostreams => AIOStreamsHomeScreen(
-            integrations: _appState.aiostreamsIntegrations,
-            apiService: _appState.aiostreamsApiService,
-            onItemSelect: (item, integrationId) => unawaited(
-              _pushDetail(
-                RouteNames.aiostreamsDetailsFor(
-                  integrationId,
-                  item.type,
-                  item.id,
-                ),
-                extra: item,
-              ),
+        ),
+        onSidebarActivate: _activateSidebar,
+      ),
+      RouteNames.search => SearchScreen(
+        onChannelSelect: _openChannel,
+        onVodSelect: _openVod,
+        onSeriesSelect: _openSeries,
+        onSidebarActivate: _activateSidebar,
+      ),
+      RouteNames.liveTv => LiveTvScreen(
+        favoritesService: _appState.favoritesService,
+        onChannelSelect: _openChannel,
+        onCatchupProgramSelect: _openCatchupProgram,
+        onSidebarActivate: _activateSidebar,
+        onScheduleProgram: (channel, program) =>
+            unawaited(_scheduleDvr(context, channel, program)),
+      ),
+      RouteNames.vod => VodScreen(
+        onVodSelect: _openVod,
+        favoritesService: _appState.vodFavoritesService,
+        onSidebarActivate: _activateSidebar,
+      ),
+      RouteNames.series => SeriesScreen(
+        onSeriesSelect: _openSeries,
+        favoritesService: _appState.seriesFavoritesService,
+        onSidebarActivate: _activateSidebar,
+      ),
+      RouteNames.aiostreams => AIOStreamsHomeScreen(
+        integrations: _appState.aiostreamsIntegrations,
+        apiService: _appState.aiostreamsApiService,
+        onItemSelect: (item, integrationId) => unawaited(
+          _pushDetail(
+            RouteNames.aiostreamsDetailsFor(
+              integrationId,
+              item.type,
+              item.id,
             ),
-            onPlay: _openPlayerFromActions,
-            favoritesService: _appState.aioFavoritesService,
-            progressList: _appState.progressList,
-            onSidebarActivate: _activateSidebar,
+            extra: item,
           ),
-          RouteNames.dvr => DvrRecordingsScreen(
-            recordings: _appState.dvrRecordings,
-            isLoading: _appState.isLoadingContent,
-            isConfigured: _appState.isConfigured,
-            onPlay: _openPlayerDirect,
-            onSidebarActivate: _activateSidebar,
-          ),
-          RouteNames.requests => RequestScreen(
-            isConfigured: _appState.isConfigured,
-            onSidebarActivate: _activateSidebar,
-          ),
-          RouteNames.notifications => NotificationsScreen(appState: _appState),
-          RouteNames.settings => SettingsScreen(
-            authNotifier: _appState.authNotifier,
-            activeViewer: _appState.activeViewer,
-            viewers: _appState.viewers,
-            sourceLabel: _appState.sourceLabel,
-            sourceError: _appState.error,
-            isConfiguredOverride: _appState.isConfigured,
-            epgRefreshInterval: _appState.epgRefreshInterval,
-            epgRefreshOptions: AppStateController.epgRefreshOptions,
-            traktService: _appState.traktService,
-            onConnect: _appState.connectXtream,
-            onDisconnect: () => unawaited(_appState.disconnect()),
-            onSwitchViewer: (viewer) =>
-                unawaited(_appState.switchViewer(viewer)),
-            onCreateViewer: _appState.createViewer,
-            onClearCache: () => unawaited(_appState.clearAndRefresh()),
-            onEpgIntervalChanged: (d) =>
-                unawaited(_appState.setEpgRefreshInterval(d)),
-            onConnected: () => _navigateTo(0),
-            locale: _appState.locale,
-            onLocaleChanged: (locale) => unawaited(_appState.setLocale(locale)),
-          ),
-          _ => const PlaceholderScreen(title: 'Home'),
-        };
-      },
-    );
+        ),
+        onPlay: _openPlayerFromActions,
+        favoritesService: _appState.aioFavoritesService,
+        progressList: _appState.progressList,
+        onSidebarActivate: _activateSidebar,
+      ),
+      RouteNames.dvr => ListenableBuilder(
+        listenable: _appState,
+        builder: (_, _) => DvrRecordingsScreen(
+          recordings: _appState.dvrRecordings,
+          isLoading: _appState.isLoadingContent,
+          isConfigured: _appState.isConfigured,
+          onPlay: _openPlayerDirect,
+          onSidebarActivate: _activateSidebar,
+        ),
+      ),
+      RouteNames.requests => ListenableBuilder(
+        listenable: _appState,
+        builder: (_, _) => RequestScreen(
+          isConfigured: _appState.isConfigured,
+          onSidebarActivate: _activateSidebar,
+        ),
+      ),
+      RouteNames.notifications => NotificationsScreen(appState: _appState),
+      RouteNames.settings => ListenableBuilder(
+        listenable: _appState,
+        builder: (_, _) => SettingsScreen(
+          authNotifier: _appState.authNotifier,
+          activeViewer: _appState.activeViewer,
+          viewers: _appState.viewers,
+          sourceLabel: _appState.sourceLabel,
+          sourceError: _appState.error,
+          isConfiguredOverride: _appState.isConfigured,
+          epgRefreshInterval: _appState.epgRefreshInterval,
+          epgRefreshOptions: AppStateController.epgRefreshOptions,
+          traktService: _appState.traktService,
+          onConnect: _appState.connectXtream,
+          onDisconnect: () => unawaited(_appState.disconnect()),
+          onSwitchViewer: (viewer) => unawaited(_appState.switchViewer(viewer)),
+          onCreateViewer: _appState.createViewer,
+          onClearCache: () => unawaited(_appState.clearAndRefresh()),
+          onEpgIntervalChanged: (d) =>
+              unawaited(_appState.setEpgRefreshInterval(d)),
+          onConnected: () => _navigateTo(0),
+          locale: _appState.locale,
+          onLocaleChanged: (locale) => unawaited(_appState.setLocale(locale)),
+        ),
+      ),
+      _ => const PlaceholderScreen(title: 'Home'),
+    };
   }
 
   @override
   Widget build(BuildContext context) {
-    // Subscribe to AppStateController so this build re-runs whenever
-    // notifyListeners fires — replaces the setState in _onAppStateChanged.
-    ref.watch(appStateControllerProvider);
+    // Watch only what AppShell.build() actually uses:
+    //   isConfigured  → recalculates feature-flag-gated routes on connect/disconnect
+    //   unreadCount   → drives notification badge without full-screen rebuilds
+    ref.watch(isConfiguredProvider);
+    final unreadCount = ref.watch(unreadNotificationCountProvider);
 
     final routes = _mainRoutes;
     _syncSidebarFocusNodes(routes);
@@ -726,8 +710,8 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
             return KeyEventResult.ignored;
           },
           child: useSidebar
-              ? _buildTvLayout(contentShell, routes)
-              : _buildMobileLayout(contentShell, routes),
+              ? _buildTvLayout(contentShell, routes, unreadCount)
+              : _buildMobileLayout(contentShell, routes, unreadCount),
         ),
       ),
     );
@@ -879,7 +863,11 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
     );
   }
 
-  Widget _buildTvLayout(Widget contentShell, List<String> routes) {
+  Widget _buildTvLayout(
+    Widget contentShell,
+    List<String> routes,
+    int unreadCount,
+  ) {
     return MediaQuery.removePadding(
       context: context,
       removeTop: true,
@@ -921,7 +909,7 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
                     sidebarActive: _sidebarActive,
                     focusNodes: _sidebarFocusNodes,
                     scopeNode: _sidebarScopeNode,
-                    unreadNotificationCount: _appState.unreadNotificationCount,
+                    unreadNotificationCount: unreadCount,
                     onNavigate: _navigateTo,
                     onActivateSidebar: _activateSidebar,
                     onDeactivateSidebar: _deactivateSidebar,
@@ -935,14 +923,18 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
     );
   }
 
-  Widget _buildMobileLayout(Widget contentShell, List<String> routes) {
+  Widget _buildMobileLayout(
+    Widget contentShell,
+    List<String> routes,
+    int unreadCount,
+  ) {
     final primaryCount = RouteNames.mobilePrimaryCount.clamp(
       0,
       routes.length,
     );
     final overflowRoutes = routes.skip(primaryCount).toList();
     final overflowUnread = overflowRoutes.contains(RouteNames.notifications)
-        ? _appState.unreadNotificationCount
+        ? unreadCount
         : 0;
     final moreTabIndex = primaryCount;
     final displayedIndex = _currentIndex < primaryCount
@@ -955,7 +947,7 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
         type: BottomNavigationBarType.fixed,
         currentIndex: displayedIndex,
         onTap: (index) => index == moreTabIndex
-            ? _showMoreSheet(overflowRoutes, primaryCount)
+            ? _showMoreSheet(overflowRoutes, primaryCount, unreadCount)
             : _navigateTo(index),
         selectedItemColor: Theme.of(context).colorScheme.primary,
         unselectedItemColor: Theme.of(context).colorScheme.onSurfaceVariant,
@@ -983,6 +975,7 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
   Future<void> _showMoreSheet(
     List<String> overflowRoutes,
     int primaryCount,
+    int unreadCount,
   ) async {
     // Return the chosen index and navigate after the sheet is fully dismissed.
     // Calling _navigateTo synchronously inside ListTile.onTap while the sheet
@@ -999,8 +992,8 @@ class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver 
                 leading: Badge(
                   isLabelVisible:
                       overflowRoutes[i] == RouteNames.notifications &&
-                      _appState.unreadNotificationCount > 0,
-                  label: Text('${_appState.unreadNotificationCount}'),
+                      unreadCount > 0,
+                  label: Text('$unreadCount'),
                   child: Icon(_routeIcon(overflowRoutes[i])),
                 ),
                 title: Text(_routeLabel(sheetContext, overflowRoutes[i])),
@@ -1376,9 +1369,8 @@ class _OfflineBanner extends StatelessWidget {
   }
 }
 
-class _HomeScreen extends StatefulWidget {
+class _HomeScreen extends ConsumerStatefulWidget {
   const _HomeScreen({
-    required this.appState,
     required this.onChannelSelect,
     required this.onVodSelect,
     required this.onSeriesSelect,
@@ -1388,7 +1380,6 @@ class _HomeScreen extends StatefulWidget {
     this.onSidebarActivate,
   });
 
-  final AppStateController appState;
   final void Function(Channel) onChannelSelect;
   final void Function(VodItem) onVodSelect;
   final void Function(Series) onSeriesSelect;
@@ -1398,24 +1389,31 @@ class _HomeScreen extends StatefulWidget {
   final VoidCallback? onSidebarActivate;
 
   @override
-  State<_HomeScreen> createState() => _HomeScreenState();
+  ConsumerState<_HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<_HomeScreen> {
+class _HomeScreenState extends ConsumerState<_HomeScreen> {
   Set<int> _favoriteChannelIds = {};
   Set<int> _favoriteVodIds = {};
   Set<int> _favoriteSeriesIds = {};
 
+  late final FavoritesService _liveFavoritesService;
+  late final FavoritesService _vodFavoritesService;
+  late final FavoritesService _seriesFavoritesService;
+
   @override
   void initState() {
     super.initState();
-    widget.appState.favoritesService.addListener(_onChannelFavoritesChanged);
+    _liveFavoritesService = ref.read(liveFavoritesServiceProvider);
+    _vodFavoritesService = ref.read(vodFavoritesServiceProvider);
+    _seriesFavoritesService = ref.read(seriesFavoritesServiceProvider);
+    _liveFavoritesService.addListener(_onChannelFavoritesChanged);
     unawaited(_loadFavorites());
   }
 
   @override
   void dispose() {
-    widget.appState.favoritesService.removeListener(_onChannelFavoritesChanged);
+    _liveFavoritesService.removeListener(_onChannelFavoritesChanged);
     super.dispose();
   }
 
@@ -1424,24 +1422,38 @@ class _HomeScreenState extends State<_HomeScreen> {
   }
 
   Future<void> _loadChannelFavorites() async {
-    final ids = await widget.appState.favoritesService.all();
+    final ids = await _liveFavoritesService.all();
     if (mounted) setState(() => _favoriteChannelIds = ids);
   }
 
   Future<void> _loadFavorites() async {
-    final appState = widget.appState;
-    final channels = await appState.favoritesService.all();
-    if (mounted) setState(() => _favoriteChannelIds = channels);
-    final vod = await appState.vodFavoritesService.all();
+    final live = await _liveFavoritesService.all();
+    if (mounted) setState(() => _favoriteChannelIds = live);
+    final vod = await _vodFavoritesService.all();
     if (mounted) setState(() => _favoriteVodIds = vod);
-    final series = await appState.seriesFavoritesService.all();
+    final series = await _seriesFavoritesService.all();
     if (mounted) setState(() => _favoriteSeriesIds = series);
   }
 
   @override
   Widget build(BuildContext context) {
-    final appState = widget.appState;
-    if (!appState.isConfigured) {
+    final isBootstrapping = ref.watch(isBootstrappingProvider);
+    final isConfigured = ref.watch(isConfiguredProvider);
+    final progressList = ref.watch(progressListProvider);
+    final channels = ref.watch(liveChannelsProvider);
+    final vodItems = ref.watch(vodItemsProvider);
+    final seriesList = ref.watch(seriesListProvider);
+    final epgService = ref.watch(epgServiceProvider);
+    final dvrRecordings = ref.watch(dvrRecordingsProvider);
+    final sourceLabel = ref.watch(sourceLabelProvider);
+    final sourceError = ref.watch(sourceErrorProvider);
+    final hasDvrFeature = ref.watch(hasDvrFeatureProvider);
+
+    if (isBootstrapping) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    if (!isConfigured) {
       return Scaffold(
         body: Center(
           child: Text(AppLocalizations.of(context).appNotConfigured),
@@ -1450,9 +1462,9 @@ class _HomeScreenState extends State<_HomeScreen> {
     }
 
     final l = AppLocalizations.of(context);
-    final continueWatchingItems = appState.progressList
+    final continueWatchingItems = progressList
         .where(_isResumeEligible)
-        .map(_resumePreviewItem)
+        .map((p) => _resumePreviewItem(p, vodItems, seriesList))
         .whereType<MediaPreviewItem>()
         .toList(growable: false);
     final continueWatchingSection = MediaPreviewSection(
@@ -1466,7 +1478,7 @@ class _HomeScreenState extends State<_HomeScreen> {
       title: channel.name,
       imageUrl: channel.logoUrl,
       subtitle:
-          appState.epgService.lookupForChannel(channel)?.current.title ??
+          epgService.lookupForChannel(channel)?.current.title ??
           channel.groupTitle ??
           l.homeLiveChannel,
       fallbackIcon: Icons.live_tv,
@@ -1476,18 +1488,18 @@ class _HomeScreenState extends State<_HomeScreen> {
       isFavorite: _favoriteChannelIds.contains(channel.id),
       onTap: () => widget.onChannelSelect(channel),
       onLongTap: () async {
-        await appState.favoritesService.toggle(channel.id);
+        await _liveFavoritesService.toggle(channel.id);
         await _loadFavorites();
       },
     );
 
-    final favoriteChannels = appState.channels
+    final favoriteChannels = channels
         .where((channel) => _favoriteChannelIds.contains(channel.id))
         .toList(growable: false);
     final liveSection = MediaPreviewSection(
       title: favoriteChannels.isEmpty ? l.navLiveTv : l.homeFavoriteChannels,
       emptyLabel: l.homeNoLiveTv,
-      items: (favoriteChannels.isEmpty ? appState.channels : favoriteChannels)
+      items: (favoriteChannels.isEmpty ? channels : favoriteChannels)
           .map(liveChannelItem)
           .toList(growable: false),
       onSidebarActivate: widget.onSidebarActivate,
@@ -1496,7 +1508,7 @@ class _HomeScreenState extends State<_HomeScreen> {
       title: l.navVod,
       emptyLabel: l.homeNoMovies,
       posterStyle: true,
-      items: appState.vodItems
+      items: vodItems
           .map(
             (item) => MediaPreviewItem(
               title: item.name,
@@ -1507,7 +1519,7 @@ class _HomeScreenState extends State<_HomeScreen> {
               isFavorite: _favoriteVodIds.contains(item.id),
               onTap: () => widget.onVodSelect(item),
               onLongTap: () async {
-                await appState.vodFavoritesService.toggle(item.id);
+                await _vodFavoritesService.toggle(item.id);
                 await _loadFavorites();
               },
             ),
@@ -1519,7 +1531,7 @@ class _HomeScreenState extends State<_HomeScreen> {
       title: l.navSeries,
       emptyLabel: l.homeNoSeries,
       posterStyle: true,
-      items: appState.seriesList
+      items: seriesList
           .map(
             (series) => MediaPreviewItem(
               title: series.name,
@@ -1532,7 +1544,7 @@ class _HomeScreenState extends State<_HomeScreen> {
               isFavorite: _favoriteSeriesIds.contains(series.id),
               onTap: () => widget.onSeriesSelect(series),
               onLongTap: () async {
-                await appState.seriesFavoritesService.toggle(series.id);
+                await _seriesFavoritesService.toggle(series.id);
                 await _loadFavorites();
               },
             ),
@@ -1546,9 +1558,9 @@ class _HomeScreenState extends State<_HomeScreen> {
       items: [
         MediaPreviewItem(
           title: 'DVR Recordings',
-          subtitle: appState.dvrRecordings.isEmpty
+          subtitle: dvrRecordings.isEmpty
               ? 'Browse completed and in-progress recordings'
-              : '${appState.dvrRecordings.length} recordings',
+              : '${dvrRecordings.length} recordings',
           fallbackIcon: Icons.video_library,
           onTap: () => widget.onRecordingsSelect(),
         ),
@@ -1564,17 +1576,17 @@ class _HomeScreenState extends State<_HomeScreen> {
             style: Theme.of(context).textTheme.headlineMedium,
           ),
           const SizedBox(height: MediaBrowsingMetrics.chipGap),
-          Text(l.homeConnectedSource(appState.sourceLabel)),
-          if (appState.error != null && appState.error!.isNotEmpty) ...[
+          Text(l.homeConnectedSource(sourceLabel)),
+          if (sourceError != null && sourceError.isNotEmpty) ...[
             const SizedBox(height: MediaBrowsingMetrics.chipGap),
-            _OfflineBanner(message: appState.error!),
+            _OfflineBanner(message: sourceError),
           ],
           const SizedBox(height: MediaBrowsingMetrics.pagePadding),
           if (continueWatchingItems.isNotEmpty) continueWatchingSection,
           liveSection,
           moviesSection,
           seriesSection,
-          if (appState.hasDvrFeature) recordingsSection,
+          if (hasDvrFeature) recordingsSection,
         ],
       ),
     );
@@ -1586,7 +1598,11 @@ class _HomeScreenState extends State<_HomeScreen> {
         !progress.completed;
   }
 
-  MediaPreviewItem? _resumePreviewItem(Progress progress) {
+  MediaPreviewItem? _resumePreviewItem(
+    Progress progress,
+    List<VodItem> vodItems,
+    List<Series> seriesList,
+  ) {
     if (progress.contentType == ContentType.vod) {
       if (progress.title != null) {
         final hasBackdrop = progress.backdropUrl != null;
@@ -1602,7 +1618,7 @@ class _HomeScreenState extends State<_HomeScreen> {
             ? (plot.length > 120 ? '${plot.substring(0, 117)}…' : plot)
             : null;
         final vodFallbackLogo = (!hasBackdrop && progress.thumbnailUrl == null)
-            ? widget.appState.vodItems
+            ? vodItems
                   .firstWhereOrNull((v) => v.id == progress.streamId)
                   ?.logoUrl
             : null;
@@ -1624,7 +1640,7 @@ class _HomeScreenState extends State<_HomeScreen> {
           onTap: () => widget.onProgressSelect(progress),
         );
       }
-      final item = widget.appState.vodItems.firstWhereOrNull(
+      final item = vodItems.firstWhereOrNull(
         (item) => item.id == progress.streamId,
       );
       if (item == null) return null;
@@ -1666,7 +1682,7 @@ class _HomeScreenState extends State<_HomeScreen> {
             (progress.seasonNumber != null
                 ? 'Season ${progress.seasonNumber}'
                 : null);
-        final seriesFallback = widget.appState.seriesList.firstWhereOrNull(
+        final seriesFallback = seriesList.firstWhereOrNull(
           (s) => s.id == progress.seriesId,
         );
         return MediaPreviewItem(
@@ -1691,7 +1707,7 @@ class _HomeScreenState extends State<_HomeScreen> {
         );
       }
       if (progress.seriesId != null) {
-        final series = widget.appState.seriesList.firstWhereOrNull(
+        final series = seriesList.firstWhereOrNull(
           (series) => series.id == progress.seriesId,
         );
         if (series == null) return null;

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -168,6 +168,7 @@ class AppShellState extends ConsumerState<AppShell>
 
   void _syncSidebarFocusNodes([List<String>? routes]) {
     final r = routes ?? _mainRoutes;
+    if (_sidebarFocusNodes.length == r.length) return;
     while (_sidebarFocusNodes.length < r.length) {
       _sidebarFocusNodes.add(FocusNode());
     }
@@ -593,23 +594,26 @@ class AppShellState extends ConsumerState<AppShell>
         favoritesService: _appState.seriesFavoritesService,
         onSidebarActivate: _activateSidebar,
       ),
-      RouteNames.aiostreams => AIOStreamsHomeScreen(
-        integrations: _appState.aiostreamsIntegrations,
-        apiService: _appState.aiostreamsApiService,
-        onItemSelect: (item, integrationId) => unawaited(
-          _pushDetail(
-            RouteNames.aiostreamsDetailsFor(
-              integrationId,
-              item.type,
-              item.id,
+      RouteNames.aiostreams => ListenableBuilder(
+        listenable: _appState,
+        builder: (_, _) => AIOStreamsHomeScreen(
+          integrations: _appState.aiostreamsIntegrations,
+          apiService: _appState.aiostreamsApiService,
+          onItemSelect: (item, integrationId) => unawaited(
+            _pushDetail(
+              RouteNames.aiostreamsDetailsFor(
+                integrationId,
+                item.type,
+                item.id,
+              ),
+              extra: item,
             ),
-            extra: item,
           ),
+          onPlay: _openPlayerFromActions,
+          favoritesService: _appState.aioFavoritesService,
+          progressList: _appState.progressList,
+          onSidebarActivate: _activateSidebar,
         ),
-        onPlay: _openPlayerFromActions,
-        favoritesService: _appState.aioFavoritesService,
-        progressList: _appState.progressList,
-        onSidebarActivate: _activateSidebar,
       ),
       RouteNames.dvr => ListenableBuilder(
         listenable: _appState,

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1564,17 +1564,6 @@ class _HomeScreenState extends State<_HomeScreen> {
           liveSection,
           moviesSection,
           seriesSection,
-          if (appState.hasAioStreams)
-            for (final integration in appState.aiostreamsIntegrations)
-              for (final catalog in integration.catalogs)
-                AIOStreamsCatalogRow(
-                  catalog: catalog,
-                  integrationId: integration.id,
-                  apiService: appState.aiostreamsApiService,
-                  onItemSelect: (item) =>
-                      widget.onAioStreamsItemSelect(item, integration.id),
-                  onSidebarActivate: widget.onSidebarActivate,
-                ),
           if (appState.hasDvrFeature) recordingsSection,
         ],
       ),

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -161,11 +161,12 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     _syncSidebarFocusNodes();
   }
 
-  void _syncSidebarFocusNodes() {
-    while (_sidebarFocusNodes.length < _mainRoutes.length) {
+  void _syncSidebarFocusNodes([List<String>? routes]) {
+    final r = routes ?? _mainRoutes;
+    while (_sidebarFocusNodes.length < r.length) {
       _sidebarFocusNodes.add(FocusNode());
     }
-    while (_sidebarFocusNodes.length > _mainRoutes.length) {
+    while (_sidebarFocusNodes.length > r.length) {
       _sidebarFocusNodes.removeLast().dispose();
     }
   }
@@ -673,7 +674,8 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
-    _syncSidebarFocusNodes();
+    final routes = _mainRoutes;
+    _syncSidebarFocusNodes(routes);
     final useSidebar = shouldUseSidebar(widget.deviceType);
 
     final contentShell = ContentActions(
@@ -717,8 +719,8 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
             return KeyEventResult.ignored;
           },
           child: useSidebar
-              ? _buildTvLayout(contentShell)
-              : _buildMobileLayout(contentShell),
+              ? _buildTvLayout(contentShell, routes)
+              : _buildMobileLayout(contentShell, routes),
         ),
       ),
     );
@@ -870,7 +872,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     );
   }
 
-  Widget _buildTvLayout(Widget contentShell) {
+  Widget _buildTvLayout(Widget contentShell, List<String> routes) {
     return MediaQuery.removePadding(
       context: context,
       removeTop: true,
@@ -908,7 +910,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
                   bottom: 0,
                   child: NavigationSidebar(
                     currentIndex: _currentIndex,
-                    routes: _mainRoutes,
+                    routes: routes,
                     sidebarActive: _sidebarActive,
                     focusNodes: _sidebarFocusNodes,
                     scopeNode: _sidebarScopeNode,
@@ -926,12 +928,12 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     );
   }
 
-  Widget _buildMobileLayout(Widget contentShell) {
+  Widget _buildMobileLayout(Widget contentShell, List<String> routes) {
     final primaryCount = RouteNames.mobilePrimaryCount.clamp(
       0,
-      _mainRoutes.length,
+      routes.length,
     );
-    final overflowRoutes = _mainRoutes.skip(primaryCount).toList();
+    final overflowRoutes = routes.skip(primaryCount).toList();
     final overflowUnread = overflowRoutes.contains(RouteNames.notifications)
         ? _appState.unreadNotificationCount
         : 0;
@@ -951,7 +953,7 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
         selectedItemColor: Theme.of(context).colorScheme.primary,
         unselectedItemColor: Theme.of(context).colorScheme.onSurfaceVariant,
         items: [
-          ..._mainRoutes.take(primaryCount).map((route) {
+          ...routes.take(primaryCount).map((route) {
             return BottomNavigationBarItem(
               icon: Icon(_routeIcon(route)),
               label: _routeLabel(context, route),

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -621,20 +621,34 @@ class AppShellState extends ConsumerState<AppShell>
       ),
       RouteNames.dvr => ListenableBuilder(
         listenable: _appState,
-        builder: (_, _) => DvrRecordingsScreen(
-          recordings: _appState.dvrRecordings,
-          isLoading: _appState.isLoadingContent,
-          isConfigured: _appState.isConfigured,
-          onPlay: _openPlayerDirect,
-          onSidebarActivate: _activateSidebar,
-        ),
+        builder: (_, _) {
+          if (_appState.isBootstrapping) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          return DvrRecordingsScreen(
+            recordings: _appState.dvrRecordings,
+            isLoading: _appState.isLoadingContent,
+            isConfigured: _appState.isConfigured,
+            onPlay: _openPlayerDirect,
+            onSidebarActivate: _activateSidebar,
+          );
+        },
       ),
       RouteNames.requests => ListenableBuilder(
         listenable: _appState,
-        builder: (_, _) => RequestScreen(
-          isConfigured: _appState.isConfigured,
-          onSidebarActivate: _activateSidebar,
-        ),
+        builder: (_, _) {
+          if (_appState.isBootstrapping) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          return RequestScreen(
+            isConfigured: _appState.isConfigured,
+            onSidebarActivate: _activateSidebar,
+          );
+        },
       ),
       RouteNames.notifications => NotificationsScreen(
         onMarkRead: _appState.markNotificationRead,

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -632,7 +632,11 @@ class AppShellState extends ConsumerState<AppShell>
           onSidebarActivate: _activateSidebar,
         ),
       ),
-      RouteNames.notifications => NotificationsScreen(appState: _appState),
+      RouteNames.notifications => NotificationsScreen(
+        onMarkRead: _appState.markNotificationRead,
+        onMarkAllRead: _appState.markAllNotificationsRead,
+        onSetChannels: _appState.setNotificationChannels,
+      ),
       RouteNames.settings => ListenableBuilder(
         listenable: _appState,
         builder: (_, _) => SettingsScreen(

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -5,6 +5,7 @@ import 'package:dpad/dpad.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:m3u_tv/features/aiostreams/aiostreams_catalog_screen.dart';
@@ -23,6 +24,7 @@ import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/navigation/content_actions.dart';
 import 'package:m3u_tv/navigation/route_names.dart';
 import 'package:m3u_tv/playback/playback_orchestrator.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/aiostreams_api_service.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/domain_models.dart';
@@ -57,7 +59,7 @@ String _routeLabel(BuildContext context, String route) {
 /// Root shell with adaptive scaffold: sidebar for TV/desktop, bottom nav for
 /// phone/tablet. Includes TV focus traversal, D-pad/keyboard shortcuts, back
 /// handling, and focus restoration.
-class AppShell extends StatefulWidget {
+class AppShell extends ConsumerStatefulWidget {
   const AppShell({
     super.key,
     required this.navigationShell,
@@ -74,10 +76,10 @@ class AppShell extends StatefulWidget {
   final Widget Function(PlayerArgs args)? playerRouteBuilder;
 
   @override
-  State<AppShell> createState() => AppShellState();
+  ConsumerState<AppShell> createState() => AppShellState();
 }
 
-class AppShellState extends State<AppShell> with WidgetsBindingObserver {
+class AppShellState extends ConsumerState<AppShell> with WidgetsBindingObserver {
   bool _sidebarActive = false;
   late final AppStateController _appState;
   late final bool _ownsAppState;
@@ -154,7 +156,8 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
     if (!_mainRoutes.contains(route)) {
       widget.navigationShell.goBranch(0, initialLocation: true);
     }
-    setState(() {});
+    // No setState needed — ref.watch(appStateControllerProvider) in build()
+    // schedules the rebuild whenever notifyListeners fires.
   }
 
   void _initSidebarFocusNodes() {
@@ -674,6 +677,10 @@ class AppShellState extends State<AppShell> with WidgetsBindingObserver {
 
   @override
   Widget build(BuildContext context) {
+    // Subscribe to AppStateController so this build re-runs whenever
+    // notifyListeners fires — replaces the setState in _onAppStateChanged.
+    ref.watch(appStateControllerProvider);
+
     final routes = _mainRoutes;
     _syncSidebarFocusNodes(routes);
     final useSidebar = shouldUseSidebar(widget.deviceType);

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -85,6 +85,7 @@ class AppShellState extends ConsumerState<AppShell>
   bool _sidebarActive = false;
   late final AppStateController _appState;
   late final bool _ownsAppState;
+  int _unreadCount = 0;
 
   DateTime? _lastBackPress;
   int _lastNavMs = 0;
@@ -121,6 +122,7 @@ class AppShellState extends ConsumerState<AppShell>
     WidgetsBinding.instance.addObserver(this);
     _appState = widget.appState ?? AppStateController();
     _ownsAppState = widget.appState == null;
+    _unreadCount = _appState.unreadNotificationCount;
     _appState.addListener(_onAppStateChanged);
     _tvNotificationSub = _appState.tvNotifications.listen(_onTvNotification);
     if (!_appState.isConfigured) {
@@ -158,8 +160,10 @@ class AppShellState extends ConsumerState<AppShell>
     if (!_mainRoutes.contains(route)) {
       widget.navigationShell.goBranch(0, initialLocation: true);
     }
-    // No setState needed — ref.watch(appStateControllerProvider) in build()
-    // schedules the rebuild whenever notifyListeners fires.
+    final newCount = _appState.unreadNotificationCount;
+    if (_unreadCount != newCount) {
+      setState(() => _unreadCount = newCount);
+    }
   }
 
   void _initSidebarFocusNodes() {
@@ -667,11 +671,8 @@ class AppShellState extends ConsumerState<AppShell>
 
   @override
   Widget build(BuildContext context) {
-    // Watch only what AppShell.build() actually uses:
-    //   isConfigured  → recalculates feature-flag-gated routes on connect/disconnect
-    //   unreadCount   → drives notification badge without full-screen rebuilds
+    // isConfigured triggers route recalculation on connect/disconnect.
     ref.watch(isConfiguredProvider);
-    final unreadCount = ref.watch(unreadNotificationCountProvider);
 
     final routes = _mainRoutes;
     _syncSidebarFocusNodes(routes);
@@ -718,8 +719,8 @@ class AppShellState extends ConsumerState<AppShell>
             return KeyEventResult.ignored;
           },
           child: useSidebar
-              ? _buildTvLayout(contentShell, routes, unreadCount)
-              : _buildMobileLayout(contentShell, routes, unreadCount),
+              ? _buildTvLayout(contentShell, routes, _unreadCount)
+              : _buildMobileLayout(contentShell, routes, _unreadCount),
         ),
       ),
     );

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3u_tv/features/epg/timeline_epg_view.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
@@ -20,37 +22,27 @@ enum _ViewMode { list, logoGrid, epgGrid }
 /// - Toggle between list and grid view modes
 /// - Long-press context menu for favorites and recording actions
 /// - Lazy EPG loading for visible channels
-class LiveTvScreen extends StatefulWidget {
+class LiveTvScreen extends ConsumerStatefulWidget {
   const LiveTvScreen({
     super.key,
-    required this.channels,
-    required this.categories,
-    required this.isLoading,
-    required this.isConfigured,
     required this.favoritesService,
-    required this.epgService,
     required this.onChannelSelect,
     this.onCatchupProgramSelect,
     this.onSidebarActivate,
     this.onScheduleProgram,
   });
 
-  final List<Channel> channels;
-  final List<Category> categories;
-  final bool isLoading;
-  final bool isConfigured;
   final FavoritesService favoritesService;
-  final EpgService epgService;
   final void Function(Channel) onChannelSelect;
   final CatchupProgramSelect? onCatchupProgramSelect;
   final VoidCallback? onSidebarActivate;
   final void Function(Channel, EpgProgram)? onScheduleProgram;
 
   @override
-  State<LiveTvScreen> createState() => _LiveTvScreenState();
+  ConsumerState<LiveTvScreen> createState() => _LiveTvScreenState();
 }
 
-class _LiveTvScreenState extends State<LiveTvScreen> {
+class _LiveTvScreenState extends ConsumerState<LiveTvScreen> {
   static const _favoritesCategoryId = '__FAVORITES__';
   String? _selectedCategory;
   String _query = '';
@@ -101,14 +93,14 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
     }
   }
 
-  List<Channel> get _filteredChannels {
+  List<Channel> _filteredChannels(List<Channel> channels) {
     final selectedCategory = _selectedCategory;
     final categoryFiltered =
         selectedCategory == null || selectedCategory.isEmpty
-        ? widget.channels
+        ? channels
         : selectedCategory == _favoritesCategoryId
-        ? widget.channels.where((channel) => _favoriteIds.contains(channel.id))
-        : widget.channels.where(
+        ? channels.where((channel) => _favoriteIds.contains(channel.id))
+        : channels.where(
             (channel) => channel.categoryId == selectedCategory,
           );
     final normalizedQuery = _query.trim().toLowerCase();
@@ -122,7 +114,7 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
         .toList(growable: false);
   }
 
-  List<CategoryTabData> get _categoryTabs {
+  List<CategoryTabData> _categoryTabs(List<Category> categories) {
     return [
       CategoryTabData(
         id: '',
@@ -132,13 +124,13 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
         id: _favoritesCategoryId,
         name: AppLocalizations.of(context).liveTvFavorites,
       ),
-      ...widget.categories.map((c) => CategoryTabData(id: c.id, name: c.name)),
+      ...categories.map((c) => CategoryTabData(id: c.id, name: c.name)),
     ];
   }
 
-  void _loadEpgForChannels(List<Channel> channels) {
+  void _loadEpgForChannels(List<Channel> channels, EpgService epgService) {
     for (final channel in channels) {
-      final result = widget.epgService.lookupForChannel(channel);
+      final result = epgService.lookupForChannel(channel);
       if (result != null) {
         _epgMap[channel.id] = result;
       }
@@ -224,7 +216,18 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.isConfigured) {
+    final isBootstrapping = ref.watch(isBootstrappingProvider);
+    final isConfigured = ref.watch(isConfiguredProvider);
+    final isLoading = ref.watch(isLoadingContentProvider);
+    final channels = ref.watch(liveChannelsProvider);
+    final categories = ref.watch(liveCategoriesProvider);
+    final epgService = ref.watch(epgServiceProvider);
+
+    if (isBootstrapping) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    if (!isConfigured) {
       return Scaffold(
         body: Center(
           child: Text(
@@ -235,18 +238,16 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
       );
     }
 
-    final filtered = _filteredChannels;
-    _loadEpgForChannels(filtered);
+    final filtered = _filteredChannels(channels);
+    _loadEpgForChannels(filtered, epgService);
 
     return Scaffold(
       body: Column(
         children: [
           _buildSearchField(),
-          // Category bar + view mode toggle
-          _buildCategoryBar(),
-          // Content area
+          _buildCategoryBar(categories),
           Expanded(
-            child: widget.isLoading
+            child: isLoading
                 ? const Center(child: CircularProgressIndicator())
                 : filtered.isEmpty
                 ? Center(
@@ -256,7 +257,7 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
                     ),
                   )
                 : switch (_viewMode) {
-                    _ViewMode.epgGrid => _buildEpgGrid(filtered),
+                    _ViewMode.epgGrid => _buildEpgGrid(filtered, epgService),
                     _ViewMode.logoGrid => _buildGridView(filtered),
                     _ViewMode.list => _buildListView(filtered),
                   },
@@ -282,9 +283,9 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
     );
   }
 
-  Widget _buildCategoryBar() {
+  Widget _buildCategoryBar(List<Category> categories) {
     return ScrollableCategoryBar(
-      tabs: _categoryTabs,
+      tabs: _categoryTabs(categories),
       selectedId: _selectedCategory ?? '',
       onSelected: (id) => setState(() => _selectedCategory = id),
       leading: IconButton(
@@ -340,7 +341,7 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
     );
   }
 
-  Widget _buildEpgGrid(List<Channel> channels) {
+  Widget _buildEpgGrid(List<Channel> channels, EpgService epgService) {
     return DpadRegion(
       memoryKey: 'live-tv/epg',
       horizontalEdge: DpadEdgeBehavior.stop,
@@ -351,7 +352,7 @@ class _LiveTvScreenState extends State<LiveTvScreen> {
       },
       child: TimelineEpgView(
         channels: channels,
-        epgService: widget.epgService,
+        epgService: epgService,
         onChannelSelect: widget.onChannelSelect,
         onCatchupProgramSelect: widget.onCatchupProgramSelect,
       ),

--- a/flutter_client/lib/features/notifications/notifications_screen.dart
+++ b/flutter_client/lib/features/notifications/notifications_screen.dart
@@ -39,6 +39,7 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen>
     with SingleTickerProviderStateMixin {
   late final _tabController = TabController(length: 2, vsync: this);
   late final TvNotificationStore _store;
+  late final StreamSubscription<void> _liveNotificationSub;
   List<StoredTvNotification> _notifications = const [];
   Set<String> _subscribed = const {};
   List<TvNotificationChannel> _knownChannels = const [];
@@ -48,11 +49,17 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen>
   void initState() {
     super.initState();
     _store = ref.read(notificationStoreProvider);
+    // Subscribe directly to the broadcast stream so new notifications trigger
+    // a reload regardless of Riverpod build-cycle timing.
+    _liveNotificationSub = ref
+        .read(tvNotificationsStreamProvider)
+        .listen((_) async => _reload());
     unawaited(_reload());
   }
 
   @override
   void dispose() {
+    unawaited(_liveNotificationSub.cancel());
     _tabController.dispose();
     super.dispose();
   }
@@ -75,10 +82,12 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen>
   Future<void> _markRead(StoredTvNotification notification) async {
     if (notification.isRead) return;
     await widget.onMarkRead(notification.item.id);
+    unawaited(_reload());
   }
 
   Future<void> _markAllRead() async {
     await widget.onMarkAllRead();
+    unawaited(_reload());
   }
 
   Future<void> _toggleChannel(String channel) async {
@@ -89,18 +98,16 @@ class _NotificationsScreenState extends ConsumerState<NotificationsScreen>
       next.add(channel);
     }
     await widget.onSetChannels(next);
+    unawaited(_reload());
   }
 
   Future<void> _clearChannelFilter() async {
     await widget.onSetChannels({});
+    unawaited(_reload());
   }
 
   @override
   Widget build(BuildContext context) {
-    // Reload whenever AppStateController notifies — covers incoming
-    // notifications, markRead mutations, and subscription changes.
-    ref.listen(appStateControllerProvider, (_, _) => unawaited(_reload()));
-
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
 

--- a/flutter_client/lib/features/notifications/notifications_screen.dart
+++ b/flutter_client/lib/features/notifications/notifications_screen.dart
@@ -2,10 +2,11 @@ import 'dart:async';
 
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
-import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/tv_notification_store.dart'
-    show StoredTvNotification, TvNotificationChannel;
+    show StoredTvNotification, TvNotificationChannel, TvNotificationStore;
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/dpad_tab_bar.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
@@ -17,18 +18,27 @@ const _kStadiumEffect = [
 /// Lists TV push notifications with local read/unread state, letting the
 /// user flip through history, mark items as read, and configure channel
 /// subscriptions.
-class NotificationsScreen extends StatefulWidget {
-  const NotificationsScreen({super.key, required this.appState});
+class NotificationsScreen extends ConsumerStatefulWidget {
+  const NotificationsScreen({
+    super.key,
+    required this.onMarkRead,
+    required this.onMarkAllRead,
+    required this.onSetChannels,
+  });
 
-  final AppStateController appState;
+  final Future<void> Function(String id) onMarkRead;
+  final Future<void> Function() onMarkAllRead;
+  final Future<void> Function(Set<String> channels) onSetChannels;
 
   @override
-  State<NotificationsScreen> createState() => _NotificationsScreenState();
+  ConsumerState<NotificationsScreen> createState() =>
+      _NotificationsScreenState();
 }
 
-class _NotificationsScreenState extends State<NotificationsScreen>
+class _NotificationsScreenState extends ConsumerState<NotificationsScreen>
     with SingleTickerProviderStateMixin {
   late final _tabController = TabController(length: 2, vsync: this);
+  late final TvNotificationStore _store;
   List<StoredTvNotification> _notifications = const [];
   Set<String> _subscribed = const {};
   List<TvNotificationChannel> _knownChannels = const [];
@@ -37,23 +47,21 @@ class _NotificationsScreenState extends State<NotificationsScreen>
   @override
   void initState() {
     super.initState();
-    widget.appState.addListener(_reload);
+    _store = ref.read(notificationStoreProvider);
     unawaited(_reload());
   }
 
   @override
   void dispose() {
     _tabController.dispose();
-    widget.appState.removeListener(_reload);
     super.dispose();
   }
 
   Future<void> _reload() async {
-    final store = widget.appState.notificationStore;
     final results = await Future.wait([
-      store.all(),
-      store.subscribedChannels(),
-      store.knownChannels(),
+      _store.all(),
+      _store.subscribedChannels(),
+      _store.knownChannels(),
     ]);
     if (!mounted) return;
     setState(() {
@@ -66,13 +74,11 @@ class _NotificationsScreenState extends State<NotificationsScreen>
 
   Future<void> _markRead(StoredTvNotification notification) async {
     if (notification.isRead) return;
-    await widget.appState.markNotificationRead(notification.item.id);
-    await _reload();
+    await widget.onMarkRead(notification.item.id);
   }
 
   Future<void> _markAllRead() async {
-    await widget.appState.markAllNotificationsRead();
-    await _reload();
+    await widget.onMarkAllRead();
   }
 
   Future<void> _toggleChannel(String channel) async {
@@ -82,17 +88,19 @@ class _NotificationsScreenState extends State<NotificationsScreen>
     } else {
       next.add(channel);
     }
-    await widget.appState.setNotificationChannels(next);
-    await _reload();
+    await widget.onSetChannels(next);
   }
 
   Future<void> _clearChannelFilter() async {
-    await widget.appState.setNotificationChannels({});
-    await _reload();
+    await widget.onSetChannels({});
   }
 
   @override
   Widget build(BuildContext context) {
+    // Reload whenever AppStateController notifies — covers incoming
+    // notifications, markRead mutations, and subscription changes.
+    ref.listen(appStateControllerProvider, (_, _) => unawaited(_reload()));
+
     final theme = Theme.of(context);
     final l = AppLocalizations.of(context);
 

--- a/flutter_client/lib/features/search/search_screen.dart
+++ b/flutter_client/lib/features/search/search_screen.dart
@@ -1,6 +1,8 @@
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/dpad_tab_bar.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
@@ -11,33 +13,25 @@ import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 /// - Case-insensitive name.includes(query) filtering
 /// - All / Live TV / Movies / Series tabs
 /// - Real-time filtering as user types
-class SearchScreen extends StatefulWidget {
+class SearchScreen extends ConsumerStatefulWidget {
   const SearchScreen({
     super.key,
-    required this.channels,
-    required this.vodItems,
-    required this.seriesList,
-    required this.isConfigured,
     required this.onChannelSelect,
     required this.onVodSelect,
     required this.onSeriesSelect,
     this.onSidebarActivate,
   });
 
-  final List<Channel> channels;
-  final List<VodItem> vodItems;
-  final List<Series> seriesList;
-  final bool isConfigured;
   final void Function(Channel) onChannelSelect;
   final void Function(VodItem) onVodSelect;
   final void Function(Series) onSeriesSelect;
   final VoidCallback? onSidebarActivate;
 
   @override
-  State<SearchScreen> createState() => _SearchScreenState();
+  ConsumerState<SearchScreen> createState() => _SearchScreenState();
 }
 
-class _SearchScreenState extends State<SearchScreen>
+class _SearchScreenState extends ConsumerState<SearchScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
   String _query = '';
@@ -55,35 +49,45 @@ class _SearchScreenState extends State<SearchScreen>
   }
 
   String get _normalizedQuery => _query.trim().toLowerCase();
-
   bool get _hasQuery => _normalizedQuery.isNotEmpty;
 
-  List<Channel> get _filteredChannels => _hasQuery
-      ? widget.channels
+  List<Channel> _filterChannels(List<Channel> channels) => _hasQuery
+      ? channels
             .where(
-              (channel) =>
-                  channel.name.toLowerCase().contains(_normalizedQuery),
+              (c) => c.name.toLowerCase().contains(_normalizedQuery),
             )
             .toList(growable: false)
       : const [];
 
-  List<VodItem> get _filteredVodItems => _hasQuery
-      ? widget.vodItems
-            .where((item) => item.name.toLowerCase().contains(_normalizedQuery))
+  List<VodItem> _filterVodItems(List<VodItem> vodItems) => _hasQuery
+      ? vodItems
+            .where(
+              (v) => v.name.toLowerCase().contains(_normalizedQuery),
+            )
             .toList(growable: false)
       : const [];
 
-  List<Series> get _filteredSeriesList => _hasQuery
-      ? widget.seriesList
+  List<Series> _filterSeriesList(List<Series> seriesList) => _hasQuery
+      ? seriesList
             .where(
-              (series) => series.name.toLowerCase().contains(_normalizedQuery),
+              (s) => s.name.toLowerCase().contains(_normalizedQuery),
             )
             .toList(growable: false)
       : const [];
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.isConfigured) {
+    final isBootstrapping = ref.watch(isBootstrappingProvider);
+    final isConfigured = ref.watch(isConfiguredProvider);
+    final channels = ref.watch(liveChannelsProvider);
+    final vodItems = ref.watch(vodItemsProvider);
+    final seriesList = ref.watch(seriesListProvider);
+
+    if (isBootstrapping) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    if (!isConfigured) {
       return Scaffold(
         body: Center(
           child: Text(
@@ -93,6 +97,10 @@ class _SearchScreenState extends State<SearchScreen>
         ),
       );
     }
+
+    final filteredChannels = _filterChannels(channels);
+    final filteredVodItems = _filterVodItems(vodItems);
+    final filteredSeries = _filterSeriesList(seriesList);
 
     return Scaffold(
       body: Column(
@@ -114,15 +122,18 @@ class _SearchScreenState extends State<SearchScreen>
               AppLocalizations.of(context).searchSectionSeries,
             ],
           ),
-          // Content
           Expanded(
             child: TabBarView(
               controller: _tabController,
               children: [
-                _buildAllTab(),
-                _buildLiveTvTab(),
-                _buildMoviesTab(),
-                _buildSeriesTab(),
+                _buildAllTab(
+                  filteredChannels,
+                  filteredVodItems,
+                  filteredSeries,
+                ),
+                _buildLiveTvTab(filteredChannels),
+                _buildMoviesTab(filteredVodItems),
+                _buildSeriesTab(filteredSeries),
               ],
             ),
           ),
@@ -131,13 +142,12 @@ class _SearchScreenState extends State<SearchScreen>
     );
   }
 
-  Widget _buildAllTab() {
+  Widget _buildAllTab(
+    List<Channel> channels,
+    List<VodItem> vodItems,
+    List<Series> seriesList,
+  ) {
     if (!_hasQuery) return _buildPromptState();
-
-    final channels = _filteredChannels;
-    final vodItems = _filteredVodItems;
-    final seriesList = _filteredSeriesList;
-
     if (channels.isEmpty && vodItems.isEmpty && seriesList.isEmpty) {
       return _buildEmptyState('No results found');
     }
@@ -187,13 +197,9 @@ class _SearchScreenState extends State<SearchScreen>
     );
   }
 
-  Widget _buildLiveTvTab() {
+  Widget _buildLiveTvTab(List<Channel> channels) {
     if (!_hasQuery) return _buildPromptState();
-
-    final channels = _filteredChannels;
-    if (channels.isEmpty) {
-      return _buildEmptyState('No results found');
-    }
+    if (channels.isEmpty) return _buildEmptyState('No results found');
     return DpadRegion(
       memoryKey: 'search/live-tv',
       horizontalEdge: DpadEdgeBehavior.stop,
@@ -213,13 +219,9 @@ class _SearchScreenState extends State<SearchScreen>
     );
   }
 
-  Widget _buildMoviesTab() {
+  Widget _buildMoviesTab(List<VodItem> vodItems) {
     if (!_hasQuery) return _buildPromptState();
-
-    final vodItems = _filteredVodItems;
-    if (vodItems.isEmpty) {
-      return _buildEmptyState('No results found');
-    }
+    if (vodItems.isEmpty) return _buildEmptyState('No results found');
     return DpadRegion(
       memoryKey: 'search/movies',
       horizontalEdge: DpadEdgeBehavior.stop,
@@ -239,13 +241,9 @@ class _SearchScreenState extends State<SearchScreen>
     );
   }
 
-  Widget _buildSeriesTab() {
+  Widget _buildSeriesTab(List<Series> seriesList) {
     if (!_hasQuery) return _buildPromptState();
-
-    final seriesList = _filteredSeriesList;
-    if (seriesList.isEmpty) {
-      return _buildEmptyState('No results found');
-    }
+    if (seriesList.isEmpty) return _buildEmptyState('No results found');
     return DpadRegion(
       memoryKey: 'search/series',
       horizontalEdge: DpadEdgeBehavior.stop,
@@ -268,11 +266,8 @@ class _SearchScreenState extends State<SearchScreen>
   Widget _buildPromptState() =>
       _buildEmptyState(AppLocalizations.of(context).searchTypeToSearch);
 
-  Widget _buildEmptyState(String label) {
-    return Center(
-      child: Text(label, style: Theme.of(context).textTheme.bodyLarge),
-    );
-  }
+  Widget _buildEmptyState(String label) =>
+      Center(child: Text(label, style: Theme.of(context).textTheme.bodyLarge));
 }
 
 class _SectionHeader extends StatelessWidget {

--- a/flutter_client/lib/features/series/series_screen.dart
+++ b/flutter_client/lib/features/series/series_screen.dart
@@ -277,10 +277,17 @@ class _SeriesCard extends StatelessWidget {
             Positioned(
               top: 4,
               left: 4,
-              child: Icon(
-                Icons.star,
-                color: Theme.of(context).colorScheme.primary,
-                size: 20,
+              child: Container(
+                padding: const EdgeInsets.all(3),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.star,
+                  color: Color(0xFFFFFFFF),
+                  size: 14,
+                ),
               ),
             ),
         ],

--- a/flutter_client/lib/features/series/series_screen.dart
+++ b/flutter_client/lib/features/series/series_screen.dart
@@ -289,7 +289,7 @@ class _SeriesCard extends StatelessWidget {
                 ),
                 child: const Icon(
                   Icons.star,
-                  color: Color(0xFFFFFFFF),
+                  color: Colors.white,
                   size: 14,
                 ),
               ),

--- a/flutter_client/lib/features/series/series_screen.dart
+++ b/flutter_client/lib/features/series/series_screen.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
@@ -15,31 +17,23 @@ import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 /// - Grid layout with cover thumbnails and ratings
 /// - Category filtering
 /// - Season/episode navigation happens in SeriesDetailsScreen (separate route)
-class SeriesScreen extends StatefulWidget {
+class SeriesScreen extends ConsumerStatefulWidget {
   const SeriesScreen({
     super.key,
-    required this.seriesList,
-    required this.categories,
-    required this.isLoading,
-    required this.isConfigured,
     required this.onSeriesSelect,
     this.favoritesService,
     this.onSidebarActivate,
   });
 
-  final List<Series> seriesList;
-  final List<Category> categories;
-  final bool isLoading;
-  final bool isConfigured;
   final void Function(Series) onSeriesSelect;
   final FavoritesService? favoritesService;
   final VoidCallback? onSidebarActivate;
 
   @override
-  State<SeriesScreen> createState() => _SeriesScreenState();
+  ConsumerState<SeriesScreen> createState() => _SeriesScreenState();
 }
 
-class _SeriesScreenState extends State<SeriesScreen> {
+class _SeriesScreenState extends ConsumerState<SeriesScreen> {
   static const double _minPosterCardWidth = 120;
   static const double _maxPosterCardWidth = 220;
   static const _kFavoritesCategoryId = '__FAVORITES__';
@@ -61,17 +55,17 @@ class _SeriesScreenState extends State<SeriesScreen> {
     if (mounted) setState(() => _favoriteIds = ids);
   }
 
-  List<Series> get _filteredItems {
+  List<Series> _filteredItems(List<Series> seriesList) {
     final selectedCategory = _selectedCategory;
     final Iterable<Series> categoryFiltered;
     if (selectedCategory == _kFavoritesCategoryId) {
-      categoryFiltered = widget.seriesList.where(
+      categoryFiltered = seriesList.where(
         (item) => _favoriteIds.contains(item.id),
       );
     } else if (selectedCategory == null || selectedCategory.isEmpty) {
-      categoryFiltered = widget.seriesList;
+      categoryFiltered = seriesList;
     } else {
-      categoryFiltered = widget.seriesList.where(
+      categoryFiltered = seriesList.where(
         (item) => item.categoryId == selectedCategory,
       );
     }
@@ -80,13 +74,25 @@ class _SeriesScreenState extends State<SeriesScreen> {
       return categoryFiltered.toList(growable: false);
     }
     return categoryFiltered
-        .where((item) => item.name.toLowerCase().contains(normalizedQuery))
+        .where(
+          (item) => item.name.toLowerCase().contains(normalizedQuery),
+        )
         .toList(growable: false);
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.isConfigured) {
+    final isBootstrapping = ref.watch(isBootstrappingProvider);
+    final isConfigured = ref.watch(isConfiguredProvider);
+    final isLoading = ref.watch(isLoadingContentProvider);
+    final seriesList = ref.watch(seriesListProvider);
+    final categories = ref.watch(seriesCategoriesProvider);
+
+    if (isBootstrapping) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    if (!isConfigured) {
       return Scaffold(
         body: Center(
           child: Text(
@@ -97,17 +103,15 @@ class _SeriesScreenState extends State<SeriesScreen> {
       );
     }
 
-    final filtered = _filteredItems;
+    final filtered = _filteredItems(seriesList);
 
     return Scaffold(
       body: Column(
         children: [
           _buildSearchField(),
-          // Category bar
-          _buildCategoryBar(),
-          // Content area
+          _buildCategoryBar(categories),
           Expanded(
-            child: widget.isLoading
+            child: isLoading
                 ? const Center(child: CircularProgressIndicator())
                 : filtered.isEmpty
                 ? Center(
@@ -139,13 +143,13 @@ class _SeriesScreenState extends State<SeriesScreen> {
     );
   }
 
-  Widget _buildCategoryBar() {
+  Widget _buildCategoryBar(List<Category> categories) {
     final l = AppLocalizations.of(context);
     final tabs = [
       CategoryTabData(id: '', name: l.seriesAllSeries),
       if (_favoriteIds.isNotEmpty)
         CategoryTabData(id: _kFavoritesCategoryId, name: l.liveTvFavorites),
-      ...widget.categories.map((c) => CategoryTabData(id: c.id, name: c.name)),
+      ...categories.map((c) => CategoryTabData(id: c.id, name: c.name)),
     ];
 
     return ScrollableCategoryBar(

--- a/flutter_client/lib/features/vod/vod_screen.dart
+++ b/flutter_client/lib/features/vod/vod_screen.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
@@ -14,31 +16,23 @@ import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 /// - All Movies + category tabs
 /// - Grid layout with poster thumbnails and ratings
 /// - Category filtering
-class VodScreen extends StatefulWidget {
+class VodScreen extends ConsumerStatefulWidget {
   const VodScreen({
     super.key,
-    required this.vodItems,
-    required this.categories,
-    required this.isLoading,
-    required this.isConfigured,
     required this.onVodSelect,
     this.favoritesService,
     this.onSidebarActivate,
   });
 
-  final List<VodItem> vodItems;
-  final List<Category> categories;
-  final bool isLoading;
-  final bool isConfigured;
   final void Function(VodItem) onVodSelect;
   final FavoritesService? favoritesService;
   final VoidCallback? onSidebarActivate;
 
   @override
-  State<VodScreen> createState() => _VodScreenState();
+  ConsumerState<VodScreen> createState() => _VodScreenState();
 }
 
-class _VodScreenState extends State<VodScreen> {
+class _VodScreenState extends ConsumerState<VodScreen> {
   static const double _minPosterCardWidth = 120;
   static const double _maxPosterCardWidth = 220;
   static const _kFavoritesCategoryId = '__FAVORITES__';
@@ -60,17 +54,17 @@ class _VodScreenState extends State<VodScreen> {
     if (mounted) setState(() => _favoriteIds = ids);
   }
 
-  List<VodItem> get _filteredItems {
+  List<VodItem> _filteredItems(List<VodItem> vodItems) {
     final selectedCategory = _selectedCategory;
     final Iterable<VodItem> categoryFiltered;
     if (selectedCategory == _kFavoritesCategoryId) {
-      categoryFiltered = widget.vodItems.where(
+      categoryFiltered = vodItems.where(
         (item) => _favoriteIds.contains(item.id),
       );
     } else if (selectedCategory == null || selectedCategory.isEmpty) {
-      categoryFiltered = widget.vodItems;
+      categoryFiltered = vodItems;
     } else {
-      categoryFiltered = widget.vodItems.where(
+      categoryFiltered = vodItems.where(
         (item) => item.categoryId == selectedCategory,
       );
     }
@@ -79,13 +73,25 @@ class _VodScreenState extends State<VodScreen> {
       return categoryFiltered.toList(growable: false);
     }
     return categoryFiltered
-        .where((item) => item.name.toLowerCase().contains(normalizedQuery))
+        .where(
+          (item) => item.name.toLowerCase().contains(normalizedQuery),
+        )
         .toList(growable: false);
   }
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.isConfigured) {
+    final isBootstrapping = ref.watch(isBootstrappingProvider);
+    final isConfigured = ref.watch(isConfiguredProvider);
+    final isLoading = ref.watch(isLoadingContentProvider);
+    final vodItems = ref.watch(vodItemsProvider);
+    final categories = ref.watch(vodCategoriesProvider);
+
+    if (isBootstrapping) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+
+    if (!isConfigured) {
       return Scaffold(
         body: Center(
           child: Text(
@@ -96,17 +102,15 @@ class _VodScreenState extends State<VodScreen> {
       );
     }
 
-    final filtered = _filteredItems;
+    final filtered = _filteredItems(vodItems);
 
     return Scaffold(
       body: Column(
         children: [
           _buildSearchField(),
-          // Category bar
-          _buildCategoryBar(),
-          // Content area
+          _buildCategoryBar(categories),
           Expanded(
-            child: widget.isLoading
+            child: isLoading
                 ? const Center(child: CircularProgressIndicator())
                 : filtered.isEmpty
                 ? Center(
@@ -138,13 +142,13 @@ class _VodScreenState extends State<VodScreen> {
     );
   }
 
-  Widget _buildCategoryBar() {
+  Widget _buildCategoryBar(List<Category> categories) {
     final l = AppLocalizations.of(context);
     final tabs = [
       CategoryTabData(id: '', name: l.vodAllMovies),
       if (_favoriteIds.isNotEmpty)
         CategoryTabData(id: _kFavoritesCategoryId, name: l.liveTvFavorites),
-      ...widget.categories.map((c) => CategoryTabData(id: c.id, name: c.name)),
+      ...categories.map((c) => CategoryTabData(id: c.id, name: c.name)),
     ];
 
     return ScrollableCategoryBar(

--- a/flutter_client/lib/features/vod/vod_screen.dart
+++ b/flutter_client/lib/features/vod/vod_screen.dart
@@ -276,10 +276,17 @@ class _VodCard extends StatelessWidget {
             Positioned(
               top: 4,
               left: 4,
-              child: Icon(
-                Icons.star,
-                color: Theme.of(context).colorScheme.primary,
-                size: 20,
+              child: Container(
+                padding: const EdgeInsets.all(3),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.star,
+                  color: Color(0xFFFFFFFF),
+                  size: 14,
+                ),
               ),
             ),
         ],

--- a/flutter_client/lib/features/vod/vod_screen.dart
+++ b/flutter_client/lib/features/vod/vod_screen.dart
@@ -288,7 +288,7 @@ class _VodCard extends StatelessWidget {
                 ),
                 child: const Icon(
                   Icons.star,
-                  color: Color(0xFFFFFFFF),
+                  color: Colors.white,
                   size: 14,
                 ),
               ),

--- a/flutter_client/lib/main.dart
+++ b/flutter_client/lib/main.dart
@@ -5,11 +5,13 @@ import 'package:dpad/dpad.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:m3u_tv/app/app_shell.dart' show shouldUseSidebar;
 import 'package:m3u_tv/app/device_type_resolver.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/navigation/go_router_config.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/persistent_store.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
@@ -26,7 +28,15 @@ Future<void> main() async {
   }
   final appState = await _buildAppState();
   final nativeTelevisionHint = await resolveNativeTelevisionHint();
-  runApp(MyApp(nativeTelevisionHint: nativeTelevisionHint, appState: appState));
+  runApp(
+    ProviderScope(
+      overrides: [overrideAppState(appState)],
+      child: MyApp(
+        nativeTelevisionHint: nativeTelevisionHint,
+        appState: appState,
+      ),
+    ),
+  );
 }
 
 Future<void> _configureSystemUi() async {

--- a/flutter_client/lib/providers/app_providers.dart
+++ b/flutter_client/lib/providers/app_providers.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/cache_service.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
 
 // ---------------------------------------------------------------------------
@@ -41,7 +43,7 @@ final appStateControllerProvider = ChangeNotifierProvider<_AppStateProxy>((_) {
   );
 });
 
-/// Creates a [ProviderOverride] that injects [appState] into the Riverpod
+/// Creates an [Override] that injects [appState] into the Riverpod
 /// provider tree without transferring disposal ownership to Riverpod.
 ///
 /// ```dart
@@ -66,6 +68,14 @@ final cacheServiceProvider = Provider<CacheService>((ref) {
 
 final xtreamServiceProvider = Provider<XtreamService>((ref) {
   return ref.read(appStateControllerProvider).appState.xtreamService;
+});
+
+// EpgService is its own ChangeNotifier — this provider subscribes directly to
+// EpgService.notifyListeners(), which fires only when EPG data loads.
+// Widgets watching this will NOT rebuild on unrelated AppStateController
+// notifications (channel refreshes, progress updates, etc.).
+final epgServiceProvider = ChangeNotifierProvider<EpgService>((ref) {
+  return ref.read(appStateControllerProvider).appState.epgService;
 });
 
 // ---------------------------------------------------------------------------
@@ -104,6 +114,50 @@ final isLoadingContentProvider = Provider<bool>((ref) {
 
 final isConfiguredProvider = Provider<bool>((ref) {
   return ref.watch(appStateControllerProvider).appState.isConfigured;
+});
+
+final isBootstrappingProvider = Provider<bool>((ref) {
+  return ref.watch(appStateControllerProvider).appState.isBootstrapping;
+});
+
+final unreadNotificationCountProvider = Provider<int>((ref) {
+  return ref.watch(appStateControllerProvider).appState.unreadNotificationCount;
+});
+
+final progressListProvider = Provider<List<Progress>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.progressList;
+});
+
+final dvrRecordingsProvider = Provider<List<DvrRecording>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.dvrRecordings;
+});
+
+final sourceLabelProvider = Provider<String>((ref) {
+  return ref.watch(appStateControllerProvider).appState.sourceLabel;
+});
+
+final sourceErrorProvider = Provider<String?>((ref) {
+  return ref.watch(appStateControllerProvider).appState.error;
+});
+
+final hasDvrFeatureProvider = Provider<bool>((ref) {
+  return ref.watch(appStateControllerProvider).appState.hasDvrFeature;
+});
+
+// Favorites services are stable ChangeNotifier instances — they notify on
+// their own channel (not through AppStateController). Widgets that need to
+// react to favorites changes addListener() in initState as before; these
+// providers are here so AppShell can pass them without coupling to _appState.
+final liveFavoritesServiceProvider = Provider<FavoritesService>((ref) {
+  return ref.read(appStateControllerProvider).appState.favoritesService;
+});
+
+final vodFavoritesServiceProvider = Provider<FavoritesService>((ref) {
+  return ref.read(appStateControllerProvider).appState.vodFavoritesService;
+});
+
+final seriesFavoritesServiceProvider = Provider<FavoritesService>((ref) {
+  return ref.read(appStateControllerProvider).appState.seriesFavoritesService;
 });
 
 // ---------------------------------------------------------------------------

--- a/flutter_client/lib/providers/app_providers.dart
+++ b/flutter_client/lib/providers/app_providers.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/foundation.dart' show ChangeNotifier;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
-import 'package:m3u_tv/services/cache_service.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
-import 'package:m3u_tv/services/xtream_service.dart';
 
 // ---------------------------------------------------------------------------
 // Proxy: wraps AppStateController and forwards ChangeNotifier notifications.
@@ -56,19 +54,6 @@ Override overrideAppState(AppStateController appState) =>
     appStateControllerProvider.overrideWith(
       (ref) => _AppStateProxy(appState),
     );
-
-// ---------------------------------------------------------------------------
-// Service providers — stable references that never change after construction.
-// Use ref.read (not ref.watch) since services don't need rebuild tracking.
-// ---------------------------------------------------------------------------
-
-final cacheServiceProvider = Provider<CacheService>((ref) {
-  return ref.read(appStateControllerProvider).appState.cacheService;
-});
-
-final xtreamServiceProvider = Provider<XtreamService>((ref) {
-  return ref.read(appStateControllerProvider).appState.xtreamService;
-});
 
 // EpgService is its own ChangeNotifier — this provider subscribes directly to
 // EpgService.notifyListeners(), which fires only when EPG data loads.
@@ -159,51 +144,3 @@ final vodFavoritesServiceProvider = Provider<FavoritesService>((ref) {
 final seriesFavoritesServiceProvider = Provider<FavoritesService>((ref) {
   return ref.read(appStateControllerProvider).appState.seriesFavoritesService;
 });
-
-// ---------------------------------------------------------------------------
-// LiveChannelsNotifier: hardened async version that owns the full
-// fetch → cache → serve cycle for live channels.
-//
-// Implements stale-while-revalidate:
-//   Fresh cache  → return immediately, no network call.
-//   Stale cache  → fetch, cache, return fresh data.
-//   No cache     → fetch, cache, return.
-//   Not configured → return cached data or empty list.
-// ---------------------------------------------------------------------------
-
-final liveChannelsNotifierProvider =
-    AsyncNotifierProvider<LiveChannelsNotifier, List<Channel>>(
-      LiveChannelsNotifier.new,
-    );
-
-class LiveChannelsNotifier extends AsyncNotifier<List<Channel>> {
-  @override
-  Future<List<Channel>> build() async {
-    // Keep alive across route changes — channels are global app state.
-    ref.keepAlive();
-
-    final cache = ref.read(cacheServiceProvider);
-    final xtream = ref.read(xtreamServiceProvider);
-
-    if (!xtream.isConfigured) {
-      final entry = await cache.get<List<Channel>>('liveStreams');
-      return entry?.data ?? const <Channel>[];
-    }
-
-    final entry = await cache.get<List<Channel>>('liveStreams');
-    if (entry != null && !entry.isStale) return entry.data;
-
-    final channels = await xtream.getLiveStreams();
-    await cache.set('liveStreams', channels);
-    return channels;
-  }
-
-  /// Forces a fresh fetch. Pass [clearCache] to also wipe persisted entries.
-  Future<void> refresh({bool clearCache = false}) async {
-    if (clearCache) {
-      await ref.read(cacheServiceProvider).clear();
-    }
-    ref.invalidateSelf();
-    await future;
-  }
-}

--- a/flutter_client/lib/providers/app_providers.dart
+++ b/flutter_client/lib/providers/app_providers.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/foundation.dart' show ChangeNotifier;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/cache_service.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/xtream_service.dart';
+
+// ---------------------------------------------------------------------------
+// Proxy: wraps AppStateController and forwards ChangeNotifier notifications.
+//
+// Riverpod owns the proxy's lifecycle — it disposes the proxy when the
+// ProviderScope tears down. The proxy's dispose() removes the forwarding
+// listener but deliberately does NOT call appState.dispose(), so the caller
+// retains full lifecycle ownership of the underlying AppStateController.
+// ---------------------------------------------------------------------------
+
+class _AppStateProxy extends ChangeNotifier {
+  _AppStateProxy(this.appState) {
+    appState.addListener(notifyListeners);
+  }
+
+  final AppStateController appState;
+
+  @override
+  void dispose() {
+    appState.removeListener(notifyListeners);
+    super.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Injection point. Override via [overrideAppState] inside ProviderScope to
+// inject an AppStateController without transferring disposal ownership to
+// Riverpod.
+// ---------------------------------------------------------------------------
+
+final appStateControllerProvider = ChangeNotifierProvider<_AppStateProxy>((_) {
+  throw UnimplementedError(
+    'appStateControllerProvider must be overridden via ProviderScope. '
+    'Call overrideAppState(yourController) in the overrides list.',
+  );
+});
+
+/// Creates a [ProviderOverride] that injects [appState] into the Riverpod
+/// provider tree without transferring disposal ownership to Riverpod.
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [overrideAppState(myController)],
+///   child: ...,
+/// )
+/// ```
+Override overrideAppState(AppStateController appState) =>
+    appStateControllerProvider.overrideWith(
+      (ref) => _AppStateProxy(appState),
+    );
+
+// ---------------------------------------------------------------------------
+// Service providers — stable references that never change after construction.
+// Use ref.read (not ref.watch) since services don't need rebuild tracking.
+// ---------------------------------------------------------------------------
+
+final cacheServiceProvider = Provider<CacheService>((ref) {
+  return ref.read(appStateControllerProvider).appState.cacheService;
+});
+
+final xtreamServiceProvider = Provider<XtreamService>((ref) {
+  return ref.read(appStateControllerProvider).appState.xtreamService;
+});
+
+// ---------------------------------------------------------------------------
+// Reactive data providers. These use ref.watch(appStateControllerProvider)
+// so they subscribe to the proxy's notifications and rebuild whenever
+// AppStateController.notifyListeners() fires.
+// ---------------------------------------------------------------------------
+
+final liveChannelsProvider = Provider<List<Channel>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.channels;
+});
+
+final liveCategoriesProvider = Provider<List<Category>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.liveCategories;
+});
+
+final vodItemsProvider = Provider<List<VodItem>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.vodItems;
+});
+
+final vodCategoriesProvider = Provider<List<Category>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.vodCategories;
+});
+
+final seriesListProvider = Provider<List<Series>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.seriesList;
+});
+
+final seriesCategoriesProvider = Provider<List<Category>>((ref) {
+  return ref.watch(appStateControllerProvider).appState.seriesCategories;
+});
+
+final isLoadingContentProvider = Provider<bool>((ref) {
+  return ref.watch(appStateControllerProvider).appState.isLoadingContent;
+});
+
+final isConfiguredProvider = Provider<bool>((ref) {
+  return ref.watch(appStateControllerProvider).appState.isConfigured;
+});
+
+// ---------------------------------------------------------------------------
+// LiveChannelsNotifier: hardened async version that owns the full
+// fetch → cache → serve cycle for live channels.
+//
+// Implements stale-while-revalidate:
+//   Fresh cache  → return immediately, no network call.
+//   Stale cache  → fetch, cache, return fresh data.
+//   No cache     → fetch, cache, return.
+//   Not configured → return cached data or empty list.
+// ---------------------------------------------------------------------------
+
+final liveChannelsNotifierProvider =
+    AsyncNotifierProvider<LiveChannelsNotifier, List<Channel>>(
+      LiveChannelsNotifier.new,
+    );
+
+class LiveChannelsNotifier extends AsyncNotifier<List<Channel>> {
+  @override
+  Future<List<Channel>> build() async {
+    // Keep alive across route changes — channels are global app state.
+    ref.keepAlive();
+
+    final cache = ref.read(cacheServiceProvider);
+    final xtream = ref.read(xtreamServiceProvider);
+
+    if (!xtream.isConfigured) {
+      final entry = await cache.get<List<Channel>>('liveStreams');
+      return entry?.data ?? const <Channel>[];
+    }
+
+    final entry = await cache.get<List<Channel>>('liveStreams');
+    if (entry != null && !entry.isStale) return entry.data;
+
+    final channels = await xtream.getLiveStreams();
+    await cache.set('liveStreams', channels);
+    return channels;
+  }
+
+  /// Forces a fresh fetch. Pass [clearCache] to also wipe persisted entries.
+  Future<void> refresh({bool clearCache = false}) async {
+    if (clearCache) {
+      await ref.read(cacheServiceProvider).clear();
+    }
+    ref.invalidateSelf();
+    await future;
+  }
+}

--- a/flutter_client/lib/providers/app_providers.dart
+++ b/flutter_client/lib/providers/app_providers.dart
@@ -4,6 +4,8 @@ import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart'
+    show TvNotificationItem;
 import 'package:m3u_tv/services/tv_notification_store.dart';
 
 // ---------------------------------------------------------------------------
@@ -106,10 +108,6 @@ final isBootstrappingProvider = Provider<bool>((ref) {
   return ref.watch(appStateControllerProvider).appState.isBootstrapping;
 });
 
-final unreadNotificationCountProvider = Provider<int>((ref) {
-  return ref.watch(appStateControllerProvider).appState.unreadNotificationCount;
-});
-
 final progressListProvider = Provider<List<Progress>>((ref) {
   return ref.watch(appStateControllerProvider).appState.progressList;
 });
@@ -148,4 +146,13 @@ final seriesFavoritesServiceProvider = Provider<FavoritesService>((ref) {
 
 final notificationStoreProvider = Provider<TvNotificationStore>((ref) {
   return ref.read(appStateControllerProvider).appState.notificationStore;
+});
+
+// Exposes the live notification broadcast stream so screens can subscribe
+// directly in initState — bypasses Riverpod change-detection timing issues
+// with ChangeNotifierProvider when the widget hasn't been built yet.
+final tvNotificationsStreamProvider = Provider<Stream<TvNotificationItem>>((
+  ref,
+) {
+  return ref.read(appStateControllerProvider).appState.tvNotifications;
 });

--- a/flutter_client/lib/providers/app_providers.dart
+++ b/flutter_client/lib/providers/app_providers.dart
@@ -4,6 +4,7 @@ import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
+import 'package:m3u_tv/services/tv_notification_store.dart';
 
 // ---------------------------------------------------------------------------
 // Proxy: wraps AppStateController and forwards ChangeNotifier notifications.
@@ -143,4 +144,8 @@ final vodFavoritesServiceProvider = Provider<FavoritesService>((ref) {
 
 final seriesFavoritesServiceProvider = Provider<FavoritesService>((ref) {
   return ref.read(appStateControllerProvider).appState.seriesFavoritesService;
+});
+
+final notificationStoreProvider = Provider<TvNotificationStore>((ref) {
+  return ref.read(appStateControllerProvider).appState.notificationStore;
 });

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -750,8 +750,10 @@ class AppStateController extends ChangeNotifier {
         );
       }
       if (programs.isNotEmpty) {
+        // EpgService.loadPrograms() calls notifyListeners() on the EpgService
+        // itself — widgets watching epgServiceProvider will rebuild without
+        // triggering a full AppStateController rebuild.
         epgService.loadPrograms(programs);
-        notifyListeners();
       }
     } on Object catch (e) {
       if (kDebugMode) debugPrint('[EPG] getEpgBatch failed: $e');

--- a/flutter_client/lib/services/epg_service.dart
+++ b/flutter_client/lib/services/epg_service.dart
@@ -1,8 +1,9 @@
+import 'package:flutter/foundation.dart' show ChangeNotifier;
 import 'package:m3u_tv/services/domain_models.dart';
 
 typedef Clock = DateTime Function();
 
-class EpgService {
+class EpgService extends ChangeNotifier {
   EpgService({Clock? clock, this.cacheTtl = const Duration(minutes: 30)})
     : _clock = clock ?? DateTime.now;
 
@@ -16,6 +17,7 @@ class EpgService {
     _programsByChannel.clear();
     _storePrograms(programs);
     _loadedAt = _clock();
+    notifyListeners();
   }
 
   void mergePrograms(List<EpgProgram> programs) {
@@ -28,6 +30,7 @@ class EpgService {
     }
     _storePrograms(programs);
     _loadedAt = _clock();
+    notifyListeners();
   }
 
   void _storePrograms(List<EpgProgram> programs) {

--- a/flutter_client/lib/services/tv_notification_service.dart
+++ b/flutter_client/lib/services/tv_notification_service.dart
@@ -107,14 +107,19 @@ class TvNotificationItem {
   /// 'success' | 'warning' | 'danger' | 'info'
   final String status;
 
-  factory TvNotificationItem.fromJson(Map<String, Object?> json) =>
-      TvNotificationItem(
-        id: '${json['id'] ?? ''}',
-        channel: '${json['channel'] ?? 'general'}',
-        title: '${json['title'] ?? ''}',
-        body: json['body'] as String?,
-        status: '${json['status'] ?? 'info'}',
-      );
+  factory TvNotificationItem.fromJson(Map<String, Object?> json) {
+    final rawId = json['id'];
+    final id = rawId is String && rawId.isNotEmpty
+        ? rawId
+        : 'live-${DateTime.now().microsecondsSinceEpoch}';
+    return TvNotificationItem(
+      id: id,
+      channel: '${json['channel'] ?? 'general'}',
+      title: '${json['title'] ?? ''}',
+      body: json['body'] as String?,
+      status: '${json['status'] ?? 'info'}',
+    );
+  }
 }
 
 /// REST client for the `/api/tv` endpoints.

--- a/flutter_client/lib/shared/media_browsing_widgets.dart
+++ b/flutter_client/lib/shared/media_browsing_widgets.dart
@@ -879,10 +879,17 @@ class _MediaPreviewCardState extends State<MediaPreviewCard> {
                   Positioned(
                     top: 4,
                     left: 4,
-                    child: Icon(
-                      Icons.star,
-                      color: colorScheme.primary,
-                      size: 20,
+                    child: Container(
+                      padding: const EdgeInsets.all(3),
+                      decoration: BoxDecoration(
+                        color: colorScheme.primary,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.star,
+                        color: Color(0xFFFFFFFF),
+                        size: 14,
+                      ),
                     ),
                   ),
               ],

--- a/flutter_client/lib/shared/media_browsing_widgets.dart
+++ b/flutter_client/lib/shared/media_browsing_widgets.dart
@@ -887,7 +887,7 @@ class _MediaPreviewCardState extends State<MediaPreviewCard> {
                       ),
                       child: const Icon(
                         Icons.star,
-                        color: Color(0xFFFFFFFF),
+                        color: Colors.white,
                         size: 14,
                       ),
                     ),

--- a/flutter_client/pubspec.lock
+++ b/flutter_client/pubspec.lock
@@ -288,6 +288,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.8"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -803,6 +811,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   safe_local_storage:
     dependency: transitive
     description:
@@ -856,6 +872,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:

--- a/flutter_client/pubspec.yaml
+++ b/flutter_client/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  flutter_riverpod: ^2.6.1
   flutter_secure_storage: ^10.3.1
   flutter_secure_storage_tvos:
     path: packages/flutter_secure_storage_tvos

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -3,11 +3,13 @@ import 'dart:convert';
 import 'dart:io' as io;
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:m3u_tv/app/app_shell.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/navigation/go_router_config.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/cache_service.dart';
 import 'package:m3u_tv/services/domain_models.dart';
@@ -625,10 +627,13 @@ class _TestAppState extends State<_TestApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      theme: ThemeData.dark(useMaterial3: true),
-      routerConfig: _router,
+    return ProviderScope(
+      overrides: [overrideAppState(widget.controller)],
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        theme: ThemeData.dark(useMaterial3: true),
+        routerConfig: _router,
+      ),
     );
   }
 }

--- a/flutter_client/test/providers/live_channels_provider_test.dart
+++ b/flutter_client/test/providers/live_channels_provider_test.dart
@@ -2,183 +2,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
-import 'package:m3u_tv/services/cache_service.dart';
-import 'package:m3u_tv/services/domain_models.dart';
-import 'package:m3u_tv/services/xtream_service.dart';
-
-// ---------------------------------------------------------------------------
-// Stubs
-// ---------------------------------------------------------------------------
-
-const _stubChannel = Channel(
-  id: 1,
-  name: 'BBC One',
-  streamUrl: 'http://example.com/bbc1.m3u8',
-);
-
-class _StubXtreamService extends XtreamService {
-  _StubXtreamService({
-    this.channels = const [],
-    this.configured = false,
-    this.delay = Duration.zero,
-  }) : super(cache: CacheService());
-
-  final List<Channel> channels;
-  final Duration delay;
-  bool configured;
-  int fetchCount = 0;
-
-  @override
-  bool get isConfigured => configured;
-
-  @override
-  Future<List<Channel>> getLiveStreams({String? categoryId}) async {
-    if (delay != Duration.zero) await Future<void>.delayed(delay);
-    fetchCount++;
-    return channels;
-  }
-}
-
-AppStateController _buildController({
-  CacheService? cache,
-  _StubXtreamService? xtream,
-}) {
-  final resolvedCache = cache ?? CacheService();
-  final resolvedXtream =
-      xtream ?? _StubXtreamService(channels: const [_stubChannel]);
-  return AppStateController(
-    cacheService: resolvedCache,
-    xtreamService: resolvedXtream,
-  );
-}
-
-ProviderContainer _container(AppStateController controller) {
-  return ProviderContainer(overrides: [overrideAppState(controller)]);
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 void main() {
   group('liveChannelsProvider (bridge)', () {
     test('reflects channels list from AppStateController synchronously', () {
-      final container = _container(_buildController());
+      final controller = AppStateController();
+      final container = ProviderContainer(
+        overrides: [overrideAppState(controller)],
+      );
       addTearDown(container.dispose);
+      addTearDown(controller.dispose);
 
       expect(container.read(liveChannelsProvider), isEmpty);
-    });
-  });
-
-  group('LiveChannelsNotifier', () {
-    test('returns empty list when not configured and cache is cold', () async {
-      final cache = CacheService();
-      final stub = _StubXtreamService();
-      final container = _container(
-        _buildController(cache: cache, xtream: stub),
-      );
-      addTearDown(container.dispose);
-
-      final result = await container.read(liveChannelsNotifierProvider.future);
-
-      expect(result, isEmpty);
-      expect(stub.fetchCount, 0);
-    });
-
-    test(
-      'returns cached data without network call when cache is fresh',
-      () async {
-        final cache = CacheService();
-        final stub = _StubXtreamService(
-          channels: const [_stubChannel],
-          configured: true,
-        );
-
-        await cache.set<List<Channel>>('liveStreams', const [_stubChannel]);
-
-        final container = _container(
-          _buildController(cache: cache, xtream: stub),
-        );
-        addTearDown(container.dispose);
-
-        final result = await container.read(
-          liveChannelsNotifierProvider.future,
-        );
-
-        expect(result, hasLength(1));
-        expect(result.first.name, 'BBC One');
-        expect(stub.fetchCount, 0);
-      },
-    );
-
-    test('fetches from network when cache is stale', () async {
-      final cache = CacheService(
-        refreshInterval: Duration.zero, // everything is immediately stale
-      );
-      final stub = _StubXtreamService(
-        channels: const [_stubChannel],
-        configured: true,
-      );
-
-      await cache.set<List<Channel>>('liveStreams', const []);
-
-      final container = _container(
-        _buildController(cache: cache, xtream: stub),
-      );
-      addTearDown(container.dispose);
-
-      final result = await container.read(liveChannelsNotifierProvider.future);
-
-      expect(result, hasLength(1));
-      expect(stub.fetchCount, 1);
-    });
-
-    test('refresh(clearCache: true) forces a fresh network fetch', () async {
-      final cache = CacheService();
-      final stub = _StubXtreamService(
-        channels: const [_stubChannel],
-        configured: true,
-      );
-
-      await cache.set<List<Channel>>('liveStreams', const [_stubChannel]);
-
-      final container = _container(
-        _buildController(cache: cache, xtream: stub),
-      );
-      addTearDown(container.dispose);
-
-      // First read — served from fresh cache.
-      await container.read(liveChannelsNotifierProvider.future);
-      expect(stub.fetchCount, 0);
-
-      await container
-          .read(liveChannelsNotifierProvider.notifier)
-          .refresh(clearCache: true);
-
-      expect(stub.fetchCount, 1);
-    });
-
-    test('concurrent reads deduplicate into a single fetch', () async {
-      final cache = CacheService(refreshInterval: Duration.zero);
-      final stub = _StubXtreamService(
-        channels: const [_stubChannel],
-        configured: true,
-        delay: const Duration(milliseconds: 10),
-      );
-
-      final container = _container(
-        _buildController(cache: cache, xtream: stub),
-      );
-      addTearDown(container.dispose);
-
-      final results = await Future.wait([
-        container.read(liveChannelsNotifierProvider.future),
-        container.read(liveChannelsNotifierProvider.future),
-        container.read(liveChannelsNotifierProvider.future),
-      ]);
-
-      expect(results.every((r) => r.length == 1), isTrue);
-      expect(stub.fetchCount, 1);
     });
   });
 }

--- a/flutter_client/test/providers/live_channels_provider_test.dart
+++ b/flutter_client/test/providers/live_channels_provider_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/cache_service.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/xtream_service.dart';
+
+// ---------------------------------------------------------------------------
+// Stubs
+// ---------------------------------------------------------------------------
+
+const _stubChannel = Channel(
+  id: 1,
+  name: 'BBC One',
+  streamUrl: 'http://example.com/bbc1.m3u8',
+);
+
+class _StubXtreamService extends XtreamService {
+  _StubXtreamService({
+    this.channels = const [],
+    this.configured = false,
+    this.delay = Duration.zero,
+  }) : super(cache: CacheService());
+
+  final List<Channel> channels;
+  final Duration delay;
+  bool configured;
+  int fetchCount = 0;
+
+  @override
+  bool get isConfigured => configured;
+
+  @override
+  Future<List<Channel>> getLiveStreams({String? categoryId}) async {
+    if (delay != Duration.zero) await Future<void>.delayed(delay);
+    fetchCount++;
+    return channels;
+  }
+}
+
+AppStateController _buildController({
+  CacheService? cache,
+  _StubXtreamService? xtream,
+}) {
+  final resolvedCache = cache ?? CacheService();
+  final resolvedXtream =
+      xtream ?? _StubXtreamService(channels: const [_stubChannel]);
+  return AppStateController(
+    cacheService: resolvedCache,
+    xtreamService: resolvedXtream,
+  );
+}
+
+ProviderContainer _container(AppStateController controller) {
+  return ProviderContainer(overrides: [overrideAppState(controller)]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('liveChannelsProvider (bridge)', () {
+    test('reflects channels list from AppStateController synchronously', () {
+      final container = _container(_buildController());
+      addTearDown(container.dispose);
+
+      expect(container.read(liveChannelsProvider), isEmpty);
+    });
+  });
+
+  group('LiveChannelsNotifier', () {
+    test('returns empty list when not configured and cache is cold', () async {
+      final cache = CacheService();
+      final stub = _StubXtreamService();
+      final container = _container(
+        _buildController(cache: cache, xtream: stub),
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(liveChannelsNotifierProvider.future);
+
+      expect(result, isEmpty);
+      expect(stub.fetchCount, 0);
+    });
+
+    test(
+      'returns cached data without network call when cache is fresh',
+      () async {
+        final cache = CacheService();
+        final stub = _StubXtreamService(
+          channels: const [_stubChannel],
+          configured: true,
+        );
+
+        await cache.set<List<Channel>>('liveStreams', const [_stubChannel]);
+
+        final container = _container(
+          _buildController(cache: cache, xtream: stub),
+        );
+        addTearDown(container.dispose);
+
+        final result = await container.read(
+          liveChannelsNotifierProvider.future,
+        );
+
+        expect(result, hasLength(1));
+        expect(result.first.name, 'BBC One');
+        expect(stub.fetchCount, 0);
+      },
+    );
+
+    test('fetches from network when cache is stale', () async {
+      final cache = CacheService(
+        refreshInterval: Duration.zero, // everything is immediately stale
+      );
+      final stub = _StubXtreamService(
+        channels: const [_stubChannel],
+        configured: true,
+      );
+
+      await cache.set<List<Channel>>('liveStreams', const []);
+
+      final container = _container(
+        _buildController(cache: cache, xtream: stub),
+      );
+      addTearDown(container.dispose);
+
+      final result = await container.read(liveChannelsNotifierProvider.future);
+
+      expect(result, hasLength(1));
+      expect(stub.fetchCount, 1);
+    });
+
+    test('refresh(clearCache: true) forces a fresh network fetch', () async {
+      final cache = CacheService();
+      final stub = _StubXtreamService(
+        channels: const [_stubChannel],
+        configured: true,
+      );
+
+      await cache.set<List<Channel>>('liveStreams', const [_stubChannel]);
+
+      final container = _container(
+        _buildController(cache: cache, xtream: stub),
+      );
+      addTearDown(container.dispose);
+
+      // First read — served from fresh cache.
+      await container.read(liveChannelsNotifierProvider.future);
+      expect(stub.fetchCount, 0);
+
+      await container
+          .read(liveChannelsNotifierProvider.notifier)
+          .refresh(clearCache: true);
+
+      expect(stub.fetchCount, 1);
+    });
+
+    test('concurrent reads deduplicate into a single fetch', () async {
+      final cache = CacheService(refreshInterval: Duration.zero);
+      final stub = _StubXtreamService(
+        channels: const [_stubChannel],
+        configured: true,
+        delay: const Duration(milliseconds: 10),
+      );
+
+      final container = _container(
+        _buildController(cache: cache, xtream: stub),
+      );
+      addTearDown(container.dispose);
+
+      final results = await Future.wait([
+        container.read(liveChannelsNotifierProvider.future),
+        container.read(liveChannelsNotifierProvider.future),
+        container.read(liveChannelsNotifierProvider.future),
+      ]);
+
+      expect(results.every((r) => r.length == 1), isTrue);
+      expect(stub.fetchCount, 1);
+    });
+  });
+}

--- a/flutter_client/test/ui/features/live_tv_screen_test.dart
+++ b/flutter_client/test/ui/features/live_tv_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/live_tv/live_tv_screen.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
@@ -316,18 +318,24 @@ class _TestApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      theme: ThemeData.dark(useMaterial3: true),
-      home: LiveTvScreen(
-        channels: channels,
-        categories: categories,
-        isLoading: isLoading,
-        isConfigured: isConfigured,
-        favoritesService: favoritesService ?? FavoritesService(),
-        epgService: epgService ?? EpgService(),
-        onChannelSelect: onChannelSelect ?? (_) {},
-        onScheduleProgram: onScheduleProgram,
+    final epg = epgService ?? EpgService();
+    return ProviderScope(
+      overrides: [
+        isBootstrappingProvider.overrideWith((_) => false),
+        isConfiguredProvider.overrideWith((_) => isConfigured),
+        isLoadingContentProvider.overrideWith((_) => isLoading),
+        liveChannelsProvider.overrideWith((_) => channels),
+        liveCategoriesProvider.overrideWith((_) => categories),
+        epgServiceProvider.overrideWith((_) => epg),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        theme: ThemeData.dark(useMaterial3: true),
+        home: LiveTvScreen(
+          favoritesService: favoritesService ?? FavoritesService(),
+          onChannelSelect: onChannelSelect ?? (_) {},
+          onScheduleProgram: onScheduleProgram,
+        ),
       ),
     );
   }

--- a/flutter_client/test/ui/features/search_screen_test.dart
+++ b/flutter_client/test/ui/features/search_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/search/search_screen.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/dpad_tab_bar.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
@@ -318,17 +320,22 @@ class _TestApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      theme: ThemeData.dark(useMaterial3: true),
-      home: SearchScreen(
-        channels: channels,
-        vodItems: vodItems,
-        seriesList: seriesList,
-        isConfigured: isConfigured,
-        onChannelSelect: onChannelSelect ?? (_) {},
-        onVodSelect: onVodSelect ?? (_) {},
-        onSeriesSelect: onSeriesSelect ?? (_) {},
+    return ProviderScope(
+      overrides: [
+        isBootstrappingProvider.overrideWith((_) => false),
+        isConfiguredProvider.overrideWith((_) => isConfigured),
+        liveChannelsProvider.overrideWith((_) => channels),
+        vodItemsProvider.overrideWith((_) => vodItems),
+        seriesListProvider.overrideWith((_) => seriesList),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        theme: ThemeData.dark(useMaterial3: true),
+        home: SearchScreen(
+          onChannelSelect: onChannelSelect ?? (_) {},
+          onVodSelect: onVodSelect ?? (_) {},
+          onSeriesSelect: onSeriesSelect ?? (_) {},
+        ),
       ),
     );
   }

--- a/flutter_client/test/ui/features/series_screen_test.dart
+++ b/flutter_client/test/ui/features/series_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/series/series_screen.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
@@ -228,15 +230,20 @@ class _TestApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      theme: ThemeData.dark(useMaterial3: true),
-      home: SeriesScreen(
-        seriesList: seriesList,
-        categories: categories,
-        isLoading: isLoading,
-        isConfigured: isConfigured,
-        onSeriesSelect: onSeriesSelect ?? (_) {},
+    return ProviderScope(
+      overrides: [
+        isBootstrappingProvider.overrideWith((_) => false),
+        isConfiguredProvider.overrideWith((_) => isConfigured),
+        isLoadingContentProvider.overrideWith((_) => isLoading),
+        seriesListProvider.overrideWith((_) => seriesList),
+        seriesCategoriesProvider.overrideWith((_) => categories),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        theme: ThemeData.dark(useMaterial3: true),
+        home: SeriesScreen(
+          onSeriesSelect: onSeriesSelect ?? (_) {},
+        ),
       ),
     );
   }

--- a/flutter_client/test/ui/features/vod_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/vod/vod_screen.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
@@ -261,15 +263,20 @@ class _TestApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      theme: ThemeData.dark(useMaterial3: true),
-      home: VodScreen(
-        vodItems: vodItems,
-        categories: categories,
-        isLoading: isLoading,
-        isConfigured: isConfigured,
-        onVodSelect: onVodSelect ?? (_) {},
+    return ProviderScope(
+      overrides: [
+        isBootstrappingProvider.overrideWith((_) => false),
+        isConfiguredProvider.overrideWith((_) => isConfigured),
+        isLoadingContentProvider.overrideWith((_) => isLoading),
+        vodItemsProvider.overrideWith((_) => vodItems),
+        vodCategoriesProvider.overrideWith((_) => categories),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        theme: ThemeData.dark(useMaterial3: true),
+        home: VodScreen(
+          onVodSelect: onVodSelect ?? (_) {},
+        ),
       ),
     );
   }

--- a/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
+++ b/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/live_tv/live_tv_screen.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
@@ -12,24 +14,30 @@ void main() {
   ) async {
     final favorites = FavoritesService(memory: <String, Object?>{});
     final epg = EpgService(clock: () => DateTime.utc(2026, 1, 1, 12));
+    const channels = [
+      Channel(
+        id: 101,
+        name: 'Route News',
+        streamUrl: 'https://example.com/news.m3u8',
+      ),
+    ];
 
     await tester.pumpWidget(
-      MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        home: LiveTvScreen(
-          channels: const [
-            Channel(
-              id: 101,
-              name: 'Route News',
-              streamUrl: 'https://example.com/news.m3u8',
-            ),
-          ],
-          categories: const [],
-          isLoading: false,
-          isConfigured: true,
-          favoritesService: favorites,
-          epgService: epg,
-          onChannelSelect: (_) {},
+      ProviderScope(
+        overrides: [
+          isBootstrappingProvider.overrideWith((_) => false),
+          isConfiguredProvider.overrideWith((_) => true),
+          isLoadingContentProvider.overrideWith((_) => false),
+          liveChannelsProvider.overrideWith((_) => channels),
+          liveCategoriesProvider.overrideWith((_) => const []),
+          epgServiceProvider.overrideWith((_) => epg),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          home: LiveTvScreen(
+            favoritesService: favorites,
+            onChannelSelect: (_) {},
+          ),
         ),
       ),
     );
@@ -65,30 +73,36 @@ void main() {
         ]);
       Channel? recordedChannel;
       EpgProgram? recordedProgram;
+      const channels = [
+        Channel(
+          id: 101,
+          name: 'Route News',
+          streamUrl: 'https://example.com/news.m3u8',
+          epgChannelId: 'news.epg',
+        ),
+      ];
 
       await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: LiveTvScreen(
-            channels: const [
-              Channel(
-                id: 101,
-                name: 'Route News',
-                streamUrl: 'https://example.com/news.m3u8',
-                epgChannelId: 'news.epg',
-              ),
-            ],
-            categories: const [],
-            isLoading: false,
-            isConfigured: true,
-            favoritesService: favorites,
-            epgService: epg,
-            onChannelSelect: (_) {},
-            onScheduleProgram: (channel, program) {
-              recordedChannel = channel;
-              recordedProgram = program;
-            },
+        ProviderScope(
+          overrides: [
+            isBootstrappingProvider.overrideWith((_) => false),
+            isConfiguredProvider.overrideWith((_) => true),
+            isLoadingContentProvider.overrideWith((_) => false),
+            liveChannelsProvider.overrideWith((_) => channels),
+            liveCategoriesProvider.overrideWith((_) => const []),
+            epgServiceProvider.overrideWith((_) => epg),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: LiveTvScreen(
+              favoritesService: favorites,
+              onChannelSelect: (_) {},
+              onScheduleProgram: (channel, program) {
+                recordedChannel = channel;
+                recordedProgram = program;
+              },
+            ),
           ),
         ),
       );

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:m3u_tv/app/app_shell.dart';
@@ -13,6 +14,7 @@ import 'package:m3u_tv/navigation/go_router_config.dart';
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/playback_orchestrator.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/cache_service.dart';
 import 'package:m3u_tv/services/domain_models.dart';
@@ -1252,18 +1254,25 @@ class _TestAppState extends State<_TestApp> {
 
   @override
   void dispose() {
+    // The proxy inside ProviderScope is disposed by Riverpod, but it does NOT
+    // dispose _appState — the caller retains lifecycle ownership. Dispose here
+    // only when _TestAppState itself created the controller (widget.appState
+    // was null); external callers (which use addTearDown) own their own.
     if (widget.appState == null) _appState.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'M3U TV Test',
-      theme: ThemeData.dark(useMaterial3: true),
-      routerConfig: _router,
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
+    return ProviderScope(
+      overrides: [overrideAppState(_appState)],
+      child: MaterialApp.router(
+        title: 'M3U TV Test',
+        theme: ThemeData.dark(useMaterial3: true),
+        routerConfig: _router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+      ),
     );
   }
 }

--- a/flutter_client/test/widget_test.dart
+++ b/flutter_client/test/widget_test.dart
@@ -1,17 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:m3u_tv/main.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
 
 void main() {
-  testWidgets('renders the app shell', (
-    tester,
-  ) async {
-    await tester.pumpWidget(const MyApp());
+  testWidgets('renders the app shell', (tester) async {
+    final appState = AppStateController();
+    addTearDown(appState.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [overrideAppState(appState)],
+        child: MyApp(appState: appState),
+      ),
+    );
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 250));
     await tester.pump();
 
-    // The app shell should render with the Home placeholder
     expect(find.text('Home'), findsAtLeast(1));
   });
 }


### PR DESCRIPTION
## Summary

Completes the Riverpod migration, all feature screens now read
display data exclusively through Riverpod providers — no screen holds a direct
`AppStateController` reference.

### What changed

**Provider layer (`lib/providers/app_providers.dart`)**
- Added `_AppStateProxy` — a thin `ChangeNotifier` wrapper that lets Riverpod own the proxy
  lifecycle while the caller retains `AppStateController` disposal ownership
- Added `overrideAppState()` helper for injecting a controller in `ProviderScope.overrides`
  during tests
- Added providers for all feature data: `progressListProvider`, `dvrRecordingsProvider`,
  `sourceLabelProvider`, `sourceErrorProvider`, `hasDvrFeatureProvider`,
  `unreadNotificationCountProvider`, `liveFavoritesServiceProvider`,
  `vodFavoritesServiceProvider`, `seriesFavoritesServiceProvider`, `epgServiceProvider`

**Screens converted to `ConsumerStatefulWidget`**
- `LiveTvScreen`, `VodScreen`, `SeriesScreen`, `SearchScreen`, `_HomeScreen` — all now read
  data via `ref.watch(...)` and receive actions as typed callbacks only

**`EpgService`** — extended `ChangeNotifier` so EPG refreshes notify independently of
`AppStateController`, preventing full-app rebuilds on schedule loads

**`AppShell` fixes**
- `_HomeScreen` no longer accepts an `AppStateController` param
- Settings, DVR, and Requests tabs wrapped in `ListenableBuilder` to stay reactive despite
  go_router's `pageBuilder` being called only once per tab
- Fixed `_showMoreSheet` missing `unreadCount` parameter
- Fixed `_resumePreviewItem` to accept `vodItems` and `seriesList` as params rather than
  reading from the controller

**Tests**
- Rewrote 5 feature screen tests to use `ProviderScope` with `.overrideWith()` instead of
  old constructor params — all 328 tests passing

**Docs**
- `CLAUDE.md` — added mandatory "State Management (Riverpod)" section with provider
  catalogue, do/don't examples, and test pattern
- `README.md` — updated project structure tree and added State Architecture table

### Architecture rule going forward

Feature screens extend `ConsumerStatefulWidget` and call `ref.watch(provider)` for all
display data. Actions arrive as callbacks. `AppStateController` remains the orchestrator
for mutations but is never referenced directly in screen widgets.
