### PR TITLE
fix: isolate favorites by source and viewer

### DIFF
--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart' hide Category;
 import 'package:flutter/widgets.dart' show Locale;
 
@@ -110,7 +111,11 @@ class AppStateController extends ChangeNotifier {
     required this.aioFavoritesService,
     required this.proxyPlaybackSettings,
     required this._pushNotificationService,
-  });
+  }) {
+    favoritesService.clearNamespace();
+    vodFavoritesService.clearNamespace();
+    seriesFavoritesService.clearNamespace();
+  }
 
   static const _sourceKey = 'm3ue_tv_source';
   static const _epgIntervalKey = 'm3ue_tv_epg_interval_minutes';
@@ -210,6 +215,7 @@ class AppStateController extends ChangeNotifier {
   Set<int> _recordingChannelIds = const <int>{};
   List<MediaRequestSummary> _mediaRequests = const <MediaRequestSummary>[];
   List<Progress> _progressList = const <Progress>[];
+  String? _favoritesSourceIdentity;
   Future<List<Progress>>? _recentlyWatchedRefresh;
   String? _recentlyWatchedRefreshViewerId;
   final Set<int> _pendingEpgChannelIds = <int>{};
@@ -323,6 +329,8 @@ class AppStateController extends ChangeNotifier {
       return false;
     }
 
+    _favoritesSourceIdentity = _xtreamFavoritesIdentity(credentials);
+    _clearFavoritesNamespace();
     final loaded = await _replaceWithXtreamContent(clearCache: true);
     _isLoadingContent = false;
     notifyListeners();
@@ -371,6 +379,8 @@ class AppStateController extends ChangeNotifier {
         name: 'Local M3U',
         isAdmin: true,
       );
+      _favoritesSourceIdentity = _m3uFavoritesIdentity(playlistText);
+      await _selectFavoritesNamespace(_activeViewer!);
       _progressList = await resumeService.all(_activeViewer!.ulid);
       _isLoadingContent = false;
       notifyListeners();
@@ -587,6 +597,8 @@ class AppStateController extends ChangeNotifier {
     _recordingChannelIds = const <int>{};
     _mediaRequests = const <MediaRequestSummary>[];
     _progressList = const <Progress>[];
+    _favoritesSourceIdentity = null;
+    _clearFavoritesNamespace();
     _error = null;
     notifyListeners();
   }
@@ -630,6 +642,7 @@ class AppStateController extends ChangeNotifier {
   Future<void> switchViewer(Viewer viewer) async {
     await viewerService.setActiveViewer(viewer);
     _activeViewer = viewer;
+    await _selectFavoritesNamespace(viewer);
     _progressList = await _loadRecentlyWatched(viewer.ulid);
     notifyListeners();
   }
@@ -831,6 +844,18 @@ class AppStateController extends ChangeNotifier {
       final mediaRequests = results[8] as List<MediaRequestSummary>;
 
       final activeViewer = await viewerService.resolveActiveViewer(viewers);
+      final credentials = authNotifier.credentials;
+      if (credentials == null) {
+        _favoritesSourceIdentity = null;
+        _clearFavoritesNamespace();
+      } else {
+        _favoritesSourceIdentity = _xtreamFavoritesIdentity(credentials);
+        if (activeViewer == null) {
+          _clearFavoritesNamespace();
+        } else {
+          await _selectFavoritesNamespace(activeViewer);
+        }
+      }
       final fetched = activeViewer == null
           ? const <Progress>[]
           : await _loadRecentlyWatchedDeduped(activeViewer.ulid);
@@ -930,6 +955,19 @@ class AppStateController extends ChangeNotifier {
     _mediaRequests = const <MediaRequestSummary>[];
     _viewers = viewers;
     _activeViewer = await viewerService.resolveActiveViewer(viewers);
+    final credentials = authNotifier.credentials;
+    if (credentials == null) {
+      _favoritesSourceIdentity = null;
+      _clearFavoritesNamespace();
+    } else {
+      _favoritesSourceIdentity = _xtreamFavoritesIdentity(credentials);
+      final activeViewer = _activeViewer;
+      if (activeViewer == null) {
+        _clearFavoritesNamespace();
+      } else {
+        await _selectFavoritesNamespace(activeViewer);
+      }
+    }
     final activeViewer = _activeViewer;
     _progressList = activeViewer == null
         ? const <Progress>[]
@@ -1125,6 +1163,45 @@ class AppStateController extends ChangeNotifier {
       return AppSourceType.none;
     }
   }
+
+  void _clearFavoritesNamespace() {
+    favoritesService.clearNamespace();
+    vodFavoritesService.clearNamespace();
+    seriesFavoritesService.clearNamespace();
+  }
+
+  Future<void> _selectFavoritesNamespace(Viewer viewer) async {
+    final sourceIdentity = _favoritesSourceIdentity;
+    if (sourceIdentity == null) {
+      _clearFavoritesNamespace();
+      return;
+    }
+    final namespace = _digest('$sourceIdentity\u0000${viewer.ulid}');
+    await Future.wait(<Future<void>>[
+      favoritesService.selectNamespace(namespace),
+      vodFavoritesService.selectNamespace(namespace),
+      seriesFavoritesService.selectNamespace(namespace),
+    ]);
+  }
+
+  static String _xtreamFavoritesIdentity(UserCredentials credentials) {
+    final server = Uri.parse(credentials.server.trim());
+    final origin = server.hasScheme && server.host.isNotEmpty
+        ? server.origin
+        : credentials.server
+              .trim()
+              .replaceFirst(RegExp(r'/+$'), '')
+              .toLowerCase();
+    return _digest(
+      'xtream\u0000$origin\u0000${credentials.username}\u0000${credentials.password}',
+    );
+  }
+
+  static String _m3uFavoritesIdentity(String playlistText) =>
+      _digest('m3u\u0000$playlistText');
+
+  static String _digest(String value) =>
+      sha256.convert(utf8.encode(value)).toString();
 
   String _redact(String message, UserCredentials? credentials) {
     if (credentials == null) return message;

--- a/flutter_client/lib/services/favorites_service.dart
+++ b/flutter_client/lib/services/favorites_service.dart
@@ -10,29 +10,62 @@ class FavoritesService extends ChangeNotifier {
     String namespace = '',
   }) : _memory = memory ?? <String, Object?>{},
        _store = store,
+       _legacyFavoritesKey = namespace.isEmpty
+           ? 'm3ue_favorites'
+           : 'm3ue_favorites_$namespace',
        _favoritesKey = namespace.isEmpty
            ? 'm3ue_favorites'
            : 'm3ue_favorites_$namespace';
 
-  final String _favoritesKey;
+  final String _legacyFavoritesKey;
+  String? _favoritesKey;
   static const _lastCategoryKey = 'm3ue_last_category';
   static const _lastViewModeKey = 'm3ue_last_view_mode';
 
   final Map<String, Object?> _memory;
   final PersistentJsonStore? _store;
 
+  void clearNamespace() {
+    if (_favoritesKey == null) return;
+    _favoritesKey = null;
+    notifyListeners();
+  }
+
+  Future<void> selectNamespace(String namespace) async {
+    final nextKey = '${_legacyFavoritesKey}_scope_$namespace';
+    final changed = _favoritesKey != nextKey;
+    _favoritesKey = nextKey;
+
+    final migrationKey = '${_legacyFavoritesKey}_scope_migrated';
+    if (await _read(migrationKey) != true) {
+      final legacyIds = await _all(_legacyFavoritesKey);
+      if (legacyIds.isNotEmpty) {
+        final scopedIds = await _all(nextKey)
+          ..addAll(legacyIds);
+        await _write(nextKey, scopedIds.toList()..sort());
+      }
+      await _write(migrationKey, true);
+    }
+
+    if (changed) notifyListeners();
+  }
+
   Future<bool> add(int streamId) async {
-    final ids = await all();
+    final key = _favoritesKey;
+    if (key == null) return false;
+    final ids = await _all(key);
     ids.add(streamId);
-    await _write(_favoritesKey, ids.toList()..sort());
+    await _write(key, ids.toList()..sort());
     notifyListeners();
     return true;
   }
 
   Future<bool> remove(int streamId) async {
-    final ids = await all();
+    final key = _favoritesKey;
+    if (key == null) return false;
+    final ids = await _all(key);
     ids.remove(streamId);
-    await _write(_favoritesKey, ids.toList()..sort());
+    await _write(key, ids.toList()..sort());
     notifyListeners();
     return false;
   }
@@ -44,7 +77,12 @@ class FavoritesService extends ChangeNotifier {
       (await all()).contains(streamId);
 
   Future<Set<int>> all() async {
-    final raw = await _read(_favoritesKey);
+    final key = _favoritesKey;
+    return key == null ? <int>{} : _all(key);
+  }
+
+  Future<Set<int>> _all(String key) async {
+    final raw = await _read(key);
     if (raw is Iterable) return raw.map((value) => int.parse('$value')).toSet();
     return <int>{};
   }

--- a/flutter_client/pubspec.lock
+++ b/flutter_client/pubspec.lock
@@ -202,7 +202,7 @@ packages:
     source: hosted
     version: "3.1.2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/flutter_client/pubspec.yaml
+++ b/flutter_client/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   cached_network_image: ^3.4.1
+  crypto: ^3.0.7
   cupertino_icons: ^1.0.8
   dpad: ^3.0.0
   firebase_core: ^4.12.1

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -548,8 +548,304 @@ void main() {
         );
       },
     );
+
+    test(
+      'Xtream favorites normalize origins and isolate servers and credentials',
+      () async {
+        final storage = InMemorySecureStorage();
+        final localMemory = <String, Object?>{};
+        final controller = _controller(
+          storage: storage,
+          localMemory: localMemory,
+          transport: _FakeXtreamTransport.success().call,
+        );
+        addTearDown(controller.dispose);
+
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'HTTPS://FIXTURE.EXAMPLE:443/',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+        await controller.favoritesService.add(101);
+        await controller.vodFavoritesService.add(101);
+        await controller.seriesFavoritesService.add(101);
+
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'https://fixture.example',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+        expect(await controller.favoritesService.all(), <int>{101});
+        expect(await controller.vodFavoritesService.all(), <int>{101});
+        expect(await controller.seriesFavoritesService.all(), <int>{101});
+
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'https://other.example',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+        expect(await controller.favoritesService.all(), isEmpty);
+        expect(await controller.vodFavoritesService.all(), isEmpty);
+        expect(await controller.seriesFavoritesService.all(), isEmpty);
+
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'https://fixture.example',
+              username: 'replacement-user',
+              password: 'replacement-password',
+            ),
+          ),
+          isTrue,
+        );
+        expect(await controller.favoritesService.all(), isEmpty);
+        expect(await controller.vodFavoritesService.all(), isEmpty);
+        expect(await controller.seriesFavoritesService.all(), isEmpty);
+
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'https://fixture.example/',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+        expect(await controller.favoritesService.all(), <int>{101});
+        expect(await controller.vodFavoritesService.all(), <int>{101});
+        expect(await controller.seriesFavoritesService.all(), <int>{101});
+      },
+    );
+
+    test('favorites switch with the active viewer', () async {
+      final controller = _controller(
+        storage: InMemorySecureStorage(),
+        transport: _FakeXtreamTransport.success().withResponse(
+          'get_viewers',
+          <Map<String, Object?>>[
+            <String, Object?>{
+              'id': 1,
+              'ulid': 'viewer-admin',
+              'name': 'Admin',
+              'is_admin': true,
+            },
+            <String, Object?>{
+              'id': 2,
+              'ulid': 'viewer-child',
+              'name': 'Child',
+              'is_admin': false,
+            },
+          ],
+        ).call,
+      );
+      addTearDown(controller.dispose);
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'fixture-user',
+            password: 'fixture-password',
+          ),
+        ),
+        isTrue,
+      );
+      await controller.favoritesService.add(101);
+      await controller.vodFavoritesService.add(201);
+      await controller.seriesFavoritesService.add(301);
+
+      await controller.switchViewer(controller.viewers[1]);
+      expect(await controller.favoritesService.all(), isEmpty);
+      expect(await controller.vodFavoritesService.all(), isEmpty);
+      expect(await controller.seriesFavoritesService.all(), isEmpty);
+      await controller.favoritesService.add(101);
+
+      await controller.switchViewer(controller.viewers[0]);
+      expect(await controller.favoritesService.all(), <int>{101});
+      expect(await controller.vodFavoritesService.all(), <int>{201});
+      expect(await controller.seriesFavoritesService.all(), <int>{301});
+    });
+
+    test('M3U favorites isolate playlists and restore after restart', () async {
+      final storage = InMemorySecureStorage();
+      final localMemory = <String, Object?>{};
+      final first = _controller(
+        storage: storage,
+        localMemory: localMemory,
+        transport: _FakeXtreamTransport.success().call,
+      );
+      addTearDown(first.dispose);
+
+      expect(
+        await first.switchToM3u(playlistText: _fixturePlaylist),
+        isTrue,
+      );
+      await first.favoritesService.add(101);
+      expect(
+        await first.switchToM3u(playlistText: _otherFixturePlaylist),
+        isTrue,
+      );
+      expect(await first.favoritesService.all(), isEmpty);
+      expect(
+        await first.switchToM3u(playlistText: _fixturePlaylist),
+        isTrue,
+      );
+      expect(await first.favoritesService.all(), <int>{101});
+
+      final restarted = _controller(
+        storage: storage,
+        localMemory: localMemory,
+        transport: _FakeXtreamTransport.success().call,
+      );
+      addTearDown(restarted.dispose);
+      await restarted.boot();
+      expect(restarted.sourceType, AppSourceType.m3u);
+      expect(await restarted.favoritesService.all(), <int>{101});
+      expect(
+        localMemory.keys.where((key) => key.contains('m3ue_favorites')),
+        everyElement(
+          allOf(
+            isNot(contains('playlist-secret')),
+            isNot(contains(_fixturePlaylist)),
+          ),
+        ),
+      );
+    });
+
+    test('logout hides favorites without deleting their namespace', () async {
+      final controller = _controller(
+        storage: InMemorySecureStorage(),
+        transport: _FakeXtreamTransport.success().call,
+      );
+      addTearDown(controller.dispose);
+      const credentials = UserCredentials(
+        server: 'https://fixture.example',
+        username: 'fixture-user',
+        password: 'fixture-password',
+      );
+      expect(await controller.connectXtream(credentials), isTrue);
+      await controller.favoritesService.add(101);
+      await controller.vodFavoritesService.add(201);
+      await controller.seriesFavoritesService.add(301);
+
+      await controller.disconnect();
+      expect(await controller.favoritesService.all(), isEmpty);
+      expect(await controller.vodFavoritesService.all(), isEmpty);
+      expect(await controller.seriesFavoritesService.all(), isEmpty);
+
+      expect(await controller.connectXtream(credentials), isTrue);
+      expect(await controller.favoritesService.all(), <int>{101});
+      expect(await controller.vodFavoritesService.all(), <int>{201});
+      expect(await controller.seriesFavoritesService.all(), <int>{301});
+    });
+
+    test('boot restores the saved Xtream favorite namespace', () async {
+      final storage = InMemorySecureStorage();
+      final localMemory = <String, Object?>{};
+      const credentials = UserCredentials(
+        server: 'https://fixture.example',
+        username: 'fixture-user',
+        password: 'fixture-password',
+      );
+      final first = _controller(
+        storage: storage,
+        localMemory: localMemory,
+        transport: _FakeXtreamTransport.success().call,
+      );
+      addTearDown(first.dispose);
+      expect(await first.connectXtream(credentials), isTrue);
+      await first.favoritesService.add(101);
+      await first.vodFavoritesService.add(201);
+      await first.seriesFavoritesService.add(301);
+
+      final restarted = _controller(
+        storage: storage,
+        localMemory: localMemory,
+        transport: _FakeXtreamTransport.success().call,
+      );
+      addTearDown(restarted.dispose);
+      await restarted.boot();
+
+      expect(await restarted.favoritesService.all(), <int>{101});
+      expect(await restarted.vodFavoritesService.all(), <int>{201});
+      expect(await restarted.seriesFavoritesService.all(), <int>{301});
+    });
+
+    test(
+      'legacy favorites migrate once without deleting legacy values',
+      () async {
+        final localMemory = <String, Object?>{
+          'm3ue_favorites': <int>[101],
+          'm3ue_favorites_vod': <int>[201],
+          'm3ue_favorites_series': <int>[301],
+        };
+        final controller = _controller(
+          storage: InMemorySecureStorage(),
+          localMemory: localMemory,
+          transport: _FakeXtreamTransport.success().call,
+        );
+        addTearDown(controller.dispose);
+        const originalCredentials = UserCredentials(
+          server: 'https://fixture.example',
+          username: 'fixture-user',
+          password: 'fixture-password',
+        );
+
+        expect(await controller.connectXtream(originalCredentials), isTrue);
+        expect(await controller.favoritesService.all(), <int>{101});
+        expect(await controller.vodFavoritesService.all(), <int>{201});
+        expect(await controller.seriesFavoritesService.all(), <int>{301});
+        expect(localMemory['m3ue_favorites'], <int>[101]);
+        expect(localMemory['m3ue_favorites_vod'], <int>[201]);
+        expect(localMemory['m3ue_favorites_series'], <int>[301]);
+
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'https://unrelated.example',
+              username: 'unrelated-user',
+              password: 'unrelated-password',
+            ),
+          ),
+          isTrue,
+        );
+        expect(await controller.favoritesService.all(), isEmpty);
+        expect(await controller.vodFavoritesService.all(), isEmpty);
+        expect(await controller.seriesFavoritesService.all(), isEmpty);
+
+        expect(await controller.connectXtream(originalCredentials), isTrue);
+        expect(await controller.favoritesService.all(), <int>{101});
+        expect(await controller.vodFavoritesService.all(), <int>{201});
+        expect(await controller.seriesFavoritesService.all(), <int>{301});
+      },
+    );
   });
 }
