### PR TITLE
fix: replace desktop template identities

### DIFF
--- a/flutter_client/linux/CMakeLists.txt
+++ b/flutter_client/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "m3u_tv")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.m3u_tv")
+set(APPLICATION_ID "dev.sparkison.tv")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/flutter_client/linux/my_application.cc
+++ b/flutter_client/linux/my_application.cc
@@ -43,11 +43,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "m3u_tv");
+    gtk_header_bar_set_title(header_bar, "M3U TV");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "m3u_tv");
+    gtk_window_set_title(window, "M3U TV");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/flutter_client/test/release/license_notices_test.dart
+++ b/flutter_client/test/release/license_notices_test.dart
@@ -167,28 +167,30 @@ void main() {
       );
       expect(androidBuildGradle, isNot(contains('com.example')));
 
-      // Non-Android platforms are future-gated; they may still have template IDs,
-      // but we record them so they are not forgotten when those platforms activate.
+      // Linux and Windows are active release targets and must not ship Flutter
+      // template identities.
       final linuxCmake = readFile('linux/CMakeLists.txt');
+      final linuxRunner = readFile('linux/my_application.cc');
       final windowsRc = readFile('windows/runner/Runner.rc');
       final macosConfig = readFile('macos/Runner/Configs/AppInfo.xcconfig');
 
-      // These are known template IDs in non-Android platforms; they are not
-      // release blockers today but must be updated before those platforms ship.
-      if (linuxCmake.contains('com.example')) {
-        expect(
-          linuxCmake,
-          contains('com.example.m3u_tv'),
-          reason: 'Linux template ID must be the known template value',
-        );
-      }
-      if (windowsRc.contains('com.example')) {
-        expect(
-          windowsRc,
-          contains('com.example'),
-          reason: 'Windows template ID must be the known template value',
-        );
-      }
+      expect(
+        linuxCmake,
+        contains('set(APPLICATION_ID "dev.sparkison.tv")'),
+      );
+      expect(linuxCmake, isNot(contains('com.example')));
+      expect(
+        linuxRunner,
+        contains('gtk_header_bar_set_title(header_bar, "M3U TV")'),
+      );
+      expect(linuxRunner, contains('gtk_window_set_title(window, "M3U TV")'));
+      expect(windowsRc, isNot(contains('com.example')));
+      expect(windowsRc, contains('VALUE "CompanyName", "M3U TV"'));
+      expect(windowsRc, contains('VALUE "FileDescription", "M3U TV"'));
+      expect(windowsRc, contains('VALUE "ProductName", "M3U TV"'));
+
+      // macOS remains future-gated and keeps its known template value until its
+      // release gate is activated.
       if (macosConfig.contains('com.example')) {
         expect(
           macosConfig,

--- a/flutter_client/windows/runner/Runner.rc
+++ b/flutter_client/windows/runner/Runner.rc
@@ -89,13 +89,13 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "m3u_tv" "\0"
+            VALUE "CompanyName", "M3U TV" "\0"
+            VALUE "FileDescription", "M3U TV" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "m3u_tv" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2026 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2026 M3U TV. All rights reserved." "\0"
             VALUE "OriginalFilename", "m3u_tv.exe" "\0"
-            VALUE "ProductName", "m3u_tv" "\0"
+            VALUE "ProductName", "M3U TV" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END


### PR DESCRIPTION
## Summary

- replace the Linux GTK template application ID with `dev.sparkison.tv`
- use `M3U TV` for Linux window titles and Windows release metadata
- make the release contract reject template identities on actively published desktop targets

## Reproduction

Before this change, the focused release contract failed because Linux used `com.example.m3u_tv`. Windows version resources also exposed `com.example` and `m3u_tv`.

## Verification

- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test --concurrency=1` (347 passed, 5 skipped)
- `git diff --check`
- no added U+2013 or U+2014 characters

Closes #106
