### PR TITLE
Handle foreground push, safe activation, and token rotation

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -40,6 +40,17 @@ enum DeviceType { tv, desktop, tablet, phone }
 bool shouldUseSidebar(DeviceType deviceType) =>
     deviceType == DeviceType.tv || deviceType == DeviceType.desktop;
 
+String notificationRouteFor(
+  TvNotificationDestination destination, {
+  bool hasDvrFeature = false,
+  bool hasRequestsFeature = false,
+}) => switch (destination) {
+  TvNotificationDestination.dvr when hasDvrFeature => RouteNames.dvr,
+  TvNotificationDestination.requests when hasRequestsFeature =>
+    RouteNames.requests,
+  _ => RouteNames.notifications,
+};
+
 String _routeLabel(BuildContext context, String route) {
   final l = AppLocalizations.of(context);
   return switch (route) {
@@ -95,6 +106,7 @@ class AppShellState extends ConsumerState<AppShell>
   int _lastNavMs = 0;
   int _lastNavIndex = -1;
   StreamSubscription<TvNotificationItem>? _tvNotificationSub;
+  StreamSubscription<TvNotificationDestination>? _notificationActivationSub;
   final _toastKey = GlobalKey<NotificationToastOverlayState>();
 
   PlayerArgs? _playerArgs;
@@ -139,6 +151,9 @@ class AppShellState extends ConsumerState<AppShell>
     _unreadCount = _appState.unreadNotificationCount;
     _appState.addListener(_onAppStateChanged);
     _tvNotificationSub = _appState.tvNotifications.listen(_onTvNotification);
+    _notificationActivationSub = _appState.notificationActivations.listen(
+      _onNotificationActivation,
+    );
     if (!_appState.isConfigured) {
       unawaited(_appState.boot());
     }
@@ -215,11 +230,22 @@ class AppShellState extends ConsumerState<AppShell>
     _navigateToRoute(RouteNames.notifications);
   }
 
+  void _onNotificationActivation(TvNotificationDestination destination) {
+    _navigateToRoute(
+      notificationRouteFor(
+        destination,
+        hasDvrFeature: _appState.hasDvrFeature,
+        hasRequestsFeature: _appState.hasRequestsFeature,
+      ),
+    );
+  }
+
   @override
   void dispose() {
     unawaited(_systemUiPolicy.applyBrowsing());
     _backExitTimer?.cancel();
     _tvNotificationSub?.cancel().ignore();
+    _notificationActivationSub?.cancel().ignore();
     WidgetsBinding.instance.removeObserver(this);
     _playerOrchestrator?.dispose().ignore();
     for (final node in _sidebarFocusNodes) {

--- a/flutter_client/lib/main.dart
+++ b/flutter_client/lib/main.dart
@@ -16,7 +16,6 @@ import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/persistent_store.dart';
 import 'package:m3u_tv/services/production_storage.dart';
-import 'package:m3u_tv/services/push_notification_service.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:path_provider/path_provider.dart';
@@ -56,15 +55,10 @@ bool _isMobilePushCapable(bool nativeTelevisionHint) =>
 
 Future<void> _initPushNotifications(AppStateController appState) async {
   try {
-    final service = PushNotificationService();
-    final token = await service.init();
-    if (token != null) {
-      appState.setPushToken(token);
-    }
-    service.onTokenRefresh.listen(appState.setPushToken);
-  } on Object catch (error) {
+    await appState.initPushNotifications();
+  } on Object catch (_) {
     // Best-effort: e.g. Firebase config not yet installed on this build.
-    debugPrint('Push notification init failed: $error');
+    debugPrint('Push notification init failed');
   }
 }
 

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart' show Locale;
 
 import 'package:m3u_tv/services/aiostreams_api_service.dart';
 import 'package:m3u_tv/services/aiostreams_favorites_service.dart';
+import 'package:m3u_tv/services/async_lifecycle.dart';
 import 'package:m3u_tv/services/auth_notifier.dart';
 import 'package:m3u_tv/services/cache_service.dart';
 import 'package:m3u_tv/services/domain_models.dart';
@@ -140,8 +141,8 @@ class AppStateController extends ChangeNotifier {
   bool _pushRegistrationSuspended = false;
   UserCredentials? _registeredPushCredentials;
   String? _registeredPushToken;
-  Future<void> _pushLifecycle = Future<void>.value();
-  int _pushLifecycleGeneration = 0;
+  final SerialQueue _pushLifecycleQueue = SerialQueue();
+  final Generation _pushLifecycleGeneration = Generation();
   Future<void>? _pushInitialization;
   StreamSubscription<String>? _pushTokenSubscription;
   final Map<String, PushMessage> _pendingPushActivations =
@@ -153,7 +154,7 @@ class AppStateController extends ChangeNotifier {
       StreamController<TvNotificationDestination>.broadcast();
   static const _maxActivatedNotificationIds = 100;
   final Set<String> _activatedNotificationIds = <String>{};
-  int _notificationSessionGeneration = 0;
+  final Generation _notificationSessionGeneration = Generation();
   int _unreadNotificationCount = 0;
 
   /// Stream of incoming TV push notifications (from Reverb WebSocket or
@@ -298,7 +299,7 @@ class AppStateController extends ChangeNotifier {
       final restored = await authNotifier.loadSavedCredentials();
       if (restored) {
         final credentials = authNotifier.credentials!;
-        final notificationGeneration = ++_notificationSessionGeneration;
+        final notificationGeneration = _notificationSessionGeneration.advance();
         if (await _hydrateCachedXtreamContent()) {
           _isBootstrapping = false;
           notifyListeners();
@@ -333,7 +334,7 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<bool> connectXtream(UserCredentials credentials) async {
-    final notificationGeneration = ++_notificationSessionGeneration;
+    final notificationGeneration = _notificationSessionGeneration.advance();
     _isLoadingContent = true;
     _error = null;
     notifyListeners();
@@ -342,7 +343,7 @@ class AppStateController extends ChangeNotifier {
     if (previousCredentials != null &&
         !_sameCredentials(previousCredentials, credentials)) {
       _pushRegistrationSuspended = true;
-      _pushLifecycleGeneration += 1;
+      _pushLifecycleGeneration.advance();
       await _reverbService.disconnect();
       await _unregisterPushToken();
     }
@@ -383,9 +384,9 @@ class AppStateController extends ChangeNotifier {
 
     try {
       final playlist = m3uParser.parse(playlistText);
-      _notificationSessionGeneration += 1;
+      _notificationSessionGeneration.advance();
       _pushRegistrationSuspended = true;
-      _pushLifecycleGeneration += 1;
+      _pushLifecycleGeneration.advance();
       await _unregisterPushToken();
       await _reverbService.disconnect();
       await authNotifier.disconnect();
@@ -439,9 +440,11 @@ class AppStateController extends ChangeNotifier {
         present: _pendingPushActivations.isEmpty,
         notificationGeneration: notificationGeneration,
       );
-      if (notificationGeneration != _notificationSessionGeneration) return;
+      if (_notificationSessionGeneration.isStale(notificationGeneration)) {
+        return;
+      }
       await _drainPendingPushActivations();
-      if (notificationGeneration != _notificationSessionGeneration ||
+      if (_notificationSessionGeneration.isStale(notificationGeneration) ||
           !_sameCredentials(authNotifier.credentials, credentials)) {
         return;
       }
@@ -477,7 +480,7 @@ class AppStateController extends ChangeNotifier {
       credentials,
     );
     if ((notificationGeneration != null &&
-            notificationGeneration != _notificationSessionGeneration) ||
+            _notificationSessionGeneration.isStale(notificationGeneration)) ||
         !_sameCredentials(authNotifier.credentials, credentials)) {
       return null;
     }
@@ -527,7 +530,7 @@ class AppStateController extends ChangeNotifier {
   Future<void> resumeNotifications() async {
     final credentials = authNotifier.credentials;
     if (credentials == null) return;
-    final notificationGeneration = _notificationSessionGeneration;
+    final notificationGeneration = _notificationSessionGeneration.current;
     try {
       await _reconcileUnreadNotifications(
         credentials,
@@ -560,20 +563,20 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<void> setPushToken(String token) {
-    final generation = _pushLifecycleGeneration;
+    final generation = _pushLifecycleGeneration.current;
     final registrationSuspended = _pushRegistrationSuspended;
     return _queuePushLifecycle(() async {
       final alreadyRegistered =
           _pushToken == token && _registeredPushToken == token;
       _pushToken = token;
-      if (generation != _pushLifecycleGeneration ||
+      if (_pushLifecycleGeneration.isStale(generation) ||
           registrationSuspended ||
           _pushRegistrationSuspended ||
           alreadyRegistered) {
         return;
       }
       await _unregisterPushTokenNow();
-      if (generation != _pushLifecycleGeneration ||
+      if (_pushLifecycleGeneration.isStale(generation) ||
           _pushRegistrationSuspended) {
         return;
       }
@@ -584,14 +587,11 @@ class AppStateController extends ChangeNotifier {
     });
   }
 
-  Future<void> _queuePushLifecycle(Future<void> Function() operation) {
-    final next = _pushLifecycle.then((_) => operation());
-    _pushLifecycle = next.catchError((_) {});
-    return next;
-  }
+  Future<void> _queuePushLifecycle(Future<void> Function() operation) =>
+      _pushLifecycleQueue.run(operation);
 
   Future<void> _registerPushToken(UserCredentials credentials) {
-    final generation = _pushLifecycleGeneration;
+    final generation = _pushLifecycleGeneration.current;
     return _queuePushLifecycle(
       () => _registerPushTokenNow(credentials, generation),
     );
@@ -601,7 +601,8 @@ class AppStateController extends ChangeNotifier {
     UserCredentials credentials,
     int generation,
   ) async {
-    if (generation != _pushLifecycleGeneration || _pushRegistrationSuspended) {
+    if (_pushLifecycleGeneration.isStale(generation) ||
+        _pushRegistrationSuspended) {
       return;
     }
     final token = _pushToken;
@@ -611,7 +612,8 @@ class AppStateController extends ChangeNotifier {
       return;
     }
     await _unregisterPushTokenNow();
-    if (generation != _pushLifecycleGeneration || _pushRegistrationSuspended) {
+    if (_pushLifecycleGeneration.isStale(generation) ||
+        _pushRegistrationSuspended) {
       return;
     }
     try {
@@ -654,7 +656,7 @@ class AppStateController extends ChangeNotifier {
     final id = message.notificationId;
     final credentials = authNotifier.credentials;
     if (id == null || credentials == null) return;
-    final notificationGeneration = _notificationSessionGeneration;
+    final notificationGeneration = _notificationSessionGeneration.current;
     try {
       await _reconcileUnreadNotifications(
         credentials,
@@ -674,13 +676,13 @@ class AppStateController extends ChangeNotifier {
       _pendingPushActivations[id] = message;
       return;
     }
-    final notificationGeneration = _notificationSessionGeneration;
+    final notificationGeneration = _notificationSessionGeneration.current;
 
     try {
       final (session, unread) = await _tvNotificationService.fetchUnread(
         credentials,
       );
-      if (notificationGeneration != _notificationSessionGeneration ||
+      if (_notificationSessionGeneration.isStale(notificationGeneration) ||
           !_sameCredentials(authNotifier.credentials, credentials)) {
         return;
       }
@@ -692,7 +694,7 @@ class AppStateController extends ChangeNotifier {
           : unread.where((item) => !item.adminOnly).toList(growable: false);
       await notificationStore.syncUnreadWithServer(authorizedUnread);
       await _refreshUnreadNotificationCount();
-      if (notificationGeneration != _notificationSessionGeneration ||
+      if (_notificationSessionGeneration.isStale(notificationGeneration) ||
           !_sameCredentials(authNotifier.credentials, credentials)) {
         return;
       }
@@ -805,9 +807,9 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<void> disconnect() async {
-    _notificationSessionGeneration += 1;
+    _notificationSessionGeneration.advance();
     _pushRegistrationSuspended = true;
-    _pushLifecycleGeneration += 1;
+    _pushLifecycleGeneration.advance();
     await _unregisterPushToken();
     await _reverbService.disconnect();
     await authNotifier.disconnect();

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -151,6 +151,7 @@ class AppStateController extends ChangeNotifier {
   final StreamController<TvNotificationDestination>
   _notificationActivationController =
       StreamController<TvNotificationDestination>.broadcast();
+  static const _maxActivatedNotificationIds = 100;
   final Set<String> _activatedNotificationIds = <String>{};
   int _notificationSessionGeneration = 0;
   int _unreadNotificationCount = 0;
@@ -356,12 +357,16 @@ class AppStateController extends ChangeNotifier {
       notifyListeners();
       return false;
     }
+    // Credentials are authenticated as of here, so the transition this flag
+    // was guarding is over — clear it even if content fails to load below,
+    // otherwise a load failure leaves push registration stuck suspended
+    // until some future connect attempt happens to fully succeed.
+    _pushRegistrationSuspended = false;
 
     final loaded = await _replaceWithXtreamContent(clearCache: true);
     _isLoadingContent = false;
     notifyListeners();
     if (loaded) {
-      _pushRegistrationSuspended = false;
       unawaited(_connectTvNotifications(credentials, notificationGeneration));
       await _registerPushToken(credentials);
     }
@@ -694,7 +699,7 @@ class AppStateController extends ChangeNotifier {
       final matching = authorizedUnread.where((item) => item.id == id);
       if (matching.isEmpty) return;
       final destination = notificationDestinationFor(matching.first.channel);
-      if (destination == null || !_activatedNotificationIds.add(id)) return;
+      if (destination == null || !_markNotificationActivated(id)) return;
       _notificationActivationController.add(destination);
     } on Object catch (_) {
       // A tap without an authorized REST record is a safe no-op.
@@ -1377,6 +1382,17 @@ class AppStateController extends ChangeNotifier {
       first.server == second.server &&
       first.username == second.username &&
       first.password == second.password;
+
+  // Bounded like TvNotificationStore's own cap, so a long-running session
+  // can't grow this set without limit.
+  bool _markNotificationActivated(String id) {
+    if (_activatedNotificationIds.contains(id)) return false;
+    if (_activatedNotificationIds.length >= _maxActivatedNotificationIds) {
+      _activatedNotificationIds.remove(_activatedNotificationIds.first);
+    }
+    _activatedNotificationIds.add(id);
+    return true;
+  }
 
   @override
   void dispose() {

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -137,8 +137,20 @@ class AppStateController extends ChangeNotifier {
   final ReverbService _reverbService;
   final PushNotificationService _pushNotificationService;
   String? _pushToken;
+  UserCredentials? _registeredPushCredentials;
+  String? _registeredPushToken;
+  Future<void> _pushLifecycle = Future<void>.value();
+  Future<void>? _pushInitialization;
+  StreamSubscription<String>? _pushTokenSubscription;
+  final Map<String, PushMessage> _pendingPushActivations =
+      <String, PushMessage>{};
   final StreamController<TvNotificationItem> _tvNotificationController =
       StreamController<TvNotificationItem>.broadcast();
+  final StreamController<TvNotificationDestination>
+  _notificationActivationController =
+      StreamController<TvNotificationDestination>.broadcast();
+  final Set<String> _activatedNotificationIds = <String>{};
+  int _notificationSessionGeneration = 0;
   int _unreadNotificationCount = 0;
 
   /// Stream of incoming TV push notifications (from Reverb WebSocket or
@@ -146,6 +158,9 @@ class AppStateController extends ChangeNotifier {
   /// show snackbars or banners.
   Stream<TvNotificationItem> get tvNotifications =>
       _tvNotificationController.stream;
+
+  Stream<TvNotificationDestination> get notificationActivations =>
+      _notificationActivationController.stream;
 
   int get unreadNotificationCount => _unreadNotificationCount;
 
@@ -280,18 +295,23 @@ class AppStateController extends ChangeNotifier {
       final restored = await authNotifier.loadSavedCredentials();
       if (restored) {
         final credentials = authNotifier.credentials!;
+        final notificationGeneration = ++_notificationSessionGeneration;
         if (await _hydrateCachedXtreamContent()) {
           _isBootstrapping = false;
           notifyListeners();
           unawaited(_refreshRecentlyWatchedForActiveViewer());
           unawaited(_replaceWithXtreamContent(clearCache: false));
-          unawaited(_connectTvNotifications(credentials));
+          unawaited(
+            _connectTvNotifications(credentials, notificationGeneration),
+          );
           unawaited(_registerPushToken(credentials));
           return;
         }
         final loaded = await _replaceWithXtreamContent(clearCache: false);
         if (loaded) {
-          unawaited(_connectTvNotifications(credentials));
+          unawaited(
+            _connectTvNotifications(credentials, notificationGeneration),
+          );
           unawaited(_registerPushToken(credentials));
         }
       } else if (savedSource == AppSourceType.xtream &&
@@ -308,9 +328,17 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<bool> connectXtream(UserCredentials credentials) async {
+    final notificationGeneration = ++_notificationSessionGeneration;
     _isLoadingContent = true;
     _error = null;
     notifyListeners();
+
+    final previousCredentials = authNotifier.credentials;
+    if (previousCredentials != null &&
+        !_sameCredentials(previousCredentials, credentials)) {
+      await _reverbService.disconnect();
+      await _unregisterPushToken();
+    }
 
     final connected = await authNotifier.connect(credentials);
     if (!connected) {
@@ -327,8 +355,8 @@ class AppStateController extends ChangeNotifier {
     _isLoadingContent = false;
     notifyListeners();
     if (loaded) {
-      unawaited(_connectTvNotifications(credentials));
-      unawaited(_registerPushToken(credentials));
+      unawaited(_connectTvNotifications(credentials, notificationGeneration));
+      await _registerPushToken(credentials);
     }
     return loaded;
   }
@@ -343,6 +371,10 @@ class AppStateController extends ChangeNotifier {
 
     try {
       final playlist = m3uParser.parse(playlistText);
+      _notificationSessionGeneration += 1;
+      await _unregisterPushToken();
+      await _reverbService.disconnect();
+      await authNotifier.disconnect();
       await cacheService.clear();
       await cacheService.set('sourceType', 'm3u');
       await cacheService.set('liveCategories', playlist.categories);
@@ -383,9 +415,22 @@ class AppStateController extends ChangeNotifier {
     }
   }
 
-  Future<void> _connectTvNotifications(UserCredentials credentials) async {
+  Future<void> _connectTvNotifications(
+    UserCredentials credentials,
+    int notificationGeneration,
+  ) async {
     try {
-      final session = await _reconcileUnreadNotifications(credentials);
+      final session = await _reconcileUnreadNotifications(
+        credentials,
+        present: _pendingPushActivations.isEmpty,
+        notificationGeneration: notificationGeneration,
+      );
+      if (notificationGeneration != _notificationSessionGeneration) return;
+      await _drainPendingPushActivations();
+      if (notificationGeneration != _notificationSessionGeneration ||
+          !_sameCredentials(authNotifier.credentials, credentials)) {
+        return;
+      }
       // Older server versions don't return Reverb config — skip WebSocket setup
       // rather than hammering a connection that can never succeed.
       if (session == null) return;
@@ -409,11 +454,19 @@ class AppStateController extends ChangeNotifier {
   /// playlist session — or `null` if the server has no Reverb config to
   /// connect a WebSocket to.
   Future<TvPlaylistSession?> _reconcileUnreadNotifications(
-    UserCredentials credentials,
-  ) async {
+    UserCredentials credentials, {
+    String? presentOnlyId,
+    bool present = true,
+    int? notificationGeneration,
+  }) async {
     final (session, unread) = await _tvNotificationService.fetchUnread(
       credentials,
     );
+    if ((notificationGeneration != null &&
+            notificationGeneration != _notificationSessionGeneration) ||
+        !_sameCredentials(authNotifier.credentials, credentials)) {
+      return null;
+    }
     if (session.availableChannels.isNotEmpty) {
       await notificationStore.setServerChannels(session.availableChannels);
     }
@@ -421,18 +474,32 @@ class AppStateController extends ChangeNotifier {
     // local unreads are marked read, new server items are added. Only
     // genuinely new items (not seen before) are surfaced as toasts — this
     // should not replay banners for notifications the user already received.
-    final newItems = await notificationStore.syncUnreadWithServer(unread);
+    final authorizedUnread = session.isAdmin
+        ? unread
+        : unread.where((item) => !item.adminOnly).toList(growable: false);
+    final newItems = await notificationStore.syncUnreadWithServer(
+      authorizedUnread,
+    );
     await _refreshUnreadNotificationCount();
-    final subscribed = await notificationStore.subscribedChannels();
-    for (final item in newItems) {
-      if (subscribed.isEmpty || subscribed.contains(item.channel)) {
-        _tvNotificationController.add(item);
+    if (present) {
+      final subscribed = await notificationStore.subscribedChannels();
+      for (final item in newItems) {
+        if ((presentOnlyId == null || item.id == presentOnlyId) &&
+            (subscribed.isEmpty || subscribed.contains(item.channel))) {
+          _tvNotificationController.add(item);
+        }
       }
     }
     if (session.channelName.isEmpty || session.reverb.appKey.isEmpty) {
       return null;
     }
     return session;
+  }
+
+  Future<void> reconcileNotifications() async {
+    final credentials = authNotifier.credentials;
+    if (credentials == null) return;
+    await _reconcileUnreadNotifications(credentials);
   }
 
   /// Suspends the TV notification WebSocket while the app is backgrounded.
@@ -446,11 +513,17 @@ class AppStateController extends ChangeNotifier {
   Future<void> resumeNotifications() async {
     final credentials = authNotifier.credentials;
     if (credentials == null) return;
+    final notificationGeneration = _notificationSessionGeneration;
     try {
-      await _reconcileUnreadNotifications(credentials);
+      await _reconcileUnreadNotifications(
+        credentials,
+        present: _pendingPushActivations.isEmpty,
+        notificationGeneration: notificationGeneration,
+      );
     } on Object catch (_) {
       // TV notifications are best-effort; a failure here must not crash the app.
     }
+    await _drainPendingPushActivations();
     await _reverbService.resume();
   }
 
@@ -458,30 +531,148 @@ class AppStateController extends ChangeNotifier {
   /// token (mobile only — TV builds never call this). Registers immediately
   /// if credentials are already connected; otherwise the token is held and
   /// registered the next time [_connectTvNotifications] runs.
-  void setPushToken(String token) {
-    _pushToken = token;
-    final credentials = authNotifier.credentials;
-    if (credentials != null) {
-      unawaited(_registerPushToken(credentials));
-    }
+  Future<void> initPushNotifications() =>
+      _pushInitialization ??= _initializePushNotifications();
+
+  Future<void> _initializePushNotifications() async {
+    final token = await _pushNotificationService.init(
+      onForegroundMessage: handleForegroundPush,
+      onMessageOpenedApp: handlePushActivation,
+    );
+    if (token != null) await setPushToken(token);
+    _pushTokenSubscription = _pushNotificationService.onTokenRefresh.listen(
+      (replacement) => unawaited(setPushToken(replacement)),
+    );
   }
 
-  Future<void> _registerPushToken(UserCredentials credentials) async {
+  Future<void> setPushToken(String token) => _queuePushLifecycle(() async {
+    if (_pushToken == token && _registeredPushToken == token) return;
+    _pushToken = token;
+    await _unregisterPushTokenNow();
+    final credentials = authNotifier.credentials;
+    if (credentials != null) {
+      await _registerPushTokenNow(credentials);
+    }
+  });
+
+  Future<void> _queuePushLifecycle(Future<void> Function() operation) {
+    final next = _pushLifecycle.then((_) => operation());
+    _pushLifecycle = next.catchError((_) {});
+    return next;
+  }
+
+  Future<void> _registerPushToken(UserCredentials credentials) =>
+      _queuePushLifecycle(() => _registerPushTokenNow(credentials));
+
+  Future<void> _registerPushTokenNow(UserCredentials credentials) async {
     final token = _pushToken;
     if (token == null) return;
+    if (_registeredPushToken == token &&
+        _sameCredentials(_registeredPushCredentials, credentials)) {
+      return;
+    }
+    await _unregisterPushTokenNow();
     try {
       await _pushNotificationService.registerToken(
         credentials,
         token: token,
         platform: Platform.isIOS ? 'ios' : 'android',
       );
+      _registeredPushCredentials = credentials;
+      _registeredPushToken = token;
     } on Object catch (_) {
       // Push registration is best-effort, same as TV notifications above.
     }
   }
 
+  Future<void> _unregisterPushToken() =>
+      _queuePushLifecycle(_unregisterPushTokenNow);
+
+  Future<void> _unregisterPushTokenNow() async {
+    final credentials = _registeredPushCredentials;
+    final token = _registeredPushToken;
+    _registeredPushCredentials = null;
+    _registeredPushToken = null;
+    if (credentials == null || token == null) return;
+    try {
+      await _pushNotificationService.unregisterToken(
+        credentials,
+        token: token,
+      );
+    } on Object catch (_) {
+      // Best-effort cleanup; do not retain a stale local association on failure.
+    }
+  }
+
   void _onPushNotification(TvNotificationItem item) {
-    unawaited(_storeAndNotify(item));
+    unawaited(receiveTvNotification(item));
+  }
+
+  Future<void> handleForegroundPush(PushMessage message) async {
+    final id = message.notificationId;
+    final credentials = authNotifier.credentials;
+    if (id == null || credentials == null) return;
+    final notificationGeneration = _notificationSessionGeneration;
+    try {
+      await _reconcileUnreadNotifications(
+        credentials,
+        presentOnlyId: id,
+        notificationGeneration: notificationGeneration,
+      );
+    } on Object catch (_) {
+      // Push reconciliation is best-effort and never trusts payload content.
+    }
+  }
+
+  Future<void> handlePushActivation(PushMessage message) async {
+    final id = message.notificationId;
+    if (id == null) return;
+    final credentials = authNotifier.credentials;
+    if (credentials == null) {
+      _pendingPushActivations[id] = message;
+      return;
+    }
+    final notificationGeneration = _notificationSessionGeneration;
+
+    try {
+      final (session, unread) = await _tvNotificationService.fetchUnread(
+        credentials,
+      );
+      if (notificationGeneration != _notificationSessionGeneration ||
+          !_sameCredentials(authNotifier.credentials, credentials)) {
+        return;
+      }
+      if (session.availableChannels.isNotEmpty) {
+        await notificationStore.setServerChannels(session.availableChannels);
+      }
+      final authorizedUnread = session.isAdmin
+          ? unread
+          : unread.where((item) => !item.adminOnly).toList(growable: false);
+      await notificationStore.syncUnreadWithServer(authorizedUnread);
+      await _refreshUnreadNotificationCount();
+      if (notificationGeneration != _notificationSessionGeneration ||
+          !_sameCredentials(authNotifier.credentials, credentials)) {
+        return;
+      }
+      final matching = authorizedUnread.where((item) => item.id == id);
+      if (matching.isEmpty || !_activatedNotificationIds.add(id)) return;
+      _notificationActivationController.add(
+        notificationDestinationFor(matching.first.channel),
+      );
+    } on Object catch (_) {
+      // A tap without an authorized REST record is a safe no-op.
+    }
+  }
+
+  Future<void> _drainPendingPushActivations() async {
+    if (authNotifier.credentials == null || _pendingPushActivations.isEmpty) {
+      return;
+    }
+    final pending = _pendingPushActivations.values.toList(growable: false);
+    _pendingPushActivations.clear();
+    for (final message in pending) {
+      await handlePushActivation(message);
+    }
   }
 
   void _onDvrStatusPush(DvrRecording recording) {
@@ -559,8 +750,9 @@ class AppStateController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> _storeAndNotify(TvNotificationItem item) async {
-    await notificationStore.add(item);
+  Future<void> receiveTvNotification(TvNotificationItem item) async {
+    final inserted = await notificationStore.add(item);
+    if (!inserted) return;
     await _refreshUnreadNotificationCount();
     // Only surface the notification in the stream (banners/toasts) if the
     // channel passes the user's subscription filter.
@@ -571,6 +763,8 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<void> disconnect() async {
+    _notificationSessionGeneration += 1;
+    await _unregisterPushToken();
     await _reverbService.disconnect();
     await authNotifier.disconnect();
     await secureStorage.delete(_sourceKey);
@@ -1138,9 +1332,20 @@ class AppStateController extends ChangeNotifier {
     return redacted;
   }
 
+  bool _sameCredentials(UserCredentials? first, UserCredentials? second) =>
+      first != null &&
+      second != null &&
+      first.server == second.server &&
+      first.username == second.username &&
+      first.password == second.password;
+
   @override
   void dispose() {
     _epgFetchDebounce?.cancel();
+    _pushTokenSubscription?.cancel().ignore();
+    unawaited(_tvNotificationController.close());
+    unawaited(_notificationActivationController.close());
+    unawaited(_pushNotificationService.dispose());
     super.dispose();
   }
 }

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -137,9 +137,11 @@ class AppStateController extends ChangeNotifier {
   final ReverbService _reverbService;
   final PushNotificationService _pushNotificationService;
   String? _pushToken;
+  bool _pushRegistrationSuspended = false;
   UserCredentials? _registeredPushCredentials;
   String? _registeredPushToken;
   Future<void> _pushLifecycle = Future<void>.value();
+  int _pushLifecycleGeneration = 0;
   Future<void>? _pushInitialization;
   StreamSubscription<String>? _pushTokenSubscription;
   final Map<String, PushMessage> _pendingPushActivations =
@@ -301,6 +303,7 @@ class AppStateController extends ChangeNotifier {
           notifyListeners();
           unawaited(_refreshRecentlyWatchedForActiveViewer());
           unawaited(_replaceWithXtreamContent(clearCache: false));
+          _pushRegistrationSuspended = false;
           unawaited(
             _connectTvNotifications(credentials, notificationGeneration),
           );
@@ -309,6 +312,7 @@ class AppStateController extends ChangeNotifier {
         }
         final loaded = await _replaceWithXtreamContent(clearCache: false);
         if (loaded) {
+          _pushRegistrationSuspended = false;
           unawaited(
             _connectTvNotifications(credentials, notificationGeneration),
           );
@@ -336,6 +340,8 @@ class AppStateController extends ChangeNotifier {
     final previousCredentials = authNotifier.credentials;
     if (previousCredentials != null &&
         !_sameCredentials(previousCredentials, credentials)) {
+      _pushRegistrationSuspended = true;
+      _pushLifecycleGeneration += 1;
       await _reverbService.disconnect();
       await _unregisterPushToken();
     }
@@ -355,6 +361,7 @@ class AppStateController extends ChangeNotifier {
     _isLoadingContent = false;
     notifyListeners();
     if (loaded) {
+      _pushRegistrationSuspended = false;
       unawaited(_connectTvNotifications(credentials, notificationGeneration));
       await _registerPushToken(credentials);
     }
@@ -372,6 +379,8 @@ class AppStateController extends ChangeNotifier {
     try {
       final playlist = m3uParser.parse(playlistText);
       _notificationSessionGeneration += 1;
+      _pushRegistrationSuspended = true;
+      _pushLifecycleGeneration += 1;
       await _unregisterPushToken();
       await _reverbService.disconnect();
       await authNotifier.disconnect();
@@ -545,15 +554,30 @@ class AppStateController extends ChangeNotifier {
     );
   }
 
-  Future<void> setPushToken(String token) => _queuePushLifecycle(() async {
-    if (_pushToken == token && _registeredPushToken == token) return;
-    _pushToken = token;
-    await _unregisterPushTokenNow();
-    final credentials = authNotifier.credentials;
-    if (credentials != null) {
-      await _registerPushTokenNow(credentials);
-    }
-  });
+  Future<void> setPushToken(String token) {
+    final generation = _pushLifecycleGeneration;
+    final registrationSuspended = _pushRegistrationSuspended;
+    return _queuePushLifecycle(() async {
+      final alreadyRegistered =
+          _pushToken == token && _registeredPushToken == token;
+      _pushToken = token;
+      if (generation != _pushLifecycleGeneration ||
+          registrationSuspended ||
+          _pushRegistrationSuspended ||
+          alreadyRegistered) {
+        return;
+      }
+      await _unregisterPushTokenNow();
+      if (generation != _pushLifecycleGeneration ||
+          _pushRegistrationSuspended) {
+        return;
+      }
+      final credentials = authNotifier.credentials;
+      if (credentials != null) {
+        await _registerPushTokenNow(credentials, generation);
+      }
+    });
+  }
 
   Future<void> _queuePushLifecycle(Future<void> Function() operation) {
     final next = _pushLifecycle.then((_) => operation());
@@ -561,10 +585,20 @@ class AppStateController extends ChangeNotifier {
     return next;
   }
 
-  Future<void> _registerPushToken(UserCredentials credentials) =>
-      _queuePushLifecycle(() => _registerPushTokenNow(credentials));
+  Future<void> _registerPushToken(UserCredentials credentials) {
+    final generation = _pushLifecycleGeneration;
+    return _queuePushLifecycle(
+      () => _registerPushTokenNow(credentials, generation),
+    );
+  }
 
-  Future<void> _registerPushTokenNow(UserCredentials credentials) async {
+  Future<void> _registerPushTokenNow(
+    UserCredentials credentials,
+    int generation,
+  ) async {
+    if (generation != _pushLifecycleGeneration || _pushRegistrationSuspended) {
+      return;
+    }
     final token = _pushToken;
     if (token == null) return;
     if (_registeredPushToken == token &&
@@ -572,6 +606,9 @@ class AppStateController extends ChangeNotifier {
       return;
     }
     await _unregisterPushTokenNow();
+    if (generation != _pushLifecycleGeneration || _pushRegistrationSuspended) {
+      return;
+    }
     try {
       await _pushNotificationService.registerToken(
         credentials,
@@ -655,10 +692,10 @@ class AppStateController extends ChangeNotifier {
         return;
       }
       final matching = authorizedUnread.where((item) => item.id == id);
-      if (matching.isEmpty || !_activatedNotificationIds.add(id)) return;
-      _notificationActivationController.add(
-        notificationDestinationFor(matching.first.channel),
-      );
+      if (matching.isEmpty) return;
+      final destination = notificationDestinationFor(matching.first.channel);
+      if (destination == null || !_activatedNotificationIds.add(id)) return;
+      _notificationActivationController.add(destination);
     } on Object catch (_) {
       // A tap without an authorized REST record is a safe no-op.
     }
@@ -764,6 +801,8 @@ class AppStateController extends ChangeNotifier {
 
   Future<void> disconnect() async {
     _notificationSessionGeneration += 1;
+    _pushRegistrationSuspended = true;
+    _pushLifecycleGeneration += 1;
     await _unregisterPushToken();
     await _reverbService.disconnect();
     await authNotifier.disconnect();

--- a/flutter_client/lib/services/async_lifecycle.dart
+++ b/flutter_client/lib/services/async_lifecycle.dart
@@ -1,0 +1,42 @@
+import 'dart:async';
+
+/// Runs asynchronous operations one at a time, in the order they were
+/// enqueued. An operation that throws does not block operations queued
+/// behind it — the error only propagates to whoever awaited that specific
+/// [run] call.
+///
+/// Used wherever a resource (a file, a remote subscription) must not see two
+/// writes in flight at once, e.g. the on-disk store, the notification store,
+/// and push-token register/unregister sequencing.
+class SerialQueue {
+  Future<void> _tail = Future<void>.value();
+
+  /// Completes once every operation enqueued so far has settled, successful
+  /// or not.
+  Future<void> get drained => _tail;
+
+  Future<T> run<T>(Future<T> Function() operation) {
+    final result = _tail.then((_) => operation());
+    _tail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+}
+
+/// A monotonically increasing token for discarding stale async work.
+///
+/// Capture [current] before starting an operation; after each `await`,
+/// compare it against [current] again — or call [isStale] — to check
+/// whether [advance] has superseded it in the meantime, and bail out rather
+/// than apply a result for a session/credential/attempt that no longer
+/// applies.
+class Generation {
+  int _value = 0;
+
+  int get current => _value;
+
+  /// Invalidates any work captured against the previous value and returns
+  /// the new one.
+  int advance() => ++_value;
+
+  bool isStale(int captured) => captured != _value;
+}

--- a/flutter_client/lib/services/persistent_store.dart
+++ b/flutter_client/lib/services/persistent_store.dart
@@ -1,15 +1,17 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:m3u_tv/services/async_lifecycle.dart';
+
 class PersistentJsonStore {
   PersistentJsonStore({File? file}) : _file = file ?? File(_defaultPath());
 
   final File _file;
   Map<String, Object?>? _cache;
-  Future<void> _pendingWrite = Future<void>.value();
+  final SerialQueue _writeQueue = SerialQueue();
 
   Future<Object?> read(String key) async {
-    await _pendingWrite;
+    await _writeQueue.drained;
     final data = await _readAllUnlocked();
     return data[key];
   }
@@ -31,7 +33,7 @@ class PersistentJsonStore {
   }
 
   Future<Map<String, Object?>> snapshot() async {
-    await _pendingWrite;
+    await _writeQueue.drained;
     return Map<String, Object?>.from(await _readAllUnlocked());
   }
 
@@ -43,12 +45,8 @@ class PersistentJsonStore {
     });
   }
 
-  Future<void> _queueWrite(Future<void> Function() operation) {
-    final previous = _pendingWrite;
-    final next = previous.then((_) => operation(), onError: (_) => operation());
-    _pendingWrite = next.catchError((_) {});
-    return next;
-  }
+  Future<void> _queueWrite(Future<void> Function() operation) =>
+      _writeQueue.run(operation);
 
   Future<Map<String, Object?>> _readAllUnlocked() async {
     final cached = _cache;

--- a/flutter_client/lib/services/push_notification_service.dart
+++ b/flutter_client/lib/services/push_notification_service.dart
@@ -6,7 +6,77 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/tv_notification_service.dart'
-    show TvApiException;
+    show TvApiException, canonicalNotificationId;
+
+typedef PushMessageHandler = FutureOr<void> Function(PushMessage message);
+
+class PushMessage {
+  const PushMessage({required this.data});
+
+  final Map<String, String> data;
+
+  String? get notificationId => canonicalNotificationId(
+    data['notification_id'],
+  );
+}
+
+abstract interface class PushMessagingClient {
+  Future<void> initialize();
+
+  Future<bool> requestPermission();
+
+  Future<String?> getToken();
+
+  Stream<String> get onTokenRefresh;
+
+  Stream<PushMessage> get onForegroundMessage;
+
+  Stream<PushMessage> get onMessageOpenedApp;
+
+  Future<PushMessage?> getInitialMessage();
+}
+
+class FirebasePushMessagingClient implements PushMessagingClient {
+  FirebasePushMessagingClient({this.options});
+
+  final FirebaseOptions? options;
+
+  @override
+  Future<void> initialize() => Firebase.initializeApp(options: options);
+
+  @override
+  Future<bool> requestPermission() async {
+    final settings = await FirebaseMessaging.instance.requestPermission();
+    return settings.authorizationStatus != AuthorizationStatus.denied;
+  }
+
+  @override
+  Future<String?> getToken() => FirebaseMessaging.instance.getToken();
+
+  @override
+  Stream<String> get onTokenRefresh =>
+      FirebaseMessaging.instance.onTokenRefresh;
+
+  @override
+  Stream<PushMessage> get onForegroundMessage =>
+      FirebaseMessaging.onMessage.map(_fromRemoteMessage);
+
+  @override
+  Stream<PushMessage> get onMessageOpenedApp =>
+      FirebaseMessaging.onMessageOpenedApp.map(_fromRemoteMessage);
+
+  @override
+  Future<PushMessage?> getInitialMessage() async {
+    final message = await FirebaseMessaging.instance.getInitialMessage();
+    return message == null ? null : _fromRemoteMessage(message);
+  }
+
+  PushMessage _fromRemoteMessage(RemoteMessage message) => PushMessage(
+    data: message.data.map(
+      (key, value) => MapEntry(key, '$value'),
+    ),
+  );
+}
 
 /// Mobile-only push notifications via Firebase Cloud Messaging.
 ///
@@ -21,36 +91,64 @@ import 'package:m3u_tv/services/tv_notification_service.dart'
 /// `GoogleService-Info.plist`) before [init] is called — until then, calling
 /// [init] throws.
 class PushNotificationService {
-  PushNotificationService({HttpClient? httpClient})
-    : _client = httpClient ?? HttpClient();
+  PushNotificationService({
+    HttpClient? httpClient,
+    PushMessagingClient? messagingClient,
+  }) : _client = httpClient ?? HttpClient(),
+       _messagingClient = messagingClient ?? FirebasePushMessagingClient();
 
   final HttpClient _client;
+  final PushMessagingClient _messagingClient;
+  Future<String?>? _initialization;
+  StreamSubscription<PushMessage>? _foregroundSubscription;
+  StreamSubscription<PushMessage>? _openedSubscription;
 
   /// Initializes Firebase, requests notification permission, and returns the
   /// device's FCM registration token (or null if permission was denied).
-  Future<String?> init({FirebaseOptions? options}) async {
-    await Firebase.initializeApp(options: options);
+  Future<String?> init({
+    required PushMessageHandler onForegroundMessage,
+    required PushMessageHandler onMessageOpenedApp,
+  }) {
+    return _initialization ??= _initialize(
+      onForegroundMessage: onForegroundMessage,
+      onMessageOpenedApp: onMessageOpenedApp,
+    );
+  }
 
-    final settings = await FirebaseMessaging.instance.requestPermission();
-    if (settings.authorizationStatus == AuthorizationStatus.denied) {
-      return null;
+  Future<String?> _initialize({
+    required PushMessageHandler onForegroundMessage,
+    required PushMessageHandler onMessageOpenedApp,
+  }) async {
+    await _messagingClient.initialize();
+    if (!await _messagingClient.requestPermission()) return null;
+
+    _foregroundSubscription = _messagingClient.onForegroundMessage.listen(
+      (message) => unawaited(Future.sync(() => onForegroundMessage(message))),
+    );
+    _openedSubscription = _messagingClient.onMessageOpenedApp.listen(
+      (message) => unawaited(Future.sync(() => onMessageOpenedApp(message))),
+    );
+    final initialMessage = await _messagingClient.getInitialMessage();
+    if (initialMessage != null) {
+      await onMessageOpenedApp(initialMessage);
     }
-
-    return FirebaseMessaging.instance.getToken();
+    return _messagingClient.getToken();
   }
 
   /// Fires whenever Firebase rotates the device's FCM token; callers should
   /// re-register with [registerToken] each time this emits.
-  Stream<String> get onTokenRefresh =>
-      FirebaseMessaging.instance.onTokenRefresh;
+  Stream<String> get onTokenRefresh => _messagingClient.onTokenRefresh;
+
+  Future<void> dispose() async {
+    await _foregroundSubscription?.cancel();
+    await _openedSubscription?.cancel();
+  }
 
   /// Registers [token] with the self-hosted m3u-editor instance so it can
   /// forward pushes through the m3u-push-relay.
   ///
-  /// Mirrors `TvNotificationService`'s no-session REST convention. The
-  /// backend endpoint (`POST /api/tv/{u}/{p}/push/subscribe`) is Phase 3 of
-  /// the push-notifications plan and doesn't exist yet — this will 404 until
-  /// then.
+  /// Mirrors `TvNotificationService`'s requester-scoped, no-session REST
+  /// convention.
   Future<void> registerToken(
     UserCredentials creds, {
     required String token,
@@ -63,6 +161,19 @@ class PushNotificationService {
     await _post(uri, {'token': token, 'platform': platform});
   }
 
+  Future<void> unregisterToken(
+    UserCredentials creds, {
+    required String token,
+  }) async {
+    final base = _baseUri(creds.server);
+    final u = Uri.encodeComponent(creds.username);
+    final p = Uri.encodeComponent(creds.password);
+    final uri = base.replace(
+      path: '${base.path}/api/tv/$u/$p/push/unsubscribe',
+    );
+    await _delete(uri, {'token': token});
+  }
+
   Uri _baseUri(String server) {
     final uri = Uri.parse(server.replaceAll(RegExp(r'/+$'), ''));
     final path = uri.path.endsWith('/player_api.php')
@@ -73,6 +184,20 @@ class PushNotificationService {
 
   Future<void> _post(Uri uri, Map<String, String> body) async {
     final request = await _client.postUrl(uri);
+    final bytes = utf8.encode(jsonEncode(body));
+    request.headers.set(HttpHeaders.contentTypeHeader, 'application/json');
+    request
+      ..contentLength = bytes.length
+      ..add(bytes);
+    final response = await request.close();
+    final text = await utf8.decodeStream(response);
+    if (response.statusCode >= HttpStatus.badRequest) {
+      throw TvApiException(response.statusCode, text, uri);
+    }
+  }
+
+  Future<void> _delete(Uri uri, Map<String, String> body) async {
+    final request = await _client.deleteUrl(uri);
     final bytes = utf8.encode(jsonEncode(body));
     request.headers.set(HttpHeaders.contentTypeHeader, 'application/json');
     request

--- a/flutter_client/lib/services/reverb_service.dart
+++ b/flutter_client/lib/services/reverb_service.dart
@@ -122,7 +122,8 @@ class ReverbService {
       case 'tv.notification':
         if (!_connected) return;
         final payload = _parseData(msg['data']);
-        final item = TvNotificationItem.fromJson(payload);
+        final item = TvNotificationItem.tryFromJson(payload);
+        if (item == null) return;
         if (_subscribedChannels.isEmpty ||
             _subscribedChannels.contains(item.channel)) {
           _onNotification?.call(item);

--- a/flutter_client/lib/services/tv_notification_service.dart
+++ b/flutter_client/lib/services/tv_notification_service.dart
@@ -7,11 +7,12 @@ import 'package:m3u_tv/services/domain_models.dart';
 
 enum TvNotificationDestination { notifications, dvr, requests }
 
-TvNotificationDestination notificationDestinationFor(String channel) =>
+TvNotificationDestination? notificationDestinationFor(String channel) =>
     switch (channel) {
+      'general' => TvNotificationDestination.notifications,
       'dvr' => TvNotificationDestination.dvr,
       'requests' => TvNotificationDestination.requests,
-      _ => TvNotificationDestination.notifications,
+      _ => null,
     };
 
 /// Reverb connection config returned by the notifications endpoint.

--- a/flutter_client/lib/services/tv_notification_service.dart
+++ b/flutter_client/lib/services/tv_notification_service.dart
@@ -5,6 +5,15 @@ import 'dart:io';
 
 import 'package:m3u_tv/services/domain_models.dart';
 
+enum TvNotificationDestination { notifications, dvr, requests }
+
+TvNotificationDestination notificationDestinationFor(String channel) =>
+    switch (channel) {
+      'dvr' => TvNotificationDestination.dvr,
+      'requests' => TvNotificationDestination.requests,
+      _ => TvNotificationDestination.notifications,
+    };
+
 /// Reverb connection config returned by the notifications endpoint.
 class ReverbConfig {
   const ReverbConfig({
@@ -95,6 +104,7 @@ class TvNotificationItem {
     required this.title,
     this.body,
     required this.status,
+    this.adminOnly = false,
   });
 
   final String id;
@@ -106,21 +116,32 @@ class TvNotificationItem {
 
   /// 'success' | 'warning' | 'danger' | 'info'
   final String status;
+  final bool adminOnly;
 
-  factory TvNotificationItem.fromJson(Map<String, Object?> json) {
-    final rawId = json['id'];
-    final id = rawId is String && rawId.isNotEmpty
-        ? rawId
-        : 'live-${DateTime.now().microsecondsSinceEpoch}';
+  static TvNotificationItem? tryFromJson(Map<String, Object?> json) {
+    final id = canonicalNotificationId(json['id']);
+    if (id == null) return null;
     return TvNotificationItem(
       id: id,
       channel: '${json['channel'] ?? 'general'}',
       title: '${json['title'] ?? ''}',
       body: json['body'] as String?,
       status: '${json['status'] ?? 'info'}',
+      adminOnly: json['admin_only'] == true,
     );
   }
 }
+
+String? canonicalNotificationId(Object? value) {
+  if (value is! String) return null;
+  final normalized = value.toLowerCase();
+  if (!_uuidPattern.hasMatch(normalized)) return null;
+  return normalized;
+}
+
+final RegExp _uuidPattern = RegExp(
+  r'^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$',
+);
 
 /// REST client for the `/api/tv` endpoints.
 ///
@@ -176,7 +197,8 @@ class TvNotificationService {
     final rawList = json['notifications'] as List? ?? const [];
     final notifications = rawList
         .whereType<Map<String, Object?>>()
-        .map(TvNotificationItem.fromJson)
+        .map(TvNotificationItem.tryFromJson)
+        .whereType<TvNotificationItem>()
         .toList(growable: false);
 
     return (session, notifications);
@@ -274,7 +296,7 @@ class TvApiException implements Exception {
   final Uri uri;
 
   @override
-  String toString() => 'TvApiException($statusCode) ${uri.path}: $body';
+  String toString() => 'TvApiException($statusCode)';
 }
 
 int _asInt(Object? value, [int fallback = 0]) {

--- a/flutter_client/lib/services/tv_notification_store.dart
+++ b/flutter_client/lib/services/tv_notification_store.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: prefer_initializing_formals
 
+import 'dart:async';
+
 import 'package:m3u_tv/services/persistent_store.dart';
 import 'package:m3u_tv/services/tv_notification_service.dart';
 
@@ -34,6 +36,7 @@ class StoredTvNotification {
     'title': item.title,
     'body': item.body,
     'status': item.status,
+    'admin_only': item.adminOnly,
     'received_at': receivedAt.toIso8601String(),
     'is_read': isRead,
     'read_at': readAt?.toIso8601String(),
@@ -51,6 +54,7 @@ class StoredTvNotification {
         title: '${map['title'] ?? ''}',
         body: map['body'] as String?,
         status: '${map['status'] ?? 'info'}',
+        adminOnly: map['admin_only'] == true,
       ),
       receivedAt: receivedAt,
       isRead: map['is_read'] == true,
@@ -85,6 +89,7 @@ class TvNotificationStore {
 
   final Map<String, Object?> _memory;
   final PersistentJsonStore? _store;
+  Future<void> _mutationQueue = Future<void>.value();
 
   // In-memory cache so callers don't need to await for a hot-path check.
   Set<String>? _subscribedChannelsCache;
@@ -186,7 +191,7 @@ class TvNotificationStore {
   /// only the newly added items so callers can decide whether to toast them.
   Future<List<TvNotificationItem>> syncUnreadWithServer(
     List<TvNotificationItem> serverUnread,
-  ) async {
+  ) => _mutate(() async {
     final serverUnreadIds = {for (final n in serverUnread) n.id};
     final existing = await all();
     final existingIds = {for (final n in existing) n.item.id};
@@ -212,13 +217,13 @@ class TvNotificationStore {
       [...newItems, ...kept].take(_maxStored).toList(growable: false),
     );
     return newItems.map((n) => n.item).toList(growable: false);
-  }
+  });
 
   /// Adds a newly received notification as unread. No-op if its id is
   /// already stored (e.g. delivered via both the unread-fetch and Reverb push).
-  Future<void> add(TvNotificationItem item) async {
+  Future<bool> add(TvNotificationItem item) => _mutate(() async {
     final existing = await all();
-    if (existing.any((n) => n.item.id == item.id)) return;
+    if (existing.any((n) => n.item.id == item.id)) return false;
     final updated = [
       StoredTvNotification(
         item: item,
@@ -228,7 +233,8 @@ class TvNotificationStore {
       ...existing,
     ];
     await _write(updated.take(_maxStored).toList(growable: false));
-  }
+    return true;
+  });
 
   Future<void> markRead(String id) async {
     final existing = await all();
@@ -262,5 +268,14 @@ class TvNotificationStore {
     final encoded = notifications.map((n) => n.toJson()).toList();
     _memory[_key] = encoded;
     await _store?.write(_key, encoded);
+  }
+
+  Future<T> _mutate<T>(Future<T> Function() operation) {
+    final result = _mutationQueue.then((_) => operation());
+    _mutationQueue = result.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    return result;
   }
 }

--- a/flutter_client/lib/services/tv_notification_store.dart
+++ b/flutter_client/lib/services/tv_notification_store.dart
@@ -2,6 +2,7 @@
 
 import 'dart:async';
 
+import 'package:m3u_tv/services/async_lifecycle.dart';
 import 'package:m3u_tv/services/persistent_store.dart';
 import 'package:m3u_tv/services/tv_notification_service.dart';
 
@@ -89,7 +90,7 @@ class TvNotificationStore {
 
   final Map<String, Object?> _memory;
   final PersistentJsonStore? _store;
-  Future<void> _mutationQueue = Future<void>.value();
+  final SerialQueue _mutationQueue = SerialQueue();
 
   // In-memory cache so callers don't need to await for a hot-path check.
   Set<String>? _subscribedChannelsCache;
@@ -270,12 +271,6 @@ class TvNotificationStore {
     await _store?.write(_key, encoded);
   }
 
-  Future<T> _mutate<T>(Future<T> Function() operation) {
-    final result = _mutationQueue.then((_) => operation());
-    _mutationQueue = result.then<void>(
-      (_) {},
-      onError: (Object _, StackTrace _) {},
-    );
-    return result;
-  }
+  Future<T> _mutate<T>(Future<T> Function() operation) =>
+      _mutationQueue.run(operation);
 }

--- a/flutter_client/test/services/notification_lifecycle_test.dart
+++ b/flutter_client/test/services/notification_lifecycle_test.dart
@@ -149,7 +149,7 @@ void main() {
       );
     }
 
-    test('unknown category fails closed to generic notifications', () async {
+    test('unknown category and arbitrary routes fail closed', () async {
       final api = _FakeTvNotificationService(<TvNotificationItem>[
         _item(id: _notificationId, channel: 'untrusted-category'),
       ]);
@@ -163,14 +163,16 @@ void main() {
 
       await controller.handlePushActivation(
         const PushMessage(
-          data: <String, String>{'notification_id': _notificationId},
+          data: <String, String>{
+            'notification_id': _notificationId,
+            'route': '/arbitrary-route',
+            'url': 'https://attacker.invalid/private',
+          },
         ),
       );
       await Future<void>.delayed(Duration.zero);
 
-      expect(destinations, <TvNotificationDestination>[
-        TvNotificationDestination.notifications,
-      ]);
+      expect(destinations, isEmpty);
     });
 
     test(

--- a/flutter_client/test/services/notification_lifecycle_test.dart
+++ b/flutter_client/test/services/notification_lifecycle_test.dart
@@ -1,0 +1,457 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/auth_notifier.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/push_notification_service.dart';
+import 'package:m3u_tv/services/secure_storage.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart';
+import 'package:m3u_tv/services/tv_notification_store.dart';
+import 'package:m3u_tv/services/xtream_service.dart';
+
+void main() {
+  group('notification reconciliation', () {
+    test('rejects a missing or malformed canonical notification UUID', () {
+      expect(
+        TvNotificationItem.tryFromJson(<String, Object?>{
+          'channel': 'general',
+          'title': 'Missing identity',
+        }),
+        isNull,
+      );
+      expect(
+        TvNotificationItem.tryFromJson(<String, Object?>{
+          'id': 'aaaaaaaa-aaaa-0aaa-0aaa-aaaaaaaaaaaa',
+          'channel': 'general',
+          'title': 'Invalid UUID version and variant',
+        }),
+        isNull,
+      );
+      expect(
+        TvNotificationItem.tryFromJson(<String, Object?>{
+          'id': 'not-a-uuid',
+          'channel': 'general',
+          'title': 'Malformed identity',
+        }),
+        isNull,
+      );
+    });
+
+    test(
+      'REST then Reverb then repeated foreground FCM stores and presents once',
+      () async {
+        final item = TvNotificationItem.tryFromJson(<String, Object?>{
+          'id': _notificationId,
+          'channel': 'general',
+          'title': 'Authoritative title',
+          'body': 'Authoritative body',
+          'status': 'info',
+        })!;
+        final api = _FakeTvNotificationService(<TvNotificationItem>[item]);
+        final store = TvNotificationStore(memory: <String, Object?>{});
+        final controller = AppStateController(
+          authNotifier: _FixedAuthNotifier(_credentials),
+          tvNotificationService: api,
+          tvNotificationStore: store,
+        );
+        addTearDown(controller.dispose);
+        final presented = <TvNotificationItem>[];
+        final subscription = controller.tvNotifications.listen(presented.add);
+        addTearDown(subscription.cancel);
+
+        await controller.reconcileNotifications();
+        await controller.receiveTvNotification(item);
+        await controller.handleForegroundPush(
+          const PushMessage(
+            data: <String, String>{'notification_id': _notificationId},
+          ),
+        );
+        await controller.handleForegroundPush(
+          const PushMessage(
+            data: <String, String>{'notification_id': _notificationId},
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect((await store.all()).map((stored) => stored.item.id), [
+          _notificationId,
+        ]);
+        expect(presented.map((notification) => notification.id), [
+          _notificationId,
+        ]);
+        expect(api.fetchCalls, 3);
+      },
+    );
+
+    test('concurrent duplicate receipts report one insertion', () async {
+      final store = TvNotificationStore(memory: <String, Object?>{});
+      final item = _item(id: _notificationId, channel: 'general');
+
+      final inserted = await Future.wait<bool>(<Future<bool>>[
+        store.add(item),
+        store.add(item),
+      ]);
+
+      expect(inserted.where((value) => value), hasLength(1));
+      expect(await store.all(), hasLength(1));
+    });
+
+    test('restores the admin-only flag from persisted notifications', () async {
+      final memory = <String, Object?>{};
+      final store = TvNotificationStore(memory: memory);
+      await store.add(
+        const TvNotificationItem(
+          id: _notificationId,
+          channel: 'general',
+          title: 'Admin only',
+          status: 'warning',
+          adminOnly: true,
+        ),
+      );
+
+      final restored = await TvNotificationStore(memory: memory).all();
+
+      expect(restored.single.item.adminOnly, isTrue);
+    });
+  });
+
+  group('notification activation', () {
+    for (final entry in <String, TvNotificationDestination>{
+      'general': TvNotificationDestination.notifications,
+      'dvr': TvNotificationDestination.dvr,
+      'requests': TvNotificationDestination.requests,
+    }.entries) {
+      test(
+        'opened-app ${entry.key} activates its safe destination once',
+        () async {
+          final item = _item(id: _notificationId, channel: entry.key);
+          final api = _FakeTvNotificationService(<TvNotificationItem>[item]);
+          final controller = _controller(api);
+          addTearDown(controller.dispose);
+          final destinations = <TvNotificationDestination>[];
+          final subscription = controller.notificationActivations.listen(
+            destinations.add,
+          );
+          addTearDown(subscription.cancel);
+          const message = PushMessage(
+            data: <String, String>{
+              'notification_id': _notificationId,
+              'route': 'https://attacker.invalid/private',
+              'url': '/arbitrary-route',
+            },
+          );
+
+          await controller.handlePushActivation(message);
+          await controller.handlePushActivation(message);
+          await Future<void>.delayed(Duration.zero);
+
+          expect(destinations, <TvNotificationDestination>[entry.value]);
+        },
+      );
+    }
+
+    test('unknown category fails closed to generic notifications', () async {
+      final api = _FakeTvNotificationService(<TvNotificationItem>[
+        _item(id: _notificationId, channel: 'untrusted-category'),
+      ]);
+      final controller = _controller(api);
+      addTearDown(controller.dispose);
+      final destinations = <TvNotificationDestination>[];
+      final subscription = controller.notificationActivations.listen(
+        destinations.add,
+      );
+      addTearDown(subscription.cancel);
+
+      await controller.handlePushActivation(
+        const PushMessage(
+          data: <String, String>{'notification_id': _notificationId},
+        ),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(destinations, <TvNotificationDestination>[
+        TvNotificationDestination.notifications,
+      ]);
+    });
+
+    test(
+      'missing and malformed UUIDs fail closed before REST lookup',
+      () async {
+        final api = _FakeTvNotificationService(<TvNotificationItem>[]);
+        final controller = _controller(api);
+        addTearDown(controller.dispose);
+        final destinations = <TvNotificationDestination>[];
+        final subscription = controller.notificationActivations.listen(
+          destinations.add,
+        );
+        addTearDown(subscription.cancel);
+
+        await controller.handlePushActivation(
+          const PushMessage(data: <String, String>{}),
+        );
+        await controller.handlePushActivation(
+          const PushMessage(
+            data: <String, String>{'notification_id': 'malformed'},
+          ),
+        );
+
+        expect(api.fetchCalls, 0);
+        expect(destinations, isEmpty);
+      },
+    );
+
+    test('admin-only content fails closed for standard credentials', () async {
+      final api = _FakeTvNotificationService(<TvNotificationItem>[
+        const TvNotificationItem(
+          id: _notificationId,
+          channel: 'general',
+          title: 'Admin only',
+          status: 'warning',
+          adminOnly: true,
+        ),
+      ]);
+      final store = TvNotificationStore(memory: <String, Object?>{});
+      final controller = _controller(api, store: store);
+      addTearDown(controller.dispose);
+      final destinations = <TvNotificationDestination>[];
+      final subscription = controller.notificationActivations.listen(
+        destinations.add,
+      );
+      addTearDown(subscription.cancel);
+
+      await controller.handlePushActivation(
+        const PushMessage(
+          data: <String, String>{'notification_id': _notificationId},
+        ),
+      );
+
+      expect(destinations, isEmpty);
+      expect(await store.all(), isEmpty);
+    });
+
+    test(
+      'unauthorized requester payload is not authorized client-side',
+      () async {
+        final api = _FakeTvNotificationService(<TvNotificationItem>[]);
+        final store = TvNotificationStore(memory: <String, Object?>{});
+        final controller = _controller(api, store: store);
+        addTearDown(controller.dispose);
+        final destinations = <TvNotificationDestination>[];
+        final subscription = controller.notificationActivations.listen(
+          destinations.add,
+        );
+        addTearDown(subscription.cancel);
+
+        await controller.handlePushActivation(
+          const PushMessage(
+            data: <String, String>{
+              'notification_id': _notificationId,
+              'channel': 'requests',
+              'request_id': '123',
+            },
+          ),
+        );
+
+        expect(destinations, isEmpty);
+        expect(await store.all(), isEmpty);
+      },
+    );
+
+    test(
+      'background OS tap reconciles without a second in-app toast',
+      () async {
+        final item = _item(id: _notificationId, channel: 'general');
+        final api = _FakeTvNotificationService(<TvNotificationItem>[item]);
+        final controller = _controller(api);
+        addTearDown(controller.dispose);
+        final presented = <TvNotificationItem>[];
+        final presentationSubscription = controller.tvNotifications.listen(
+          presented.add,
+        );
+        addTearDown(presentationSubscription.cancel);
+
+        await controller.handlePushActivation(
+          const PushMessage(
+            data: <String, String>{'notification_id': _notificationId},
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(presented, isEmpty);
+        expect(
+          (await controller.notificationStore.all()).single.item.id,
+          item.id,
+        );
+      },
+    );
+
+    for (final entry in <String, TvNotificationDestination>{
+      'general': TvNotificationDestination.notifications,
+      'dvr': TvNotificationDestination.dvr,
+      'requests': TvNotificationDestination.requests,
+    }.entries) {
+      test('cold-start ${entry.key} waits for restored credentials', () async {
+        final item = _item(id: _notificationId, channel: entry.key);
+        final api = _FakeTvNotificationService(<TvNotificationItem>[item]);
+        final auth = _MutableAuthNotifier();
+        final controller = AppStateController(
+          authNotifier: auth,
+          tvNotificationService: api,
+          tvNotificationStore: TvNotificationStore(memory: <String, Object?>{}),
+        );
+        addTearDown(controller.dispose);
+        final presented = <TvNotificationItem>[];
+        final destinations = <TvNotificationDestination>[];
+        final presentationSubscription = controller.tvNotifications.listen(
+          presented.add,
+        );
+        final activationSubscription = controller.notificationActivations
+            .listen(
+              destinations.add,
+            );
+        addTearDown(presentationSubscription.cancel);
+        addTearDown(activationSubscription.cancel);
+
+        await controller.handlePushActivation(
+          const PushMessage(
+            data: <String, String>{'notification_id': _notificationId},
+          ),
+        );
+        expect(api.fetchCalls, 0);
+
+        auth.fixedCredentials = _credentials;
+        await controller.resumeNotifications();
+        await Future<void>.delayed(Duration.zero);
+
+        expect(presented, isEmpty);
+        expect(destinations, <TvNotificationDestination>[entry.value]);
+      });
+    }
+
+    test('requester-scoped REST fixture isolates two credentials', () async {
+      final requesterItem = _item(
+        id: _notificationId,
+        channel: 'requests',
+      );
+      final requesterApi = _FakeTvNotificationService(<TvNotificationItem>[
+        requesterItem,
+      ]);
+      final otherApi = _FakeTvNotificationService(const <TvNotificationItem>[]);
+      final requester = _controller(requesterApi);
+      final other = _controller(otherApi, credentials: _otherCredentials);
+      addTearDown(requester.dispose);
+      addTearDown(other.dispose);
+      final requesterDestinations = <TvNotificationDestination>[];
+      final otherDestinations = <TvNotificationDestination>[];
+      final requesterSubscription = requester.notificationActivations.listen(
+        requesterDestinations.add,
+      );
+      final otherSubscription = other.notificationActivations.listen(
+        otherDestinations.add,
+      );
+      addTearDown(requesterSubscription.cancel);
+      addTearDown(otherSubscription.cancel);
+      const message = PushMessage(
+        data: <String, String>{'notification_id': _notificationId},
+      );
+
+      await requester.handlePushActivation(message);
+      await other.handlePushActivation(message);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(requesterDestinations, <TvNotificationDestination>[
+        TvNotificationDestination.requests,
+      ]);
+      expect(otherDestinations, isEmpty);
+      expect(await requester.notificationStore.all(), hasLength(1));
+      expect(await other.notificationStore.all(), isEmpty);
+    });
+  });
+}
+
+const _notificationId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const _credentials = UserCredentials(
+  server: 'https://fixture.invalid',
+  username: 'requester-one',
+  password: 'private-value',
+);
+const _otherCredentials = UserCredentials(
+  server: 'https://fixture.invalid',
+  username: 'requester-two',
+  password: 'other-private-value',
+);
+
+TvNotificationItem _item({required String id, required String channel}) =>
+    TvNotificationItem(
+      id: id,
+      channel: channel,
+      title: 'Authoritative title',
+      body: 'Authoritative body',
+      status: 'info',
+    );
+
+AppStateController _controller(
+  _FakeTvNotificationService api, {
+  TvNotificationStore? store,
+  UserCredentials credentials = _credentials,
+}) => AppStateController(
+  authNotifier: _FixedAuthNotifier(credentials),
+  tvNotificationService: api,
+  tvNotificationStore:
+      store ?? TvNotificationStore(memory: <String, Object?>{}),
+);
+
+class _FixedAuthNotifier extends AuthNotifier {
+  _FixedAuthNotifier(this.fixedCredentials)
+    : super(
+        xtreamService: XtreamService(),
+        secureStorage: InMemorySecureStorage(),
+      );
+
+  final UserCredentials fixedCredentials;
+
+  @override
+  UserCredentials? get credentials => fixedCredentials;
+}
+
+class _MutableAuthNotifier extends AuthNotifier {
+  _MutableAuthNotifier()
+    : super(
+        xtreamService: XtreamService(),
+        secureStorage: InMemorySecureStorage(),
+      );
+
+  UserCredentials? fixedCredentials;
+
+  @override
+  UserCredentials? get credentials => fixedCredentials;
+}
+
+class _FakeTvNotificationService extends TvNotificationService {
+  _FakeTvNotificationService(this.unread);
+
+  final List<TvNotificationItem> unread;
+  int fetchCalls = 0;
+
+  @override
+  Future<(TvPlaylistSession, List<TvNotificationItem>)> fetchUnread(
+    UserCredentials creds, {
+    List<String>? channels,
+  }) async {
+    fetchCalls += 1;
+    return (
+      const TvPlaylistSession(
+        notifiableId: 1,
+        notifiableType: 'playlist',
+        isAdmin: false,
+        channelName: '',
+        reverb: ReverbConfig(
+          host: 'fixture.invalid',
+          port: 443,
+          scheme: 'wss',
+          appKey: '',
+        ),
+      ),
+      unread,
+    );
+  }
+}

--- a/flutter_client/test/services/push_notification_service_test.dart
+++ b/flutter_client/test/services/push_notification_service_test.dart
@@ -1,0 +1,161 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/push_notification_service.dart';
+
+void main() {
+  group('PushNotificationService', () {
+    test(
+      'registers foreground, opened-app, and cold-start handlers once',
+      () async {
+        final messaging = _FakePushMessagingClient(
+          initialMessage: const PushMessage(
+            data: <String, String>{'notification_id': _firstId},
+          ),
+        );
+        final service = PushNotificationService(messagingClient: messaging);
+        final foreground = <PushMessage>[];
+        final opened = <PushMessage>[];
+
+        final first = service.init(
+          onForegroundMessage: foreground.add,
+          onMessageOpenedApp: opened.add,
+        );
+        final second = service.init(
+          onForegroundMessage: foreground.add,
+          onMessageOpenedApp: opened.add,
+        );
+        expect(await first, 'device-token');
+        expect(await second, 'device-token');
+
+        messaging
+          ..emitForeground(
+            const PushMessage(
+              data: <String, String>{'notification_id': _secondId},
+            ),
+          )
+          ..emitOpened(
+            const PushMessage(
+              data: <String, String>{'notification_id': _thirdId},
+            ),
+          );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(messaging.initializeCalls, 1);
+        expect(messaging.foregroundListenerCount, 1);
+        expect(messaging.openedListenerCount, 1);
+        expect(messaging.initialMessageCalls, 1);
+        expect(foreground.map((message) => message.notificationId), [
+          _secondId,
+        ]);
+        expect(opened.map((message) => message.notificationId), [
+          _firstId,
+          _thirdId,
+        ]);
+      },
+    );
+
+    test('uses requester-scoped subscribe and unsubscribe contracts', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(() => server.close(force: true));
+      final requests = <(String, String, Map<String, Object?>)>[];
+      server.listen((request) async {
+        final body = jsonDecode(await utf8.decoder.bind(request).join());
+        requests.add((
+          request.method,
+          request.uri.path,
+          (body as Map).cast<String, Object?>(),
+        ));
+        request.response.headers.set(
+          HttpHeaders.contentTypeHeader,
+          'application/json',
+        );
+        request.response.write('{"ok":true}');
+        await request.response.close();
+      });
+      final service = PushNotificationService();
+      final credentials = UserCredentials(
+        server: 'http://${server.address.host}:${server.port}/player_api.php',
+        username: 'fixture user',
+        password: 'fixture value',
+      );
+
+      await service.registerToken(
+        credentials,
+        token: 'old-token',
+        platform: 'android',
+      );
+      await service.unregisterToken(credentials, token: 'old-token');
+
+      expect(requests.map((request) => request.$1), <String>['POST', 'DELETE']);
+      expect(requests.map((request) => request.$2), <String>[
+        '/api/tv/fixture%20user/fixture%20value/push/subscribe',
+        '/api/tv/fixture%20user/fixture%20value/push/unsubscribe',
+      ]);
+      expect(requests.first.$3, <String, Object?>{
+        'token': 'old-token',
+        'platform': 'android',
+      });
+      expect(requests.last.$3, <String, Object?>{'token': 'old-token'});
+    });
+  });
+}
+
+const _firstId = '11111111-1111-4111-8111-111111111111';
+const _secondId = '22222222-2222-4222-8222-222222222222';
+const _thirdId = '33333333-3333-4333-8333-333333333333';
+
+class _FakePushMessagingClient implements PushMessagingClient {
+  _FakePushMessagingClient({this.initialMessage});
+
+  final PushMessage? initialMessage;
+  final StreamController<PushMessage> _foreground =
+      StreamController<PushMessage>.broadcast();
+  final StreamController<PushMessage> _opened =
+      StreamController<PushMessage>.broadcast();
+  final StreamController<String> _tokens = StreamController<String>.broadcast();
+
+  int initializeCalls = 0;
+  int foregroundListenerCount = 0;
+  int openedListenerCount = 0;
+  int initialMessageCalls = 0;
+
+  @override
+  Future<void> initialize() async {
+    initializeCalls += 1;
+  }
+
+  @override
+  Future<bool> requestPermission() async => true;
+
+  @override
+  Future<String?> getToken() async => 'device-token';
+
+  @override
+  Stream<PushMessage> get onForegroundMessage {
+    foregroundListenerCount += 1;
+    return _foreground.stream;
+  }
+
+  @override
+  Stream<PushMessage> get onMessageOpenedApp {
+    openedListenerCount += 1;
+    return _opened.stream;
+  }
+
+  @override
+  Stream<String> get onTokenRefresh => _tokens.stream;
+
+  @override
+  Future<PushMessage?> getInitialMessage() async {
+    initialMessageCalls += 1;
+    return initialMessage;
+  }
+
+  void emitForeground(PushMessage message) => _foreground.add(message);
+
+  void emitOpened(PushMessage message) => _opened.add(message);
+}

--- a/flutter_client/test/services/push_token_lifecycle_test.dart
+++ b/flutter_client/test/services/push_token_lifecycle_test.dart
@@ -1,0 +1,276 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/auth_notifier.dart';
+import 'package:m3u_tv/services/cache_service.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/persistent_store.dart';
+import 'package:m3u_tv/services/push_notification_service.dart';
+import 'package:m3u_tv/services/reverb_service.dart';
+import 'package:m3u_tv/services/secure_storage.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart';
+import 'package:m3u_tv/services/xtream_service.dart';
+
+void main() {
+  group('push token identity lifecycle', () {
+    test('refresh unsubscribes the old token before registering new', () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.controller.dispose);
+      expect(await fixture.controller.connectXtream(_firstCredentials), isTrue);
+      await fixture.controller.setPushToken('old-token');
+      fixture.push.events.clear();
+
+      await fixture.controller.setPushToken('new-token');
+
+      expect(fixture.push.events, <String>[
+        'unsubscribe:first:old-token:true',
+        'register:first:new-token',
+      ]);
+    });
+
+    test('logout unsubscribes before credentials are cleared', () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.controller.dispose);
+      expect(await fixture.controller.connectXtream(_firstCredentials), isTrue);
+      await fixture.controller.setPushToken('device-token');
+      fixture.push.events.clear();
+
+      await fixture.controller.disconnect();
+
+      expect(fixture.push.events, <String>[
+        'unsubscribe:first:device-token:true',
+      ]);
+      expect(fixture.auth.credentials, isNull);
+    });
+
+    test('credential replacement unsubscribes prior requester first', () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.controller.dispose);
+      expect(await fixture.controller.connectXtream(_firstCredentials), isTrue);
+      await fixture.controller.setPushToken('device-token');
+      fixture.push.events.clear();
+
+      expect(
+        await fixture.controller.connectXtream(_secondCredentials),
+        isTrue,
+      );
+
+      expect(fixture.push.events, <String>[
+        'unsubscribe:first:device-token:true',
+        'register:second:device-token',
+      ]);
+    });
+
+    test('switching to direct M3U unsubscribes the prior requester', () async {
+      final fixture = _Fixture();
+      addTearDown(fixture.controller.dispose);
+      expect(await fixture.controller.connectXtream(_firstCredentials), isTrue);
+      await fixture.controller.setPushToken('device-token');
+      fixture.push.events.clear();
+
+      expect(
+        await fixture.controller.switchToM3u(
+          playlistText:
+              '#EXTM3U\n#EXTINF:-1,Fixture Channel\nhttps://media.invalid/live.m3u8',
+        ),
+        isTrue,
+      );
+
+      expect(fixture.push.events, <String>[
+        'unsubscribe:first:device-token:true',
+      ]);
+      expect(fixture.auth.credentials, isNull);
+    });
+
+    test('credential replacement ignores stale notification setup', () async {
+      final api = _DelayedTvNotificationService();
+      final reverb = _RecordingReverbService();
+      final fixture = _Fixture(notificationApi: api, reverbService: reverb);
+      addTearDown(fixture.controller.dispose);
+
+      expect(await fixture.controller.connectXtream(_firstCredentials), isTrue);
+      await api.firstFetchStarted.future;
+
+      expect(
+        await fixture.controller.connectXtream(_secondCredentials),
+        isTrue,
+      );
+      await reverb.secondConnected.future;
+      api.releaseFirstFetch.complete();
+      await api.firstFetchReturned.future;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(reverb.connectedUsers, <String>['second']);
+    });
+  });
+}
+
+const _firstCredentials = UserCredentials(
+  server: 'https://fixture.invalid',
+  username: 'first',
+  password: 'first-private-value',
+);
+const _secondCredentials = UserCredentials(
+  server: 'https://fixture.invalid',
+  username: 'second',
+  password: 'second-private-value',
+);
+
+class _Fixture {
+  _Fixture({
+    TvNotificationService? notificationApi,
+    ReverbService? reverbService,
+  }) {
+    final store = PersistentJsonStore(
+      file: File(
+        '${Directory.systemTemp.path}/m3u-tv-push-${identityHashCode(this)}.json',
+      ),
+    );
+    xtream = XtreamService(
+      transport: _FakeXtreamTransport().call,
+      cache: CacheService(memory: <String, Object?>{}),
+    );
+    auth = AuthNotifier(
+      xtreamService: xtream,
+      secureStorage: InMemorySecureStorage(),
+    );
+    push = _FakePushNotificationService(
+      credentialsArePresent: (credentials) =>
+          identical(auth.credentials, credentials),
+    );
+    controller = AppStateController(
+      authNotifier: auth,
+      xtreamService: xtream,
+      secureStorage: auth.secureStorage,
+      persistentStore: store,
+      pushNotificationService: push,
+      tvNotificationService: notificationApi ?? _EmptyTvNotificationService(),
+      reverbService: reverbService,
+    );
+  }
+
+  late final XtreamService xtream;
+  late final AuthNotifier auth;
+  late final _FakePushNotificationService push;
+  late final AppStateController controller;
+}
+
+class _FakePushNotificationService extends PushNotificationService {
+  _FakePushNotificationService({required this.credentialsArePresent});
+
+  final bool Function(UserCredentials credentials) credentialsArePresent;
+  final List<String> events = <String>[];
+
+  @override
+  Future<void> registerToken(
+    UserCredentials creds, {
+    required String token,
+    required String platform,
+  }) async {
+    events.add('register:${creds.username}:$token');
+  }
+
+  @override
+  Future<void> unregisterToken(
+    UserCredentials creds, {
+    required String token,
+  }) async {
+    events.add(
+      'unsubscribe:${creds.username}:$token:${credentialsArePresent(creds)}',
+    );
+  }
+}
+
+class _EmptyTvNotificationService extends TvNotificationService {
+  @override
+  Future<(TvPlaylistSession, List<TvNotificationItem>)> fetchUnread(
+    UserCredentials creds, {
+    List<String>? channels,
+  }) async => (
+    const TvPlaylistSession(
+      notifiableId: 1,
+      notifiableType: 'playlist',
+      isAdmin: false,
+      channelName: '',
+      reverb: ReverbConfig(
+        host: 'fixture.invalid',
+        port: 443,
+        scheme: 'wss',
+        appKey: '',
+      ),
+    ),
+    const <TvNotificationItem>[],
+  );
+}
+
+class _DelayedTvNotificationService extends TvNotificationService {
+  final Completer<void> firstFetchStarted = Completer<void>();
+  final Completer<void> releaseFirstFetch = Completer<void>();
+  final Completer<void> firstFetchReturned = Completer<void>();
+
+  @override
+  Future<(TvPlaylistSession, List<TvNotificationItem>)> fetchUnread(
+    UserCredentials creds, {
+    List<String>? channels,
+  }) async {
+    if (creds.username == 'first') {
+      firstFetchStarted.complete();
+      await releaseFirstFetch.future;
+      firstFetchReturned.complete();
+    }
+    return (
+      const TvPlaylistSession(
+        notifiableId: 1,
+        notifiableType: 'playlist',
+        isAdmin: false,
+        channelName: 'private-tv.playlist.fixture',
+        reverb: ReverbConfig(
+          host: 'fixture.invalid',
+          port: 443,
+          scheme: 'wss',
+          appKey: 'fixture-key',
+        ),
+      ),
+      const <TvNotificationItem>[],
+    );
+  }
+}
+
+class _RecordingReverbService extends ReverbService {
+  final List<String> connectedUsers = <String>[];
+  final Completer<void> secondConnected = Completer<void>();
+
+  @override
+  Future<void> connect({
+    required TvPlaylistSession session,
+    required UserCredentials credentials,
+    Set<String> subscribedChannels = const <String>{},
+    required void Function(TvNotificationItem) onNotification,
+    void Function(DvrRecording)? onDvrStatus,
+    void Function(MediaRequestSummary)? onRequestStatus,
+    void Function()? onConnected,
+  }) async {
+    connectedUsers.add(credentials.username);
+    if (credentials.username == 'second') secondConnected.complete();
+  }
+}
+
+class _FakeXtreamTransport {
+  Future<Object?> call(XtreamRequest request) async =>
+      switch (request.action ?? 'auth') {
+        'auth' => <String, Object?>{
+          'user_info': <String, Object?>{'auth': 1, 'status': 'Active'},
+          'm3u_editor': <String, Object?>{'version': '0.10.0'},
+        },
+        'get_live_categories' ||
+        'get_vod_categories' ||
+        'get_series_categories' ||
+        'get_live_streams' ||
+        'get_vod_streams' ||
+        'get_series' ||
+        'get_viewers' => <Object?>[],
+        _ => throw StateError('Unexpected fixture action'),
+      };
+}

--- a/flutter_client/test/services/push_token_lifecycle_test.dart
+++ b/flutter_client/test/services/push_token_lifecycle_test.dart
@@ -45,6 +45,60 @@ void main() {
       expect(fixture.auth.credentials, isNull);
     });
 
+    test(
+      'logout rejects a direct token replacement queued behind unsubscribe',
+      () async {
+        final fixture = _Fixture();
+        addTearDown(fixture.controller.dispose);
+        expect(
+          await fixture.controller.connectXtream(_firstCredentials),
+          isTrue,
+        );
+        await fixture.controller.setPushToken('old-token');
+        fixture.push.events.clear();
+        final unregisterStarted = fixture.push.delayNextUnregister();
+
+        final disconnect = fixture.controller.disconnect();
+        await unregisterStarted;
+        final replacement = fixture.controller.setPushToken('new-token');
+        fixture.push.releaseUnregister();
+        await Future.wait<void>(<Future<void>>[disconnect, replacement]);
+
+        expect(fixture.push.events, <String>[
+          'unsubscribe:first:old-token:true',
+        ]);
+        expect(fixture.auth.credentials, isNull);
+      },
+    );
+
+    test(
+      'logout rejects a token refresh queued behind unsubscribe',
+      () async {
+        final fixture = _Fixture();
+        addTearDown(fixture.controller.dispose);
+        expect(
+          await fixture.controller.connectXtream(_firstCredentials),
+          isTrue,
+        );
+        await fixture.controller.initPushNotifications();
+        await fixture.controller.setPushToken('old-token');
+        fixture.push.events.clear();
+        final unregisterStarted = fixture.push.delayNextUnregister();
+
+        final disconnect = fixture.controller.disconnect();
+        await unregisterStarted;
+        fixture.push.emitTokenRefresh('new-token');
+        fixture.push.releaseUnregister();
+        await disconnect;
+        await fixture.controller.setPushToken('after-logout-token');
+
+        expect(fixture.push.events, <String>[
+          'unsubscribe:first:old-token:true',
+        ]);
+        expect(fixture.auth.credentials, isNull);
+      },
+    );
+
     test('credential replacement unsubscribes prior requester first', () async {
       final fixture = _Fixture();
       addTearDown(fixture.controller.dispose);
@@ -162,6 +216,29 @@ class _FakePushNotificationService extends PushNotificationService {
 
   final bool Function(UserCredentials credentials) credentialsArePresent;
   final List<String> events = <String>[];
+  final StreamController<String> _tokenRefreshes =
+      StreamController<String>.broadcast(sync: true);
+  Completer<void>? _unregisterStarted;
+  Completer<void>? _releaseUnregister;
+
+  Future<void> delayNextUnregister() {
+    _unregisterStarted = Completer<void>();
+    _releaseUnregister = Completer<void>();
+    return _unregisterStarted!.future;
+  }
+
+  void releaseUnregister() => _releaseUnregister!.complete();
+
+  void emitTokenRefresh(String token) => _tokenRefreshes.add(token);
+
+  @override
+  Stream<String> get onTokenRefresh => _tokenRefreshes.stream;
+
+  @override
+  Future<String?> init({
+    required PushMessageHandler onForegroundMessage,
+    required PushMessageHandler onMessageOpenedApp,
+  }) async => null;
 
   @override
   Future<void> registerToken(
@@ -180,6 +257,20 @@ class _FakePushNotificationService extends PushNotificationService {
     events.add(
       'unsubscribe:${creds.username}:$token:${credentialsArePresent(creds)}',
     );
+    final unregisterStarted = _unregisterStarted;
+    final releaseUnregister = _releaseUnregister;
+    if (unregisterStarted != null && releaseUnregister != null) {
+      unregisterStarted.complete();
+      await releaseUnregister.future;
+      _unregisterStarted = null;
+      _releaseUnregister = null;
+    }
+  }
+
+  @override
+  Future<void> dispose() async {
+    await _tokenRefreshes.close();
+    await super.dispose();
   }
 }
 

--- a/flutter_client/test/ui/navigation/notification_activation_test.dart
+++ b/flutter_client/test/ui/navigation/notification_activation_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/app/app_shell.dart';
+import 'package:m3u_tv/navigation/route_names.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart';
+
+void main() {
+  test('safe activation destinations use the fixed route table', () {
+    expect(
+      notificationRouteFor(TvNotificationDestination.notifications),
+      RouteNames.notifications,
+    );
+    expect(
+      notificationRouteFor(
+        TvNotificationDestination.dvr,
+        hasDvrFeature: true,
+      ),
+      RouteNames.dvr,
+    );
+    expect(
+      notificationRouteFor(
+        TvNotificationDestination.requests,
+        hasRequestsFeature: true,
+      ),
+      RouteNames.requests,
+    );
+  });
+
+  test('unavailable feature destinations fail closed to notifications', () {
+    expect(
+      notificationRouteFor(TvNotificationDestination.dvr),
+      RouteNames.notifications,
+    );
+    expect(
+      notificationRouteFor(TvNotificationDestination.requests),
+      RouteNames.notifications,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- register foreground, opened-app, and cold-start Firebase handlers exactly once and reconcile REST, Reverb, and FCM deliveries by canonical notification UUID
- resolve tap destinations from server-authoritative notification records through a fixed route table, with admin, requester, malformed-data, and unavailable-feature fail-closed behavior
- serialize token refresh, logout, credential replacement, and direct-M3U cleanup so the previous requester is unsubscribed before a replacement is registered
- guard asynchronous notification setup against stale credentials, preserve `admin_only` through persistence, and prevent API errors from rendering credential-bearing URIs or response bodies

## Backend Dependency

Depends on m3u-editor PR https://github.com/m3ue/m3u-editor/pull/1323 for the requester-scoped push subscription and notification visibility contract. The client treats FCM data only as an opaque notification UUID and never authorizes request visibility from payload fields.

## Verification

- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze lib test`
- `flutter test --concurrency=1` (416 passed, 5 skipped)
- `flutter build apk --debug`
- `./android/gradlew -p android :app:testDebugUnitTest`
- `flutter build linux --release` plus CI-equivalent bundle and `ldd` checks in isolated Ubuntu 24.04

Closes #126