### PR TITLE
fix: load bundled Windows libmpv runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -471,9 +471,8 @@ jobs:
 
   # ── Windows ───────────────────────────────────────────────────────────────
   #
-  # Note: the Windows target uses a custom libmpv backend (desktop_libmpv_backend.cpp).
-  # The build output will not include libmpv.dll — users may need to install
-  # the mpv runtime or bundle libmpv.dll separately for video playback.
+  # The Windows target uses a custom libmpv backend (desktop_libmpv_backend.cpp)
+  # and loads the libmpv-2.dll bundled by media_kit_libs_windows_video.
   # ─────────────────────────────────────────────────────────────────────────
   build-windows:
     name: Build Windows ZIP
@@ -505,6 +504,16 @@ jobs:
           flutter build windows --release `
             --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} `
             --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
+
+      - name: Verify bundled libmpv runtime
+        run: |
+          $MpvDll = "build\windows\x64\runner\Release\libmpv-2.dll"
+          if (-not (Test-Path $MpvDll -PathType Leaf)) {
+            throw "Required bundled playback runtime is missing: $MpvDll"
+          }
+          if ((Get-Item $MpvDll).Length -eq 0) {
+            throw "Bundled playback runtime is empty: $MpvDll"
+          }
 
       - name: Package as ZIP
         run: |

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -161,6 +161,22 @@ void main() {
       },
     );
 
+    test('Windows loader resolves the libmpv DLL bundled by media_kit', () {
+      final windowsBackend = File(
+        'windows/runner/desktop_libmpv_backend.cpp',
+      ).readAsStringSync();
+      final releaseWorkflow = File(
+        '../.github/workflows/release.yml',
+      ).readAsStringSync();
+
+      final bundledNameIndex = windowsBackend.indexOf('L"libmpv-2.dll"');
+      final compatibilityNameIndex = windowsBackend.indexOf('L"mpv-2.dll"');
+      expect(bundledNameIndex, isNonNegative);
+      expect(compatibilityNameIndex, greaterThan(bundledNameIndex));
+      expect(releaseWorkflow, contains(r'Test-Path $MpvDll'));
+      expect(releaseWorkflow, contains('libmpv-2.dll'));
+    });
+
     test(
       'desktop software texture render paths use Flutter RGBA pixel buffers',
       () {

--- a/flutter_client/windows/runner/desktop_libmpv_backend.cpp
+++ b/flutter_client/windows/runner/desktop_libmpv_backend.cpp
@@ -24,7 +24,10 @@ using MethodResult = flutter::MethodResult<flutter::EncodableValue>;
 
 constexpr char kChannelName[] = "m3u_tv/desktop_libmpv";
 constexpr char kBackendUnavailableCode[] = "backend_unavailable";
-constexpr wchar_t kMpvDll[] = L"mpv-2.dll";
+constexpr const wchar_t* kMpvDllNames[] = {
+    L"libmpv-2.dll",
+    L"mpv-2.dll",
+};
 constexpr uint32_t kTextureWidth = 1280;
 constexpr uint32_t kTextureHeight = 720;
 constexpr int kBytesPerPixel = 4;
@@ -192,32 +195,42 @@ LibmpvApi& Api() {
   if (g_api.library != nullptr || !g_api.error.empty()) return g_api;
 
   const std::wstring runner_dir = RunnerDirectory();
-  std::wstring bundled_path;
-  if (!runner_dir.empty()) bundled_path = runner_dir + L"\\" + kMpvDll;
-
   std::ostringstream attempted;
   DWORD last_error = 0;
-  if (!bundled_path.empty()) {
-    attempted << Narrow(bundled_path) << " ";
-    g_api.library = LoadLibraryExW(
-        bundled_path.c_str(), nullptr,
-        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-    if (g_api.library == nullptr) last_error = GetLastError();
+  if (!runner_dir.empty()) {
+    for (const wchar_t* name : kMpvDllNames) {
+      const std::wstring bundled_path = runner_dir + L"\\" + name;
+      attempted << Narrow(bundled_path) << " ";
+      g_api.library = LoadLibraryExW(
+          bundled_path.c_str(), nullptr,
+          LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+      if (g_api.library != nullptr) {
+        g_api.library_name = Narrow(bundled_path);
+        break;
+      }
+      last_error = GetLastError();
+    }
   }
 
   if (g_api.library == nullptr) {
-    attempted << "Windows DLL search path " << Narrow(kMpvDll);
-    g_api.library = LoadLibraryExW(kMpvDll, nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-    if (g_api.library == nullptr) last_error = GetLastError();
+    for (const wchar_t* name : kMpvDllNames) {
+      attempted << "Windows DLL search path " << Narrow(name) << " ";
+      g_api.library =
+          LoadLibraryExW(name, nullptr, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+      if (g_api.library != nullptr) {
+        g_api.library_name = Narrow(name);
+        break;
+      }
+      last_error = GetLastError();
+    }
   }
 
   if (g_api.library == nullptr) {
-    g_api.error = "mpv-2.dll not found; tried runner directory and Windows DLL search path; " +
+    g_api.error = "libmpv DLL not found; tried " + attempted.str() + "; " +
                   LastErrorMessage(last_error);
     return g_api;
   }
 
-  g_api.library_name = !bundled_path.empty() ? Narrow(bundled_path) : Narrow(kMpvDll);
   g_api.create = reinterpret_cast<mpv_create_fn>(LoadSymbol(g_api.library, "mpv_create"));
   g_api.initialize = reinterpret_cast<mpv_initialize_fn>(LoadSymbol(g_api.library, "mpv_initialize"));
   g_api.command = reinterpret_cast<mpv_command_fn>(LoadSymbol(g_api.library, "mpv_command"));


### PR DESCRIPTION
## Summary

- load the bundled `libmpv-2.dll` before the compatibility name `mpv-2.dll`
- report every attempted runner-directory and Windows search-path candidate
- make the Windows release job fail before packaging when the bundled runtime is absent or empty
- add a regression contract for the package and loader filename agreement

## Root cause

`media_kit_libs_windows_video 1.0.11` installs `libmpv-2.dll`, while the custom backend only searched for `mpv-2.dll`. The published ZIP therefore carried a runtime the player could not resolve.

## Verification

- focused regression test failed before the implementation and passes after it
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze`
- `flutter test --concurrency=1` (348 passed, 5 skipped)
- release workflow syntax validation from the patch tool
- `git diff --check`
- no added U+2013 or U+2014 characters

Closes #107
