### PR TITLE
fix: enforce stable Android release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,22 @@ jobs:
         run: |
           sed -i "s/^version: .*/version: ${{ needs.validate.outputs.version }}+${{ needs.validate.outputs.build_number }}/" pubspec.yaml
 
-      - name: Decode keystore
+      - name: Validate and decode keystore
         env:
           KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
-        run: echo "$KEYSTORE_B64" | base64 --decode > upload-keystore.jks
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for name in KEYSTORE_B64 ANDROID_KEY_ALIAS ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_PASSWORD; do
+            if [ -z "${!name:-}" ]; then
+              echo "ERROR: Required Android signing secret $name is missing or empty."
+              exit 1
+            fi
+          done
+          printf '%s' "$KEYSTORE_B64" | base64 --decode > upload-keystore.jks
+          test -s upload-keystore.jks
 
       - name: Build APK
         run: |
@@ -110,10 +122,38 @@ jobs:
             --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} \
             --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
         env:
-          ANDROID_KEYSTORE_PATH: ../upload-keystore.jks
+          ANDROID_KEYSTORE_PATH: ../../upload-keystore.jks
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_REQUIRE_RELEASE_SIGNING: "true"
+
+      - name: Verify APK signer
+        run: |
+          set -euo pipefail
+          APK="build/app/outputs/flutter-apk/app-release.apk"
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -type f -name apksigner | sort -V | tail -1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "ERROR: apksigner was not found in the Android SDK build-tools."
+            exit 1
+          fi
+          SIGNER_INFO=$("$APKSIGNER" verify --verbose --print-certs "$APK")
+          printf '%s\n' "$SIGNER_INFO"
+          SIGNER_SHA256=$(printf '%s\n' "$SIGNER_INFO" \
+            | sed -n 's/^Signer #1 certificate SHA-256 digest: //p' \
+            | head -1)
+          if [ -z "$SIGNER_SHA256" ]; then
+            echo "ERROR: APK signer SHA-256 digest could not be determined."
+            exit 1
+          fi
+          if printf '%s\n' "$SIGNER_INFO" | grep -qi 'Android Debug'; then
+            echo "ERROR: Refusing to publish an APK signed with an Android Debug certificate."
+            exit 1
+          fi
+          {
+            echo "### Android APK signing"
+            echo "- Signer certificate SHA-256: \`$SIGNER_SHA256\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Stage artifact
         run: cp build/app/outputs/flutter-apk/app-release.apk m3u-tv-v${{ needs.validate.outputs.version }}-android.apk

--- a/docs/release/platform-release-matrix.md
+++ b/docs/release/platform-release-matrix.md
@@ -41,8 +41,10 @@ The workflow does not run Electron builder commands, Electron scripts, or React 
 ## Android App ID, Signing, and TV Release Metadata
 
 - Application ID: `dev.sparkison.tv`; active Android release configuration must not use `com.example` or other template identifiers.
-- Release signing is intentionally blocked until external signing material exists. `flutter_client/android/app/build.gradle.kts` reads `ANDROID_KEYSTORE_PATH`, `ANDROID_KEY_ALIAS`, `ANDROID_KEYSTORE_PASSWORD`, and `ANDROID_KEY_PASSWORD` from Gradle properties, environment variables, or the local ignored file `flutter_client/android/signing.properties`.
-- No debug signing is allowed for release builds. Missing signing values or a missing keystore path must fail release tasks honestly instead of producing a debug-signed production artifact.
+- `flutter_client/android/app/build.gradle.kts` reads `ANDROID_KEYSTORE_PATH`, `ANDROID_KEY_ALIAS`, `ANDROID_KEYSTORE_PASSWORD`, and `ANDROID_KEY_PASSWORD` from Gradle properties, environment variables, or the local ignored file `flutter_client/android/signing.properties`.
+- The publication workflow enables `ANDROID_REQUIRE_RELEASE_SIGNING`. Missing signing values or a missing keystore path therefore fail publication instead of producing a debug-signed artifact. The workflow verifies the APK signer before staging and records its SHA-256 certificate digest in the job summary.
+- Without `ANDROID_REQUIRE_RELEASE_SIGNING`, contributors can create a debug-signed release build for local development only and must not publish it.
+- Users upgrading from a debug-signed version must uninstall the existing debug-signed app once before installing the first stable release-signed build. Uninstalling removes local app data and settings, so users must configure the app again afterward.
 - Android TV launcher metadata must remain present in `flutter_client/android/app/src/main/AndroidManifest.xml`: `android.software.leanback`, optional touchscreen support, application banner, exported main activity, and `LEANBACK_LAUNCHER` category.
 - Play Store and Android TV store distribution remain blocked until signed AAB/APK artifacts, Play Console metadata, data-safety declarations, codec/legal review, physical Android phone/tablet QA, and physical Android TV hardware QA are supplied as release evidence outside git.
 

--- a/flutter_client/android/app/build.gradle.kts
+++ b/flutter_client/android/app/build.gradle.kts
@@ -21,8 +21,8 @@ val androidSigningProperties = Properties().apply {
 }
 
 fun signingValue(name: String): String? =
-    providers.gradleProperty(name).orNull
-        ?: providers.environmentVariable(name).orNull
+    providers.gradleProperty(name).orNull?.takeIf { it.isNotBlank() }
+        ?: providers.environmentVariable(name).orNull?.takeIf { it.isNotBlank() }
         ?: androidSigningProperties.getProperty(name)?.takeIf { it.isNotBlank() }
 
 val releaseSigningKeys = listOf(
@@ -36,6 +36,16 @@ fun hasReleaseSigningKeys(): Boolean {
     val keystorePath = signingValue("ANDROID_KEYSTORE_PATH") ?: return false
     if (!file(keystorePath).isFile) return false
     return releaseSigningKeys.all { !signingValue(it).isNullOrBlank() }
+}
+
+val releaseSigningRequired =
+    signingValue("ANDROID_REQUIRE_RELEASE_SIGNING")?.toBooleanStrictOrNull() ?: false
+val releaseSigningAvailable = hasReleaseSigningKeys()
+
+if (releaseSigningRequired && !releaseSigningAvailable) {
+    throw GradleException(
+        "ANDROID_REQUIRE_RELEASE_SIGNING is enabled, but Android release signing inputs are incomplete or the keystore file is missing.",
+    )
 }
 
 android {
@@ -72,11 +82,12 @@ android {
 
     buildTypes {
         release {
-            // Use release signing when keys are available, otherwise fall back to
-            // debug signing so contributors can build without credentials.
-            signingConfig = if (hasReleaseSigningKeys()) {
+            // Publication requires release signing. Local contributors without
+            // credentials retain a debug-signed release build for development only.
+            signingConfig = if (releaseSigningAvailable) {
                 signingConfigs.getByName("release")
             } else {
+                logger.warn("Creating a debug-signed release build for local development only. Do not publish it.")
                 signingConfigs.getByName("debug")
             }
         }

--- a/flutter_client/test/release/release_matrix_documentation_test.dart
+++ b/flutter_client/test/release/release_matrix_documentation_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   const workflowPath = '../.github/workflows/ci.yml';
+  const releaseWorkflowPath = '../.github/workflows/release.yml';
   const releaseMatrixPath = '../docs/release/platform-release-matrix.md';
   const readmePath = 'README.md';
 
@@ -144,6 +145,70 @@ void main() {
     expect(settingsGradle, contains('org.jetbrains.kotlin.android'));
   });
 
+  test('android publication requires and verifies stable release signing', () {
+    final buildGradle = readFile('android/app/build.gradle.kts');
+    final releaseWorkflow = readFile(releaseWorkflowPath);
+    final releaseMatrix = readFile(releaseMatrixPath);
+
+    expect(buildGradle, contains('ANDROID_REQUIRE_RELEASE_SIGNING'));
+    expect(buildGradle, contains('GradleException'));
+    expect(
+      buildGradle,
+      contains('providers.gradleProperty(name).orNull?.takeIf'),
+    );
+    expect(
+      buildGradle,
+      contains('providers.environmentVariable(name).orNull?.takeIf'),
+    );
+    expect(
+      buildGradle,
+      contains('signingConfigs.getByName("debug")'),
+      reason: 'Local contributor builds keep an explicit debug fallback.',
+    );
+
+    for (final expected in <String>[
+      'set -euo pipefail',
+      r'KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}',
+      r'ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}',
+      r'ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}',
+      r'ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}',
+      'ANDROID_KEYSTORE_PATH: ../../upload-keystore.jks',
+      'ANDROID_REQUIRE_RELEASE_SIGNING: "true"',
+      'APKSIGNER=',
+      'verify --verbose --print-certs',
+      'Signer #1 certificate SHA-256 digest:',
+      'Android Debug',
+      r'$GITHUB_STEP_SUMMARY',
+    ]) {
+      expect(releaseWorkflow, contains(expected));
+    }
+
+    final signingPreflight = releaseWorkflow.indexOf(
+      '- name: Validate and decode keystore',
+    );
+    final buildApk = releaseWorkflow.indexOf('- name: Build APK');
+    final verifySigner = releaseWorkflow.indexOf('- name: Verify APK signer');
+    final stageArtifact = releaseWorkflow.indexOf('- name: Stage artifact');
+    final uploadArtifact = releaseWorkflow.indexOf(
+      '- uses: actions/upload-artifact@v7',
+      verifySigner,
+    );
+    expect(signingPreflight, lessThan(buildApk));
+    expect(buildApk, lessThan(verifySigner));
+    expect(verifySigner, lessThan(stageArtifact));
+    expect(verifySigner, lessThan(uploadArtifact));
+
+    for (final expected in <String>[
+      'local development only',
+      'must not publish it',
+      'uninstall the existing debug-signed app once',
+      'removes local app data and settings',
+      'configure the app again',
+    ]) {
+      expect(releaseMatrix, contains(expected));
+    }
+  });
+
   test('android manifest exposes Android TV launcher metadata', () {
     final manifest = readFile('android/app/src/main/AndroidManifest.xml');
 
@@ -221,9 +286,10 @@ void main() {
 
     for (final expected in <String>[
       'Application ID: `dev.sparkison.tv`',
-      'Release signing is intentionally blocked until external signing material exists',
+      'The publication workflow enables `ANDROID_REQUIRE_RELEASE_SIGNING`',
       '`flutter_client/android/signing.properties`',
-      'No debug signing is allowed for release builds',
+      'fail publication instead of producing a debug-signed artifact',
+      'debug-signed release build for local development only',
       'Android TV launcher metadata',
       'Dependency and License Gates',
       'Media3',


### PR DESCRIPTION
## Summary

- require complete stable Android signing inputs for publication builds
- reject Android Debug APK signers before staging or upload and record the signer SHA-256 fingerprint
- keep local debug-signed release builds explicit and non-publishable
- document the one-time uninstall and data loss when migrating from previous debug-signed releases

## Root cause

Published APKs for v1.0.3, v1.0.4, and v1.0.5 use the same package ID but different Android Debug certificates. Android therefore rejects an APK from a later release as an update to an existing installation.

## Verification

- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test --concurrency=1`: 348 passed, 5 skipped
- focused release-signing regression test: passed
- Gradle fail-closed check without signing inputs: failed as expected
- Gradle `signingReport` with a temporary release keystore: release config resolved `flutter_client/upload-keystore.jks`
- workflow YAML parse: passed
- `git diff --check`
- added-line scan for U+2013 and U+2014: passed
- secret-pattern scan: passed

## Additional build observation

A local signed APK assembly accepted the release keystore and passed the signing guard, then stopped at the existing generated Android plugin registrant because `dev.flutter.plugins.integration_test.IntegrationTestPlugin` was unavailable during release Java compilation. This is outside the signing diff and occurs after signing configuration.

Closes #104
