### PR TITLE
fix: paint Android mobile routes edge to edge

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -279,7 +279,7 @@ class AppShellState extends ConsumerState<AppShell>
   }
 
   // Stable method tearoff passed to ContentActions.onOpenPlayer.
-  // Must NOT be a local closure in build() — closures are always new instances,
+  // Must NOT be a local closure in build() - closures are always new instances,
   // which makes ContentActions.updateShouldNotify return true on every rebuild
   // and cascade unnecessary rebuilds to all feature screens.
   void _openPlayerFromActions(PlayerArgs args) =>
@@ -965,7 +965,7 @@ class AppShellState extends ConsumerState<AppShell>
         : moreTabIndex;
 
     return Scaffold(
-      body: SafeArea(bottom: false, child: contentShell),
+      body: contentShell,
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.fixed,
         currentIndex: displayedIndex,

--- a/flutter_client/lib/navigation/go_router_config.dart
+++ b/flutter_client/lib/navigation/go_router_config.dart
@@ -27,12 +27,17 @@ const BoxDecoration _kGradientBg = BoxDecoration(
   ),
 );
 
-Widget _withGradient(Widget screen) =>
-    DecoratedBox(decoration: _kGradientBg, child: screen);
+Widget _withGradient(Widget screen) => DecoratedBox(
+  decoration: _kGradientBg,
+  child: SafeArea(bottom: false, child: screen),
+);
 
 CustomTransitionPage<void> _slidePage(Widget screen) =>
     CustomTransitionPage<void>(
-      child: ColoredBox(color: const Color(0xFF09090b), child: screen),
+      child: ColoredBox(
+        color: const Color(0xFF09090b),
+        child: SafeArea(bottom: false, child: screen),
+      ),
       transitionsBuilder: (context, animation, _, child) => SlideTransition(
         position: Tween<Offset>(
           begin: const Offset(1, 0),

--- a/flutter_client/test/ui/navigation/mobile_edge_to_edge_test.dart
+++ b/flutter_client/test/ui/navigation/mobile_edge_to_edge_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/app/app_shell.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/navigation/go_router_config.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/cache_service.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
+import 'package:m3u_tv/services/resume_service.dart';
+import 'package:m3u_tv/services/secure_storage.dart';
+import 'package:m3u_tv/services/viewer_service.dart';
+
+void main() {
+  testWidgets(
+    'phone route paints behind portrait top inset while content stays safe',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(400, 800));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await _pumpPhoneApp(tester, const EdgeInsets.only(top: 48));
+
+      final routePaint = _routeGradient();
+      final content = find.text('Please connect to your service in Settings');
+
+      expect(routePaint, findsOneWidget);
+      expect(tester.getTopLeft(routePaint), Offset.zero);
+      expect(tester.getTopRight(routePaint).dx, 400);
+      expect(tester.getTopLeft(content).dy, greaterThanOrEqualTo(48));
+    },
+  );
+
+  testWidgets(
+    'phone route paints behind landscape side insets while content stays safe',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 400));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      await _pumpPhoneApp(
+        tester,
+        const EdgeInsets.only(left: 36, right: 52),
+      );
+
+      final routePaint = _routeGradient();
+      final contentRect = tester.getRect(
+        find.text('Please connect to your service in Settings'),
+      );
+
+      expect(routePaint, findsOneWidget);
+      expect(tester.getTopLeft(routePaint).dx, 0);
+      expect(tester.getTopRight(routePaint).dx, 800);
+      expect(contentRect.left, greaterThanOrEqualTo(36));
+      expect(contentRect.right, lessThanOrEqualTo(748));
+    },
+  );
+}
+
+Future<void> _pumpPhoneApp(
+  WidgetTester tester,
+  EdgeInsets padding,
+) async {
+  final memory = <String, Object?>{};
+  final appState = AppStateController(
+    secureStorage: InMemorySecureStorage(),
+    cacheService: CacheService(memory: <String, Object?>{}),
+    favoritesService: FavoritesService(memory: memory),
+    resumeService: ResumeService(memory: memory),
+    viewerService: ViewerService(memory: memory),
+  );
+  addTearDown(appState.dispose);
+  final router = createGoRouter(
+    appState: appState,
+    nativeTelevisionHint: false,
+    deviceTypeOverride: DeviceType.phone,
+  );
+  addTearDown(router.dispose);
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [overrideAppState(appState)],
+      child: MaterialApp.router(
+        theme: ThemeData.dark(useMaterial3: true).copyWith(
+          scaffoldBackgroundColor: Colors.transparent,
+        ),
+        routerConfig: router,
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        builder: (context, child) => MediaQuery(
+          data: MediaQuery.of(context).copyWith(padding: padding),
+          child: child!,
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 250));
+  await tester.pump();
+}
+
+Finder _routeGradient() {
+  return find.byWidgetPredicate(
+    (widget) =>
+        widget is DecoratedBox &&
+        widget.decoration is BoxDecoration &&
+        (widget.decoration as BoxDecoration).gradient is LinearGradient,
+  );
+}


### PR DESCRIPTION
## Summary
- let mobile tab and detail route backgrounds paint to the full body bounds
- keep route content inside MediaQuery safe insets for status bars and display cutouts
- add portrait top-inset and landscape side-inset geometry regressions

## Root cause
AppShell wrapped the complete mobile navigation shell in SafeArea. That constrained both route content and the route DecoratedBox, so the gradient started below the top inset and inside side insets. On Android 15 and 16, edge-to-edge window behavior can still report nonzero MediaQuery padding, which made the black window background visible above the route.

The fix removes the outer mobile SafeArea and places SafeArea inside each painted route wrapper. The gradient or detail color now paints behind system insets while interactive route content remains protected. BottomNavigationBar placement, TV and desktop layout, player overlays, resume handling, and orientation behavior are unchanged.

## RED evidence
Before production changes, both new widget regressions failed:
- portrait: expected route paint at Offset(0, 0), actual Offset(0, 48)
- landscape: expected route paint at x=0, actual x=36

Both tests also assert that visible route content remains within the synthetic top or side padding.

## Android system UI rationale
SystemUiMode.immersiveSticky remains configured at startup and on resume because it is useful for full-screen Android TV and playback behavior. The layout fix does not assume immersive mode clears MediaQuery.padding and does not use an SDK 35 opt-out. No native theme, manifest, SDK, lifecycle, resume, or orientation changes were required.

## Validation
- flutter pub get
- dart format --output=none --set-exit-if-changed .
- flutter analyze
- flutter test test/ui/navigation/navigation_test.dart
- flutter test test/ui/navigation/mobile_edge_to_edge_test.dart
- flutter test --concurrency=1: 325 passed, 5 pre-existing skipped
- flutter build apk --release --dart-define=TRAKT_CLIENT_ID= --dart-define=TRAKT_CLIENT_SECRET=
- APK SHA-256: 0d3cd3aa36a877a2f9f3e1be7bfc95a515bfe0e4a39a163edaeebe3e8d8531c2
- apksigner verification: v2 signature valid with the expected contributor debug fallback certificate
- git diff --check
- no U+2013 or U+2014 in changed files or commit text

## Remaining QA
Physical Android phone or tablet QA is still required for Android 15 and 16 status bars, gesture or three-button navigation, rotation, and real display cutouts. Physical Android TV smoke testing remains recommended.

Closes #92