+
+const _fixturePlaylist = '''
+#EXTM3U
+#EXTINF:-1 group-title="News",Fixture News
+https://playlist-secret.example/live/news.m3u8''';
+
+const _otherFixturePlaylist = '''
+#EXTM3U
+#EXTINF:-1 group-title="Sports",Fixture Sports
+https://other.example/live/sports.m3u8''';
 
 AppStateController _controller({
   required InMemorySecureStorage storage,
@@ -566,6 +862,14 @@ AppStateController _controller({
     secureStorage: storage,
     cacheService: CacheService(memory: cacheMemory ?? <String, Object?>{}),
     favoritesService: FavoritesService(memory: sharedLocalMemory),
+    vodFavoritesService: FavoritesService(
+      memory: sharedLocalMemory,
+      namespace: 'vod',
+    ),
+    seriesFavoritesService: FavoritesService(
+      memory: sharedLocalMemory,
+      namespace: 'series',
+    ),
     resumeService: ResumeService(memory: sharedLocalMemory),
     viewerService: ViewerService(memory: sharedLocalMemory),
   );

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -1735,6 +1735,11 @@ AppStateController _testAppState({required XtreamService xtreamService}) {
     secureStorage: InMemorySecureStorage(),
     cacheService: CacheService(memory: <String, Object?>{}),
     favoritesService: FavoritesService(memory: memory),
+    vodFavoritesService: FavoritesService(memory: memory, namespace: 'vod'),
+    seriesFavoritesService: FavoritesService(
+      memory: memory,
+      namespace: 'series',
+    ),
     resumeService: ResumeService(memory: memory),
     viewerService: ViewerService(memory: memory),
   );


### PR DESCRIPTION
Closes #136

## Behavior

- Scope Live, VOD, and Series favorites by media kind, active viewer, and a SHA-256 source identity.
- Normalize Xtream server values to their URI origin before hashing credentials, so default ports and trailing slashes do not create duplicate scopes.
- Hash direct M3U playlist content for a stable source identity without storing playlist contents or plaintext credentials in favorite keys.
- Select the matching scope on connect, source restore, source switch, and viewer switch. Logout clears only the active selection and preserves stored scopes.
- Keep the three FavoritesService instances stable for existing providers and widgets.

## Migration Contract

Each media kind copies its existing unscoped favorites into the first valid scoped namespace once. The migration marker is per media kind, the original legacy value is retained as no-loss evidence, and later unrelated namespaces do not adopt it. Existing scoped values are merged during adoption, making migration safe and idempotent.

## Verification

- RED: focused namespace command ran 6 tests against the original implementation; 1 passed and 5 failed on server, viewer, playlist, logout, and migration isolation.
- GREEN: the same focused command passes all 6 tests.
- `flutter pub get`: passed.
- `./android/gradlew -p android :app:testDebugUnitTest`: passed, 197 actionable tasks.
- `dart format --output=none --set-exit-if-changed lib test`: passed, 129 files and 0 changes.
- `flutter analyze lib test`: passed with no issues.
- `flutter test --concurrency=1`: passed, 397 tests with 5 existing skips.
- `git diff --check`, `git diff --cached --check`, and the added-text U+2013/U+2014 scan: passed.
- `flutter build linux --release`: attempted but unavailable in this environment because Ninja and a C++ compiler are not installed.

## Risks

- Legacy favorites are assigned to the first valid source and viewer opened after upgrade because the old keys contain no source metadata. The legacy keys remain intact.
- Direct M3U identity is content based, so editing a saved playlist creates a new namespace even when its display name is unchanged.