### PR TITLE
fix: expose desktop libmpv track selectors

### DIFF
--- a/flutter_client/ios/Runner/AvKitPlaybackPlugin.swift
+++ b/flutter_client/ios/Runner/AvKitPlaybackPlugin.swift
@@ -293,8 +293,8 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         if let ar = videoAspectRatio { event["videoAspectRatio"] = ar }
         if let a  = audioTracks { event["audioTracks"] = a        }
         if let st = subtitleTracks { event["subtitleTracks"] = st }
-        if includeSelectedAudioTrackId { event["selectedAudioTrackId"] = selectedAudioTrackId }
-        if includeSelectedSubtitleTrackId { event["selectedSubtitleTrackId"] = selectedSubtitleTrackId }
+        if includeSelectedAudioTrackId { event["selectedAudioTrackId"] = selectedAudioTrackId ?? NSNull() }
+        if includeSelectedSubtitleTrackId { event["selectedSubtitleTrackId"] = selectedSubtitleTrackId ?? NSNull() }
         if let c  = code        { event["code"]        = c        }
         if let m  = message     { event["message"]     = m        }
         if recoverable          { event["recoverable"] = true      }

--- a/flutter_client/lib/features/player/playback_controls.dart
+++ b/flutter_client/lib/features/player/playback_controls.dart
@@ -28,6 +28,8 @@ class PlaybackControls extends StatelessWidget {
     this.subtitleTracks = const <PlaybackTrack>[],
     this.selectedAudioTrackId,
     this.selectedSubtitleTrackId,
+    this.isAudioTrackSelectionKnown = false,
+    this.isSubtitleTrackSelectionKnown = false,
     this.onAudioTrackSelected,
     this.onSubtitleTrackSelected,
     this.fallbackReason,
@@ -49,6 +51,8 @@ class PlaybackControls extends StatelessWidget {
   final List<PlaybackTrack> subtitleTracks;
   final String? selectedAudioTrackId;
   final String? selectedSubtitleTrackId;
+  final bool isAudioTrackSelectionKnown;
+  final bool isSubtitleTrackSelectionKnown;
   final ValueChanged<String?>? onAudioTrackSelected;
   final ValueChanged<String?>? onSubtitleTrackSelected;
   final String? fallbackReason;
@@ -155,6 +159,8 @@ class PlaybackControls extends StatelessWidget {
       subtitleTracks: subtitleTracks,
       selectedAudioTrackId: selectedAudioTrackId,
       selectedSubtitleTrackId: selectedSubtitleTrackId,
+      isAudioTrackSelectionKnown: isAudioTrackSelectionKnown,
+      isSubtitleTrackSelectionKnown: isSubtitleTrackSelectionKnown,
       onAudioTrackSelected: onAudioTrackSelected ?? (_) {},
       onSubtitleTrackSelected: onSubtitleTrackSelected ?? (_) {},
     );

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -73,6 +73,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
   List<PlaybackTrack> _subtitleTracks = [];
   String? _selectedAudioTrackId;
   String? _selectedSubtitleTrackId;
+  bool _isAudioTrackSelectionKnown = false;
+  bool _isSubtitleTrackSelectionKnown = false;
 
   EpgCurrentNext? _epgData;
 
@@ -113,7 +115,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     // widget already holds focus when the player opens via the AppShell Stack).
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        // Overlay is visible on open — focus the play/pause button directly
+        // Overlay is visible on open - focus the play/pause button directly
         // so D-pad traversal works immediately. Falls back to _screenFocusNode
         // if somehow the overlay was already hidden.
         if (_overlayVisible) {
@@ -276,6 +278,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
       _subtitleTracks = state.subtitleTracks;
       _selectedAudioTrackId = state.selectedAudioTrackId;
       _selectedSubtitleTrackId = state.selectedSubtitleTrackId;
+      _isAudioTrackSelectionKnown = state.isAudioTrackSelectionKnown;
+      _isSubtitleTrackSelectionKnown = state.isSubtitleTrackSelectionKnown;
 
       final aspectRatio =
           state.videoAspectRatio ?? state.source?.videoAspectRatio;
@@ -508,7 +512,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
           LogicalKeySet(LogicalKeyboardKey.goBack): const _BackIntent(),
           LogicalKeySet(LogicalKeyboardKey.mediaPlayPause):
               const _PlayPauseIntent(),
-          // Only claim arrow keys when the overlay is hidden — when visible,
+          // Only claim arrow keys when the overlay is hidden - when visible,
           // let dpad's root Shortcuts handle them for spatial navigation.
           if (!_overlayVisible) ...{
             LogicalKeySet(LogicalKeyboardKey.arrowLeft):
@@ -535,7 +539,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
               if (event is KeyDownEvent &&
                   !_overlayVisible &&
                   _errorMessage == null) {
-                // Don't intercept back/escape — let the Shortcuts above handle
+                // Don't intercept back/escape - let the Shortcuts above handle
                 // it as a direct back action. Intercepting it here would set
                 // _overlayVisible = true, causing _handleBack() to call
                 // _hideOverlay() instead of _goBack(), making back a no-op.
@@ -646,6 +650,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
                     subtitleTracks: _subtitleTracks,
                     selectedAudioTrackId: _selectedAudioTrackId,
                     selectedSubtitleTrackId: _selectedSubtitleTrackId,
+                    isAudioTrackSelectionKnown: _isAudioTrackSelectionKnown,
+                    isSubtitleTrackSelectionKnown:
+                        _isSubtitleTrackSelectionKnown,
                     onAudioTrackSelected: _handleAudioTrackSelected,
                     onSubtitleTrackSelected: _handleSubtitleTrackSelected,
                     fallbackReason: _showPlaybackDiagnostics

--- a/flutter_client/lib/features/player/track_selector.dart
+++ b/flutter_client/lib/features/player/track_selector.dart
@@ -18,6 +18,8 @@ class TrackSelector extends StatelessWidget {
     required this.selectedSubtitleTrackId,
     required this.onAudioTrackSelected,
     required this.onSubtitleTrackSelected,
+    this.isAudioTrackSelectionKnown = false,
+    this.isSubtitleTrackSelectionKnown = false,
     super.key,
   });
 
@@ -35,6 +37,10 @@ class TrackSelector extends StatelessWidget {
 
   /// Currently selected subtitle track ID, or null for off.
   final String? selectedSubtitleTrackId;
+
+  final bool isAudioTrackSelectionKnown;
+
+  final bool isSubtitleTrackSelectionKnown;
 
   /// Called when the user selects an audio track.
   final ValueChanged<String?> onAudioTrackSelected;
@@ -65,8 +71,9 @@ class TrackSelector extends StatelessWidget {
     );
   }
 
-  String? get _effectiveAudioTrackId =>
-      selectedAudioTrackId ?? audioTracks.firstOrNull?.id;
+  String? get _effectiveAudioTrackId => isAudioTrackSelectionKnown
+      ? selectedAudioTrackId
+      : selectedAudioTrackId ?? audioTracks.firstOrNull?.id;
 
   void _showAudioDialog(BuildContext context) {
     unawaited(
@@ -114,7 +121,9 @@ class TrackSelector extends StatelessWidget {
               children: [
                 ListTile(
                   title: const Text('Off'),
-                  selected: selectedSubtitleTrackId == null,
+                  selected:
+                      isSubtitleTrackSelectionKnown &&
+                      selectedSubtitleTrackId == null,
                   onTap: () {
                     onSubtitleTrackSelected(null);
                     Navigator.of(context).pop();

--- a/flutter_client/lib/playback/android_playback_adapter.dart
+++ b/flutter_client/lib/playback/android_playback_adapter.dart
@@ -199,7 +199,12 @@ class AndroidPlaybackAdapter implements PlayerAdapter, VideoTextureProvider {
     if (_activeBackend == PlaybackBackend.androidExoPlayer) {
       await _media3Host.setAudioTrack(trackId);
     }
-    _emit(_state.copyWith(selectedAudioTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedAudioTrackId: trackId,
+        isAudioTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override
@@ -207,7 +212,12 @@ class AndroidPlaybackAdapter implements PlayerAdapter, VideoTextureProvider {
     if (_activeBackend == PlaybackBackend.androidExoPlayer) {
       await _media3Host.setSubtitleTrack(trackId);
     }
-    _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedSubtitleTrackId: trackId,
+        isSubtitleTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override
@@ -330,11 +340,13 @@ class AndroidPlaybackAdapter implements PlayerAdapter, VideoTextureProvider {
     if (event.hasSelectedAudioTrackId) {
       nextState = nextState.copyWith(
         selectedAudioTrackId: event.selectedAudioTrackId,
+        isAudioTrackSelectionKnown: true,
       );
     }
     if (event.hasSelectedSubtitleTrackId) {
       nextState = nextState.copyWith(
         selectedSubtitleTrackId: event.selectedSubtitleTrackId,
+        isSubtitleTrackSelectionKnown: true,
       );
     }
     _emit(nextState);

--- a/flutter_client/lib/playback/apple_avkit_backend.dart
+++ b/flutter_client/lib/playback/apple_avkit_backend.dart
@@ -88,13 +88,23 @@ class AppleAvKitBackend implements PlayerAdapter, VideoTextureProvider {
   @override
   Future<void> setAudioTrack(String? trackId) async {
     await _host.setAudioTrack(trackId);
-    _emit(_state.copyWith(selectedAudioTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedAudioTrackId: trackId,
+        isAudioTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override
   Future<void> setSubtitleTrack(String? trackId) async {
     await _host.setSubtitleTrack(trackId);
-    _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedSubtitleTrackId: trackId,
+        isSubtitleTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override
@@ -142,11 +152,13 @@ class AppleAvKitBackend implements PlayerAdapter, VideoTextureProvider {
     if (event.hasSelectedAudioTrackId) {
       nextState = nextState.copyWith(
         selectedAudioTrackId: event.selectedAudioTrackId,
+        isAudioTrackSelectionKnown: true,
       );
     }
     if (event.hasSelectedSubtitleTrackId) {
       nextState = nextState.copyWith(
         selectedSubtitleTrackId: event.selectedSubtitleTrackId,
+        isSubtitleTrackSelectionKnown: true,
       );
     }
     _emit(nextState);
@@ -158,7 +170,7 @@ class AppleAvKitBackend implements PlayerAdapter, VideoTextureProvider {
   }
 }
 
-// --- Host abstraction (private — uses private event types) ---
+// --- Host abstraction (private - uses private event types) ---
 
 abstract class _AvKitHost {
   Stream<_AvKitEvent> get events;

--- a/flutter_client/lib/playback/desktop_libmpv_backend.dart
+++ b/flutter_client/lib/playback/desktop_libmpv_backend.dart
@@ -670,6 +670,8 @@ class DesktopLibmpvEventReducer {
           subtitleTracks: event.subtitleTracks ?? const <PlaybackTrack>[],
           selectedAudioTrackId: event.hasAid ? event.aid : null,
           selectedSubtitleTrackId: event.hasSid ? event.sid : null,
+          isAudioTrackSelectionKnown: event.hasAid,
+          isSubtitleTrackSelectionKnown: event.hasSid,
         );
       case DesktopLibmpvEventKind.playbackRestart:
         final status = event.paused
@@ -692,6 +694,10 @@ class DesktopLibmpvEventReducer {
           selectedSubtitleTrackId: event.hasSid
               ? event.sid
               : current.selectedSubtitleTrackId,
+          isAudioTrackSelectionKnown:
+              event.hasAid || current.isAudioTrackSelectionKnown,
+          isSubtitleTrackSelectionKnown:
+              event.hasSid || current.isSubtitleTrackSelectionKnown,
         );
       case DesktopLibmpvEventKind.videoReconfig:
         return current.copyWith(

--- a/flutter_client/lib/playback/desktop_libmpv_backend.dart
+++ b/flutter_client/lib/playback/desktop_libmpv_backend.dart
@@ -515,14 +515,19 @@ class DesktopLibmpvEvent {
     this.speed,
     this.aid,
     this.sid,
+    this.hasAid = false,
+    this.hasSid = false,
+    this.audioTracks,
+    this.subtitleTracks,
     this.message,
     this.code,
     this.recoverable = false,
   });
 
   factory DesktopLibmpvEvent.fromMap(Map<String, Object?> map) {
+    final schemaVersion = (map['schemaVersion'] as num?)?.toInt() ?? 0;
     return DesktopLibmpvEvent(
-      schemaVersion: (map['schemaVersion'] as num?)?.toInt() ?? 0,
+      schemaVersion: schemaVersion,
       handle: (map['handle'] as num?)?.toInt() ?? 0,
       sequence: (map['sequence'] as num?)?.toInt() ?? 0,
       kind: _kindFromString(map['kind'] as String?),
@@ -542,8 +547,16 @@ class DesktopLibmpvEvent {
         height: map['videoHeight'] ?? map['height'],
       ),
       speed: _asPositiveDouble(map['speed']),
-      aid: _nonEmptyString(map['aid']),
-      sid: _nonEmptyString(map['sid']),
+      aid: _selectedTrackId(map['aid']),
+      sid: _selectedTrackId(map['sid']),
+      hasAid: map.containsKey('aid'),
+      hasSid: map.containsKey('sid'),
+      audioTracks: schemaVersion >= 2
+          ? _tracksFromValue(map['audioTracks'])
+          : null,
+      subtitleTracks: schemaVersion >= 2
+          ? _tracksFromValue(map['subtitleTracks'])
+          : null,
       message: map['message'] as String?,
       code: map['code'] as String?,
       recoverable: map['recoverable'] == true,
@@ -563,6 +576,10 @@ class DesktopLibmpvEvent {
   final double? speed;
   final String? aid;
   final String? sid;
+  final bool hasAid;
+  final bool hasSid;
+  final List<PlaybackTrack>? audioTracks;
+  final List<PlaybackTrack>? subtitleTracks;
   final String? message;
   final String? code;
   final bool recoverable;
@@ -597,7 +614,28 @@ class DesktopLibmpvEvent {
   }
 
   static String? _nonEmptyString(Object? value) {
-    return value is String && value.isNotEmpty ? value : null;
+    if (value is! String) return null;
+    final normalized = value.trim();
+    return normalized.isEmpty ? null : normalized;
+  }
+
+  static String? _selectedTrackId(Object? value) {
+    final id = _nonEmptyString(value);
+    return id == null || id.toLowerCase() == 'no' ? null : id;
+  }
+
+  static List<PlaybackTrack>? _tracksFromValue(Object? value) {
+    if (value is! List<Object?>) return null;
+    final tracks = <PlaybackTrack>[];
+    for (final item in value) {
+      if (item is! Map<Object?, Object?>) continue;
+      final id = _nonEmptyString(item['id']);
+      if (id == null) continue;
+      final language = _nonEmptyString(item['language']);
+      final label = _nonEmptyString(item['label']) ?? language ?? id;
+      tracks.add(PlaybackTrack(id: id, label: label, language: language));
+    }
+    return tracks;
   }
 }
 
@@ -628,8 +666,10 @@ class DesktopLibmpvEventReducer {
           duration: event.duration,
           videoAspectRatio: event.videoAspectRatio,
           playbackSpeed: event.speed,
-          selectedAudioTrackId: event.aid,
-          selectedSubtitleTrackId: event.sid,
+          audioTracks: event.audioTracks ?? const <PlaybackTrack>[],
+          subtitleTracks: event.subtitleTracks ?? const <PlaybackTrack>[],
+          selectedAudioTrackId: event.hasAid ? event.aid : null,
+          selectedSubtitleTrackId: event.hasSid ? event.sid : null,
         );
       case DesktopLibmpvEventKind.playbackRestart:
         final status = event.paused
@@ -644,8 +684,14 @@ class DesktopLibmpvEventReducer {
           duration: event.duration ?? current.duration,
           videoAspectRatio: event.videoAspectRatio ?? current.videoAspectRatio,
           playbackSpeed: event.speed ?? current.playbackSpeed,
-          selectedAudioTrackId: event.aid ?? current.selectedAudioTrackId,
-          selectedSubtitleTrackId: event.sid ?? current.selectedSubtitleTrackId,
+          audioTracks: event.audioTracks ?? current.audioTracks,
+          subtitleTracks: event.subtitleTracks ?? current.subtitleTracks,
+          selectedAudioTrackId: event.hasAid
+              ? event.aid
+              : current.selectedAudioTrackId,
+          selectedSubtitleTrackId: event.hasSid
+              ? event.sid
+              : current.selectedSubtitleTrackId,
         );
       case DesktopLibmpvEventKind.videoReconfig:
         return current.copyWith(

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -97,6 +97,7 @@ class MediaKitDesktopAdapter
                 _player.state.track.audio,
                 tracks.audio,
               ),
+              isAudioTrackSelectionKnown: true,
             ),
           );
         }),
@@ -110,6 +111,8 @@ class MediaKitDesktopAdapter
                 _player.state.tracks.audio,
               ),
               selectedSubtitleTrackId: _selectedTrackId(track.subtitle.id),
+              isAudioTrackSelectionKnown: true,
+              isSubtitleTrackSelectionKnown: true,
             ),
           );
         }),
@@ -166,7 +169,12 @@ class MediaKitDesktopAdapter
             orElse: () => mk.AudioTrack(trackId, null, null),
           );
     await _player.setAudioTrack(track);
-    _emit(_state.copyWith(selectedAudioTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedAudioTrackId: trackId,
+        isAudioTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override
@@ -178,7 +186,12 @@ class MediaKitDesktopAdapter
             orElse: () => mk.SubtitleTrack(trackId, null, null),
           );
     await _player.setSubtitleTrack(track);
-    _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedSubtitleTrackId: trackId,
+        isSubtitleTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override

--- a/flutter_client/lib/playback/media_kit_desktop_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_desktop_adapter.dart
@@ -104,15 +104,19 @@ class MediaKitDesktopAdapter
       )
       ..add(
         _player.stream.track.listen((track) {
+          final subtitleSelection = selectedMediaKitSubtitleTrack(
+            track.subtitle,
+            _player.state.tracks.subtitle,
+          );
           _emit(
             _state.copyWith(
               selectedAudioTrackId: selectedMediaKitAudioTrackId(
                 track.audio,
                 _player.state.tracks.audio,
               ),
-              selectedSubtitleTrackId: _selectedTrackId(track.subtitle.id),
+              selectedSubtitleTrackId: subtitleSelection.selectedTrackId,
               isAudioTrackSelectionKnown: true,
-              isSubtitleTrackSelectionKnown: true,
+              isSubtitleTrackSelectionKnown: subtitleSelection.isKnown,
             ),
           );
         }),
@@ -293,6 +297,25 @@ String? selectedMediaKitAudioTrackId(
       ?.id;
 }
 
-String? _selectedTrackId(String id) => id == 'no' || id == 'auto' ? null : id;
+({String? selectedTrackId, bool isKnown}) selectedMediaKitSubtitleTrack(
+  mk.SubtitleTrack selectedTrack,
+  List<mk.SubtitleTrack> availableTracks,
+) {
+  if (selectedTrack.id == 'no') {
+    return (selectedTrackId: null, isKnown: true);
+  }
+  if (selectedTrack.id != 'auto') {
+    return (selectedTrackId: selectedTrack.id, isKnown: true);
+  }
+
+  final selectedTrackId = availableTracks
+      .where((track) => !_isMediaKitSentinelTrack(track.id))
+      .firstOrNull
+      ?.id;
+  return (
+    selectedTrackId: selectedTrackId,
+    isKnown: selectedTrackId != null,
+  );
+}
 
 bool _isMediaKitSentinelTrack(String id) => id == 'auto' || id == 'no';

--- a/flutter_client/lib/playback/media_kit_ios_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_ios_adapter.dart
@@ -97,6 +97,7 @@ class MediaKitIosAdapter
                 _player.state.track.audio,
                 tracks.audio,
               ),
+              isAudioTrackSelectionKnown: true,
             ),
           );
         }),
@@ -113,6 +114,8 @@ class MediaKitIosAdapter
                   track.subtitle.id == 'no' || track.subtitle.id == 'auto'
                   ? null
                   : track.subtitle.id,
+              isAudioTrackSelectionKnown: true,
+              isSubtitleTrackSelectionKnown: true,
             ),
           );
         }),
@@ -174,7 +177,12 @@ class MediaKitIosAdapter
             orElse: () => mk.AudioTrack(trackId, null, null),
           );
     await _player.setAudioTrack(track);
-    _emit(_state.copyWith(selectedAudioTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedAudioTrackId: trackId,
+        isAudioTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override
@@ -186,7 +194,12 @@ class MediaKitIosAdapter
             orElse: () => mk.SubtitleTrack(trackId, null, null),
           );
     await _player.setSubtitleTrack(track);
-    _emit(_state.copyWith(selectedSubtitleTrackId: trackId));
+    _emit(
+      _state.copyWith(
+        selectedSubtitleTrackId: trackId,
+        isSubtitleTrackSelectionKnown: true,
+      ),
+    );
   }
 
   @override

--- a/flutter_client/lib/playback/media_kit_ios_adapter.dart
+++ b/flutter_client/lib/playback/media_kit_ios_adapter.dart
@@ -104,18 +104,19 @@ class MediaKitIosAdapter
       )
       ..add(
         _player.stream.track.listen((track) {
+          final subtitleSelection = selectedMediaKitSubtitleTrack(
+            track.subtitle,
+            _player.state.tracks.subtitle,
+          );
           _emit(
             _state.copyWith(
               selectedAudioTrackId: selectedMediaKitAudioTrackId(
                 track.audio,
                 _player.state.tracks.audio,
               ),
-              selectedSubtitleTrackId:
-                  track.subtitle.id == 'no' || track.subtitle.id == 'auto'
-                  ? null
-                  : track.subtitle.id,
+              selectedSubtitleTrackId: subtitleSelection.selectedTrackId,
               isAudioTrackSelectionKnown: true,
-              isSubtitleTrackSelectionKnown: true,
+              isSubtitleTrackSelectionKnown: subtitleSelection.isKnown,
             ),
           );
         }),

--- a/flutter_client/lib/playback/player_adapter.dart
+++ b/flutter_client/lib/playback/player_adapter.dart
@@ -201,6 +201,8 @@ class PlaybackState {
     this.subtitleTracks = const <PlaybackTrack>[],
     this.selectedAudioTrackId,
     this.selectedSubtitleTrackId,
+    this.isAudioTrackSelectionKnown = false,
+    this.isSubtitleTrackSelectionKnown = false,
     this.playbackSpeed = 1,
     this.videoAspectRatio,
   });
@@ -214,6 +216,8 @@ class PlaybackState {
       subtitleTracks = const <PlaybackTrack>[],
       selectedAudioTrackId = null,
       selectedSubtitleTrackId = null,
+      isAudioTrackSelectionKnown = false,
+      isSubtitleTrackSelectionKnown = false,
       playbackSpeed = 1,
       videoAspectRatio = null;
 
@@ -226,6 +230,8 @@ class PlaybackState {
   final List<PlaybackTrack> subtitleTracks;
   final String? selectedAudioTrackId;
   final String? selectedSubtitleTrackId;
+  final bool isAudioTrackSelectionKnown;
+  final bool isSubtitleTrackSelectionKnown;
   final double playbackSpeed;
   final double? videoAspectRatio;
 
@@ -239,6 +245,8 @@ class PlaybackState {
     List<PlaybackTrack>? subtitleTracks,
     Object? selectedAudioTrackId = _unchanged,
     Object? selectedSubtitleTrackId = _unchanged,
+    bool? isAudioTrackSelectionKnown,
+    bool? isSubtitleTrackSelectionKnown,
     double? playbackSpeed,
     double? videoAspectRatio,
   }) {
@@ -256,6 +264,10 @@ class PlaybackState {
       selectedSubtitleTrackId: identical(selectedSubtitleTrackId, _unchanged)
           ? this.selectedSubtitleTrackId
           : selectedSubtitleTrackId as String?,
+      isAudioTrackSelectionKnown:
+          isAudioTrackSelectionKnown ?? this.isAudioTrackSelectionKnown,
+      isSubtitleTrackSelectionKnown:
+          isSubtitleTrackSelectionKnown ?? this.isSubtitleTrackSelectionKnown,
       playbackSpeed: playbackSpeed ?? this.playbackSpeed,
       videoAspectRatio: videoAspectRatio ?? this.videoAspectRatio,
     );

--- a/flutter_client/linux/desktop_libmpv_backend.cc
+++ b/flutter_client/linux/desktop_libmpv_backend.cc
@@ -279,6 +279,8 @@ struct EventSnapshot {
   double speed = 0.0;
   std::string aid;
   std::string sid;
+  bool has_aid = false;
+  bool has_sid = false;
   struct Track {
     std::string id;
     std::string label;
@@ -700,18 +702,19 @@ bool FlagProperty(PlayerInstance* player, const char* name, bool* value) {
   return true;
 }
 
-std::string StringProperty(PlayerInstance* player, const char* name) {
+bool StringProperty(PlayerInstance* player, const char* name,
+                    std::string* value) {
   if (player == nullptr || player->api == nullptr ||
-      player->api->get_property == nullptr) {
-    return "";
+      player->api->get_property == nullptr || player->api->free == nullptr) {
+    return false;
   }
   char* current = nullptr;
   const int rc = player->api->get_property(
       player->handle, name, MPV_FORMAT_STRING, &current);
-  if (rc < 0 || current == nullptr || player->api->free == nullptr) return "";
-  std::string result(current);
+  if (rc < 0 || current == nullptr) return false;
+  *value = current;
   player->api->free(current);
-  return result;
+  return true;
 }
 
 FlValue* VideoAspectRatioResult(PlayerInstance* player) {
@@ -764,8 +767,12 @@ FlValue* BuildEventValue(const EventSnapshot& snapshot) {
   if (snapshot.speed > 0.0) {
     fl_value_set_string_take(event, "speed", fl_value_new_float(snapshot.speed));
   }
-  fl_value_set_string_take(event, "aid", fl_value_new_string(snapshot.aid.c_str()));
-  fl_value_set_string_take(event, "sid", fl_value_new_string(snapshot.sid.c_str()));
+  if (snapshot.has_aid) {
+    fl_value_set_string_take(event, "aid", fl_value_new_string(snapshot.aid.c_str()));
+  }
+  if (snapshot.has_sid) {
+    fl_value_set_string_take(event, "sid", fl_value_new_string(snapshot.sid.c_str()));
+  }
   if (snapshot.has_track_lists) {
     auto build_tracks = [](const std::vector<EventSnapshot::Track>& tracks) {
       FlValue* values = fl_value_new_list();
@@ -835,6 +842,8 @@ void PlayerInstance::ReadSnapshotProperties(EventSnapshot* snapshot) {
   snapshot->speed = 0.0;
   snapshot->aid.clear();
   snapshot->sid.clear();
+  snapshot->has_aid = false;
+  snapshot->has_sid = false;
 
   DoubleProperty(this, "time-pos", &snapshot->position);
   DoubleProperty(this, "duration", &snapshot->duration);
@@ -856,8 +865,8 @@ void PlayerInstance::ReadSnapshotProperties(EventSnapshot* snapshot) {
     }
   }
 
-  snapshot->aid = StringProperty(this, "aid");
-  snapshot->sid = StringProperty(this, "sid");
+  snapshot->has_aid = StringProperty(this, "aid", &snapshot->aid);
+  snapshot->has_sid = StringProperty(this, "sid", &snapshot->sid);
 }
 
 std::string NormalizeTrackString(std::string value) {

--- a/flutter_client/linux/desktop_libmpv_backend.cc
+++ b/flutter_client/linux/desktop_libmpv_backend.cc
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 #include <map>
@@ -33,12 +34,32 @@ constexpr uint32_t kTextureHeight = 720;
 constexpr int kBytesPerPixel = 4;
 
 using mpv_handle = struct mpv_handle;
+struct mpv_node;
+struct mpv_node_list;
+union mpv_node_union {
+  char* string;
+  int flag;
+  int64_t int64;
+  double double_;
+  mpv_node_list* list;
+  void* ba;
+};
+struct mpv_node {
+  mpv_node_union u;
+  int format;
+};
+struct mpv_node_list {
+  int num;
+  mpv_node* values;
+  char** keys;
+};
 using mpv_create_fn = mpv_handle* (*)();
 using mpv_initialize_fn = int (*)(mpv_handle*);
 using mpv_command_fn = int (*)(mpv_handle*, const char**);
 using mpv_set_option_string_fn = int (*)(mpv_handle*, const char*, const char*);
 using mpv_get_property_fn = int (*)(mpv_handle*, const char*, int, void*);
 using mpv_free_fn = void (*)(void*);
+using mpv_free_node_contents_fn = void (*)(mpv_node*);
 using mpv_terminate_destroy_fn = void (*)(mpv_handle*);
 using mpv_observe_property_fn = int (*)(mpv_handle*, uint64_t, const char*, int);
 using mpv_unobserve_property_fn = int (*)(mpv_handle*, uint64_t);
@@ -82,6 +103,10 @@ constexpr int MPV_END_FILE_REASON_REDIRECT = 5;
 constexpr int MPV_FORMAT_DOUBLE = 5;
 constexpr int MPV_FORMAT_FLAG = 3;
 constexpr int MPV_FORMAT_STRING = 1;
+constexpr int MPV_FORMAT_INT64 = 4;
+constexpr int MPV_FORMAT_NODE = 6;
+constexpr int MPV_FORMAT_NODE_ARRAY = 7;
+constexpr int MPV_FORMAT_NODE_MAP = 8;
 
 constexpr int MPV_RENDER_PARAM_INVALID = 0;
 constexpr int MPV_RENDER_PARAM_API_TYPE = 1;
@@ -100,6 +125,7 @@ struct LibmpvApi {
   mpv_set_option_string_fn set_option_string = nullptr;
   mpv_get_property_fn get_property = nullptr;
   mpv_free_fn free = nullptr;
+  mpv_free_node_contents_fn free_node_contents = nullptr;
   mpv_terminate_destroy_fn terminate_destroy = nullptr;
   mpv_observe_property_fn observe_property = nullptr;
   mpv_unobserve_property_fn unobserve_property = nullptr;
@@ -116,7 +142,8 @@ struct LibmpvApi {
   bool client_available() const {
     return library != nullptr && create != nullptr && initialize != nullptr &&
            command != nullptr && set_option_string != nullptr &&
-           get_property != nullptr && free != nullptr && terminate_destroy != nullptr &&
+           get_property != nullptr && free != nullptr &&
+           free_node_contents != nullptr && terminate_destroy != nullptr &&
            observe_property != nullptr && unobserve_property != nullptr &&
            wakeup != nullptr && wait_event != nullptr;
   }
@@ -252,6 +279,14 @@ struct EventSnapshot {
   double speed = 0.0;
   std::string aid;
   std::string sid;
+  struct Track {
+    std::string id;
+    std::string label;
+    std::string language;
+  };
+  std::vector<Track> audio_tracks;
+  std::vector<Track> subtitle_tracks;
+  bool has_track_lists = false;
   std::string message;
   std::string code;
   bool recoverable = false;
@@ -410,6 +445,7 @@ struct PlayerInstance {
   void StartEventThread();
   void QueueEvent(EventSnapshot snapshot);
   void ReadSnapshotProperties(EventSnapshot* snapshot);
+  void ReadTrackLists(EventSnapshot* snapshot);
 
   LibmpvApi* api = nullptr;
   FlTextureRegistrar* texture_registrar = nullptr;
@@ -461,6 +497,8 @@ LibmpvApi& Api() {
   g_api.set_option_string = reinterpret_cast<mpv_set_option_string_fn>(LoadSymbol(g_api.library, "mpv_set_option_string"));
   g_api.get_property = reinterpret_cast<mpv_get_property_fn>(LoadSymbol(g_api.library, "mpv_get_property"));
   g_api.free = reinterpret_cast<mpv_free_fn>(LoadSymbol(g_api.library, "mpv_free"));
+  g_api.free_node_contents = reinterpret_cast<mpv_free_node_contents_fn>(
+      LoadSymbol(g_api.library, "mpv_free_node_contents"));
   g_api.terminate_destroy = reinterpret_cast<mpv_terminate_destroy_fn>(LoadSymbol(g_api.library, "mpv_terminate_destroy"));
   g_api.observe_property = reinterpret_cast<mpv_observe_property_fn>(LoadSymbol(g_api.library, "mpv_observe_property"));
   g_api.unobserve_property = reinterpret_cast<mpv_unobserve_property_fn>(LoadSymbol(g_api.library, "mpv_unobserve_property"));
@@ -707,7 +745,7 @@ void RenderUpdate(void* data) {
 
 FlValue* BuildEventValue(const EventSnapshot& snapshot) {
   g_autoptr(FlValue) event = fl_value_new_map();
-  fl_value_set_string_take(event, "schemaVersion", fl_value_new_int(1));
+  fl_value_set_string_take(event, "schemaVersion", fl_value_new_int(2));
   fl_value_set_string_take(event, "handle", fl_value_new_int(snapshot.handle));
   fl_value_set_string_take(event, "sequence", fl_value_new_int(snapshot.sequence));
   fl_value_set_string_take(event, "kind", fl_value_new_string(snapshot.kind.c_str()));
@@ -726,11 +764,27 @@ FlValue* BuildEventValue(const EventSnapshot& snapshot) {
   if (snapshot.speed > 0.0) {
     fl_value_set_string_take(event, "speed", fl_value_new_float(snapshot.speed));
   }
-  if (!snapshot.aid.empty()) {
-    fl_value_set_string_take(event, "aid", fl_value_new_string(snapshot.aid.c_str()));
-  }
-  if (!snapshot.sid.empty()) {
-    fl_value_set_string_take(event, "sid", fl_value_new_string(snapshot.sid.c_str()));
+  fl_value_set_string_take(event, "aid", fl_value_new_string(snapshot.aid.c_str()));
+  fl_value_set_string_take(event, "sid", fl_value_new_string(snapshot.sid.c_str()));
+  if (snapshot.has_track_lists) {
+    auto build_tracks = [](const std::vector<EventSnapshot::Track>& tracks) {
+      FlValue* values = fl_value_new_list();
+      for (const EventSnapshot::Track& track : tracks) {
+        FlValue* value = fl_value_new_map();
+        fl_value_set_string_take(value, "id", fl_value_new_string(track.id.c_str()));
+        fl_value_set_string_take(value, "label", fl_value_new_string(track.label.c_str()));
+        if (!track.language.empty()) {
+          fl_value_set_string_take(value, "language",
+                                   fl_value_new_string(track.language.c_str()));
+        }
+        fl_value_append_take(values, value);
+      }
+      return values;
+    };
+    fl_value_set_string_take(event, "audioTracks",
+                             build_tracks(snapshot.audio_tracks));
+    fl_value_set_string_take(event, "subtitleTracks",
+                             build_tracks(snapshot.subtitle_tracks));
   }
   if (!snapshot.message.empty()) {
     fl_value_set_string_take(event, "message", fl_value_new_string(snapshot.message.c_str()));
@@ -806,6 +860,79 @@ void PlayerInstance::ReadSnapshotProperties(EventSnapshot* snapshot) {
   snapshot->sid = StringProperty(this, "sid");
 }
 
+std::string NormalizeTrackString(std::string value) {
+  const auto first = std::find_if_not(
+      value.begin(), value.end(),
+      [](unsigned char character) { return std::isspace(character) != 0; });
+  const auto last = std::find_if_not(
+      value.rbegin(), value.rend(),
+      [](unsigned char character) { return std::isspace(character) != 0; })
+                        .base();
+  return first < last ? std::string(first, last) : "";
+}
+
+const mpv_node* MapNodeValue(const mpv_node& node, const char* key) {
+  if (node.format != MPV_FORMAT_NODE_MAP || node.u.list == nullptr ||
+      node.u.list->keys == nullptr || node.u.list->values == nullptr) {
+    return nullptr;
+  }
+  for (int index = 0; index < node.u.list->num; ++index) {
+    if (node.u.list->keys[index] != nullptr &&
+        std::strcmp(node.u.list->keys[index], key) == 0) {
+      return &node.u.list->values[index];
+    }
+  }
+  return nullptr;
+}
+
+std::string TrackNodeString(const mpv_node* node) {
+  if (node == nullptr) return "";
+  if (node->format == MPV_FORMAT_STRING && node->u.string != nullptr) {
+    return NormalizeTrackString(node->u.string);
+  }
+  if (node->format == MPV_FORMAT_INT64) {
+    return std::to_string(node->u.int64);
+  }
+  return "";
+}
+
+void PlayerInstance::ReadTrackLists(EventSnapshot* snapshot) {
+  snapshot->audio_tracks.clear();
+  snapshot->subtitle_tracks.clear();
+  snapshot->has_track_lists = false;
+  if (api == nullptr || api->get_property == nullptr ||
+      api->free_node_contents == nullptr) {
+    return;
+  }
+
+  mpv_node node{};
+  if (api->get_property(handle, "track-list", MPV_FORMAT_NODE, &node) < 0) {
+    return;
+  }
+  snapshot->has_track_lists = true;
+  if (node.format == MPV_FORMAT_NODE_ARRAY && node.u.list != nullptr &&
+      node.u.list->values != nullptr) {
+    for (int index = 0; index < node.u.list->num; ++index) {
+      const mpv_node& item = node.u.list->values[index];
+      const std::string type = TrackNodeString(MapNodeValue(item, "type"));
+      const std::string id = TrackNodeString(MapNodeValue(item, "id"));
+      if (id.empty() || (type != "audio" && type != "sub")) continue;
+      const std::string language =
+          TrackNodeString(MapNodeValue(item, "lang"));
+      const std::string label = TrackNodeString(MapNodeValue(item, "title"));
+      const std::string normalized_label = label.empty() ? language : label;
+      EventSnapshot::Track track{
+          id, normalized_label.empty() ? id : normalized_label, language};
+      if (type == "audio") {
+        snapshot->audio_tracks.push_back(std::move(track));
+      } else if (type == "sub") {
+        snapshot->subtitle_tracks.push_back(std::move(track));
+      }
+    }
+  }
+  api->free_node_contents(&node);
+}
+
 void PlayerInstance::StartEventThread() {
   event_thread = std::thread([this]() {
     if (api == nullptr || api->observe_property == nullptr) return;
@@ -866,6 +993,7 @@ void PlayerInstance::StartEventThread() {
           snapshot.sequence = sequence.fetch_add(1);
           snapshot.kind = "FILE_LOADED";
           ReadSnapshotProperties(&snapshot);
+          ReadTrackLists(&snapshot);
           QueueEvent(snapshot);
           break;
         case 21:  // MPV_EVENT_PLAYBACK_RESTART
@@ -1072,10 +1200,24 @@ FlMethodResponse* Control(const gchar* method, FlValue* args) {
     const std::string track = StringArg(args, "trackId");
     const char* command[] = {"set", "aid", track.empty() ? "no" : track.c_str(), nullptr};
     player->api->command(player->handle, command);
+    EventSnapshot snapshot;
+    snapshot.handle = player->id;
+    snapshot.sequence = player->sequence.fetch_add(1);
+    snapshot.kind = "PLAYBACK_RESTART";
+    player->ReadSnapshotProperties(&snapshot);
+    player->ReadTrackLists(&snapshot);
+    player->QueueEvent(snapshot);
   } else if (g_strcmp0(method, "setSubtitleTrack") == 0) {
     const std::string track = StringArg(args, "trackId");
     const char* command[] = {"set", "sid", track.empty() ? "no" : track.c_str(), nullptr};
     player->api->command(player->handle, command);
+    EventSnapshot snapshot;
+    snapshot.handle = player->id;
+    snapshot.sequence = player->sequence.fetch_add(1);
+    snapshot.kind = "PLAYBACK_RESTART";
+    player->ReadSnapshotProperties(&snapshot);
+    player->ReadTrackLists(&snapshot);
+    player->QueueEvent(snapshot);
   } else if (g_strcmp0(method, "setPlaybackSpeed") == 0) {
     FlValue* value = args == nullptr ? nullptr : fl_value_lookup_string(args, "speed");
     const double speed = value != nullptr && fl_value_get_type(value) == FL_VALUE_TYPE_FLOAT

--- a/flutter_client/test/playback/android_backend_fallback_test.dart
+++ b/flutter_client/test/playback/android_backend_fallback_test.dart
@@ -307,6 +307,7 @@ void main() {
         ]);
         expect(states.last.subtitleTracks.single.label, 'English CC');
         expect(states.last.selectedAudioTrackId, 'audio:0:0');
+        expect(states.last.isAudioTrackSelectionKnown, isTrue);
 
         await adapter.setAudioTrack('audio:0:1');
         await adapter.setSubtitleTrack('subtitle:1:0');
@@ -323,6 +324,7 @@ void main() {
         );
         expect(states.last.selectedAudioTrackId, 'audio:0:1');
         expect(states.last.selectedSubtitleTrackId, isNull);
+        expect(states.last.isSubtitleTrackSelectionKnown, isTrue);
 
         await subscription.cancel();
         await adapter.dispose();

--- a/flutter_client/test/playback/avkit_playback_plugin_source_test.dart
+++ b/flutter_client/test/playback/avkit_playback_plugin_source_test.dart
@@ -1,0 +1,30 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AVKit emits explicit nulls only for included track selections', () {
+    final source = File(
+      'ios/Runner/AvKitPlaybackPlugin.swift',
+    ).readAsStringSync();
+
+    expect(
+      source,
+      contains(
+        'if includeSelectedAudioTrackId { event["selectedAudioTrackId"] = selectedAudioTrackId ?? NSNull() }',
+      ),
+    );
+    expect(
+      source,
+      contains(
+        'if includeSelectedSubtitleTrackId { event["selectedSubtitleTrackId"] = selectedSubtitleTrackId ?? NSNull() }',
+      ),
+    );
+    expect(source, contains('includeSelectedAudioTrackId: Bool = false'));
+    expect(source, contains('includeSelectedSubtitleTrackId: Bool = false'));
+    expect(source, contains('if let a  = audioTracks'));
+    expect(source, contains('event["audioTracks"] = a'));
+    expect(source, contains('if let st = subtitleTracks'));
+    expect(source, contains('event["subtitleTracks"] = st'));
+  });
+}

--- a/flutter_client/test/playback/avkit_playback_plugin_source_test.dart
+++ b/flutter_client/test/playback/avkit_playback_plugin_source_test.dart
@@ -27,4 +27,69 @@ void main() {
     expect(source, contains('if let st = subtitleTracks'));
     expect(source, contains('event["subtitleTracks"] = st'));
   });
+
+  test('tvOS AVKit supports track discovery and selection', () {
+    final source = File(
+      'tvos/Runner/AvKitPlaybackPlugin.swift',
+    ).readAsStringSync();
+
+    expect(source, contains('case "setAudioTrack":'));
+    expect(source, contains('case "setSubtitleTrack":'));
+    expect(
+      source,
+      contains(
+        'selectTrack(characteristic: .audible, trackId: args?["trackId"] as? String)',
+      ),
+    );
+    expect(
+      source,
+      contains(
+        'selectTrack(characteristic: .legible, trackId: args?["trackId"] as? String)',
+      ),
+    );
+    expect(source, contains('group.options.enumerated().map'));
+    expect(source, contains(r'"id": "\(prefix):\(index)"'));
+    expect(source, contains('item.select(group.options[index], in: group)'));
+    expect(source, contains('item.select(nil, in: group)'));
+    expect(
+      source,
+      contains('audioTracks: playbackTracks(characteristic: .audible)'),
+    );
+    expect(
+      source,
+      contains('subtitleTracks: playbackTracks(characteristic: .legible)'),
+    );
+    expect(
+      source,
+      contains(
+        'selectedAudioTrackId: selectedTrackId(characteristic: .audible)',
+      ),
+    );
+    expect(
+      source,
+      contains(
+        'selectedSubtitleTrackId: selectedTrackId(characteristic: .legible)',
+      ),
+    );
+    expect(source, contains('includeSelectedAudioTrackId: true'));
+    expect(source, contains('includeSelectedSubtitleTrackId: true'));
+    expect(source, contains('includeSelectedAudioTrackId: Bool = false'));
+    expect(source, contains('includeSelectedSubtitleTrackId: Bool = false'));
+    expect(
+      source,
+      contains(
+        'if includeSelectedAudioTrackId { event["selectedAudioTrackId"] = selectedAudioTrackId ?? NSNull() }',
+      ),
+    );
+    expect(
+      source,
+      contains(
+        'if includeSelectedSubtitleTrackId { event["selectedSubtitleTrackId"] = selectedSubtitleTrackId ?? NSNull() }',
+      ),
+    );
+    expect(source, contains('if let a  = audioTracks'));
+    expect(source, contains('event["audioTracks"] = a'));
+    expect(source, contains('if let st = subtitleTracks'));
+    expect(source, contains('event["subtitleTracks"] = st'));
+  });
 }

--- a/flutter_client/test/playback/desktop_libmpv_event_test.dart
+++ b/flutter_client/test/playback/desktop_libmpv_event_test.dart
@@ -509,6 +509,46 @@ void main() {
       expect(selected.audioTracks, hasLength(2));
       expect(selected.subtitleTracks, hasLength(1));
     });
+
+    test('distinguishes unknown selections from confirmed disabled', () {
+      final loaded = DesktopLibmpvEventReducer.reduce(
+        idle,
+        DesktopLibmpvEvent.fromMap(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 1,
+          'sequence': 1,
+          'kind': 'FILE_LOADED',
+          'audioTracks': <Object?>[
+            <String, Object?>{'id': '1', 'label': 'English'},
+          ],
+          'subtitleTracks': <Object?>[
+            <String, Object?>{'id': '4', 'label': 'English CC'},
+          ],
+        }),
+        source,
+      );
+      final disabled = DesktopLibmpvEventReducer.reduce(
+        loaded,
+        DesktopLibmpvEvent.fromMap(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 1,
+          'sequence': 2,
+          'kind': 'PLAYBACK_RESTART',
+          'aid': 'no',
+          'sid': '',
+        }),
+        source,
+      );
+
+      expect(loaded.isAudioTrackSelectionKnown, isFalse);
+      expect(loaded.isSubtitleTrackSelectionKnown, isFalse);
+      expect(disabled.isAudioTrackSelectionKnown, isTrue);
+      expect(disabled.isSubtitleTrackSelectionKnown, isTrue);
+      expect(disabled.selectedAudioTrackId, isNull);
+      expect(disabled.selectedSubtitleTrackId, isNull);
+      expect(disabled.audioTracks, same(loaded.audioTracks));
+      expect(disabled.subtitleTracks, same(loaded.subtitleTracks));
+    });
   });
 
   group('DesktopLibmpvBackend event integration', () {

--- a/flutter_client/test/playback/desktop_libmpv_event_test.dart
+++ b/flutter_client/test/playback/desktop_libmpv_event_test.dart
@@ -41,7 +41,7 @@ void main() {
       expect(event.videoAspectRatio, 1.78);
       expect(event.speed, 1.0);
       expect(event.aid, '1');
-      expect(event.sid, 'no');
+      expect(event.sid, isNull);
     });
 
     test('parses minimal snapshot with defaults', () {
@@ -95,6 +95,74 @@ void main() {
 
       expect(event.aid, isNull);
       expect(event.sid, isNull);
+    });
+
+    test('parses and normalizes schema v2 track lists', () {
+      final event = DesktopLibmpvEvent.fromMap(<String, Object?>{
+        'schemaVersion': 2,
+        'handle': 1,
+        'sequence': 0,
+        'kind': 'FILE_LOADED',
+        'audioTracks': <Object?>[
+          <String, Object?>{
+            'id': ' 1 ',
+            'label': ' English ',
+            'language': ' eng ',
+          },
+          <String, Object?>{'id': '2', 'label': ' ', 'language': ' deu '},
+          <String, Object?>{'id': '3', 'label': ''},
+          <String, Object?>{'id': '', 'label': 'Missing ID'},
+          <String, Object?>{'id': 4, 'label': 'Wrong ID type'},
+          'not a map',
+        ],
+        'subtitleTracks': <Object?>[
+          <String, Object?>{'id': '4', 'label': ' Commentary '},
+          <String, Object?>{'id': '5', 'label': 5, 'language': ''},
+        ],
+      });
+
+      expect(event.audioTracks, hasLength(3));
+      expect(event.audioTracks![0].id, '1');
+      expect(event.audioTracks![0].label, 'English');
+      expect(event.audioTracks![0].language, 'eng');
+      expect(event.audioTracks![1].label, 'deu');
+      expect(event.audioTracks![1].language, 'deu');
+      expect(event.audioTracks![2].label, '3');
+      expect(event.audioTracks![2].language, isNull);
+      expect(event.subtitleTracks, hasLength(2));
+      expect(event.subtitleTracks![0].label, 'Commentary');
+      expect(event.subtitleTracks![0].language, isNull);
+      expect(event.subtitleTracks![1].label, '5');
+      expect(event.subtitleTracks![1].language, isNull);
+    });
+
+    test('gates track lists by schema version and payload shape', () {
+      final legacy = DesktopLibmpvEvent.fromMap(<String, Object?>{
+        'schemaVersion': 1,
+        'kind': 'FILE_LOADED',
+        'audioTracks': <Object?>[
+          <String, Object?>{'id': '1', 'label': 'Legacy'},
+        ],
+      });
+      final malformed = DesktopLibmpvEvent.fromMap(<String, Object?>{
+        'schemaVersion': 2,
+        'kind': 'FILE_LOADED',
+        'audioTracks': <String, Object?>{'id': '1'},
+        'subtitleTracks': 'not a list',
+      });
+      final empty = DesktopLibmpvEvent.fromMap(<String, Object?>{
+        'schemaVersion': 2,
+        'kind': 'PLAYBACK_RESTART',
+        'audioTracks': <Object?>[],
+        'subtitleTracks': <Object?>[],
+      });
+
+      expect(legacy.audioTracks, isNull);
+      expect(legacy.subtitleTracks, isNull);
+      expect(malformed.audioTracks, isNull);
+      expect(malformed.subtitleTracks, isNull);
+      expect(empty.audioTracks, isEmpty);
+      expect(empty.subtitleTracks, isEmpty);
     });
 
     test('parses ERROR kind with message and code', () {
@@ -365,6 +433,82 @@ void main() {
       expect(next.selectedAudioTrackId, '2');
       expect(next.selectedSubtitleTrackId, '3');
     });
+
+    test('preserves track lists across selection and disable events', () {
+      final loaded = DesktopLibmpvEventReducer.reduce(
+        idle,
+        DesktopLibmpvEvent.fromMap(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 1,
+          'sequence': 1,
+          'kind': 'FILE_LOADED',
+          'aid': '1',
+          'sid': '4',
+          'audioTracks': <Object?>[
+            <String, Object?>{'id': '1', 'label': 'English'},
+            <String, Object?>{'id': '2', 'label': 'Deutsch'},
+          ],
+          'subtitleTracks': <Object?>[
+            <String, Object?>{'id': '4', 'label': 'English CC'},
+          ],
+        }),
+        source,
+      );
+      final omitted = DesktopLibmpvEventReducer.reduce(
+        loaded,
+        DesktopLibmpvEvent.fromMap(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 1,
+          'sequence': 2,
+          'kind': 'PLAYBACK_RESTART',
+        }),
+        source,
+      );
+      final disabled = DesktopLibmpvEventReducer.reduce(
+        omitted,
+        DesktopLibmpvEvent.fromMap(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 1,
+          'sequence': 3,
+          'kind': 'PLAYBACK_RESTART',
+          'aid': 'no',
+          'sid': '',
+        }),
+        source,
+      );
+      final selected = DesktopLibmpvEventReducer.reduce(
+        disabled,
+        DesktopLibmpvEvent.fromMap(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 1,
+          'sequence': 4,
+          'kind': 'PLAYBACK_RESTART',
+          'aid': '2',
+          'sid': '4',
+          'audioTracks': <Object?>[
+            <String, Object?>{'id': '1', 'label': 'English'},
+            <String, Object?>{'id': '2', 'label': 'Deutsch'},
+          ],
+          'subtitleTracks': <Object?>[
+            <String, Object?>{'id': '4', 'label': 'English CC'},
+          ],
+        }),
+        source,
+      );
+
+      expect(loaded.audioTracks, hasLength(2));
+      expect(loaded.subtitleTracks, hasLength(1));
+      expect(omitted.audioTracks, same(loaded.audioTracks));
+      expect(omitted.subtitleTracks, same(loaded.subtitleTracks));
+      expect(disabled.selectedAudioTrackId, isNull);
+      expect(disabled.selectedSubtitleTrackId, isNull);
+      expect(disabled.audioTracks, same(loaded.audioTracks));
+      expect(disabled.subtitleTracks, same(loaded.subtitleTracks));
+      expect(selected.selectedAudioTrackId, '2');
+      expect(selected.selectedSubtitleTrackId, '4');
+      expect(selected.audioTracks, hasLength(2));
+      expect(selected.subtitleTracks, hasLength(1));
+    });
   });
 
   group('DesktopLibmpvBackend event integration', () {
@@ -462,6 +606,79 @@ void main() {
         await events.close();
       },
     );
+
+    test('publishes v2 track lists through selection transitions', () async {
+      final events = StreamController<Map<String, Object?>>.broadcast();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(methodChannel, (call) async {
+            if (call.method == 'load') {
+              scheduleMicrotask(() {
+                events.add(<String, Object?>{
+                  'schemaVersion': 2,
+                  'handle': 70,
+                  'sequence': 0,
+                  'kind': 'FILE_LOADED',
+                  'aid': '1',
+                  'sid': '4',
+                  'audioTracks': <Object?>[
+                    <String, Object?>{'id': '1', 'label': 'English'},
+                    <String, Object?>{'id': '2', 'label': 'Deutsch'},
+                  ],
+                  'subtitleTracks': <Object?>[
+                    <String, Object?>{'id': '4', 'label': 'English CC'},
+                  ],
+                });
+              });
+              return <String, Object?>{
+                'ok': true,
+                'handle': 70,
+                'textureId': 700,
+              };
+            }
+            return null;
+          });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+            eventChannel,
+            MockStreamHandler.inline(
+              onListen: (arguments, eventSink) {
+                events.stream.listen(eventSink.success);
+              },
+            ),
+          );
+
+      final backend = DesktopLibmpvBackend();
+      final states = <PlaybackState>[];
+      final stateSub = backend.onState.listen(states.add);
+      await backend.load(
+        const PlaybackSource(uri: 'https://example.test/tracks.mkv'),
+      );
+      events
+        ..add(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 70,
+          'sequence': 1,
+          'kind': 'PLAYBACK_RESTART',
+          'sid': 'no',
+        })
+        ..add(<String, Object?>{
+          'schemaVersion': 2,
+          'handle': 70,
+          'sequence': 2,
+          'kind': 'PLAYBACK_RESTART',
+          'aid': '2',
+        });
+      await pumpEventQueue();
+
+      expect(states.last.audioTracks, hasLength(2));
+      expect(states.last.subtitleTracks, hasLength(1));
+      expect(states.last.selectedAudioTrackId, '2');
+      expect(states.last.selectedSubtitleTrackId, isNull);
+
+      await stateSub.cancel();
+      await backend.dispose();
+      await events.close();
+    });
 
     test('ignores events from stale handle', () async {
       final events = StreamController<Map<String, Object?>>.broadcast();

--- a/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
+++ b/flutter_client/test/playback/media_kit_desktop_adapter_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/playback/media_kit_desktop_adapter.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
@@ -67,6 +69,86 @@ void main() {
       );
 
       expect(selectedTrackId, isNull);
+    });
+
+    test('resolves automatic subtitle selection to the first real track', () {
+      final selection = selectedMediaKitSubtitleTrack(
+        mk.SubtitleTrack.auto(),
+        const <mk.SubtitleTrack>[
+          mk.SubtitleTrack('auto', null, null),
+          mk.SubtitleTrack('no', null, null),
+          mk.SubtitleTrack('3', null, 'de'),
+          mk.SubtitleTrack('4', null, 'en'),
+        ],
+      );
+
+      expect(selection.selectedTrackId, '3');
+      expect(selection.isKnown, isTrue);
+    });
+
+    test('keeps disabled subtitle selection confirmed disabled', () {
+      final selection = selectedMediaKitSubtitleTrack(
+        mk.SubtitleTrack.no(),
+        const <mk.SubtitleTrack>[
+          mk.SubtitleTrack('auto', null, null),
+          mk.SubtitleTrack('no', null, null),
+          mk.SubtitleTrack('3', null, 'de'),
+        ],
+      );
+
+      expect(selection.selectedTrackId, isNull);
+      expect(selection.isKnown, isTrue);
+    });
+
+    test('keeps a real subtitle selection unchanged and known', () {
+      final selection = selectedMediaKitSubtitleTrack(
+        const mk.SubtitleTrack('4', null, 'en'),
+        const <mk.SubtitleTrack>[
+          mk.SubtitleTrack('auto', null, null),
+          mk.SubtitleTrack('no', null, null),
+          mk.SubtitleTrack('3', null, 'de'),
+          mk.SubtitleTrack('4', null, 'en'),
+        ],
+      );
+
+      expect(selection.selectedTrackId, '4');
+      expect(selection.isKnown, isTrue);
+    });
+
+    test('keeps automatic subtitle selection unknown without a real track', () {
+      final selection = selectedMediaKitSubtitleTrack(
+        mk.SubtitleTrack.auto(),
+        const <mk.SubtitleTrack>[
+          mk.SubtitleTrack('auto', null, null),
+          mk.SubtitleTrack('no', null, null),
+        ],
+      );
+
+      expect(selection.selectedTrackId, isNull);
+      expect(selection.isKnown, isFalse);
+    });
+
+    test('both MediaKit track streams use subtitle selection semantics', () {
+      for (final path in <String>[
+        'lib/playback/media_kit_desktop_adapter.dart',
+        'lib/playback/media_kit_ios_adapter.dart',
+      ]) {
+        final source = File(path).readAsStringSync();
+        final handlerStart = source.indexOf('_player.stream.track.listen');
+        final handlerEnd = source.indexOf(
+          '_player.stream.completed.listen',
+          handlerStart,
+        );
+        final handler = source.substring(handlerStart, handlerEnd);
+
+        expect(handler, contains('selectedMediaKitSubtitleTrack('));
+        expect(
+          handler,
+          contains(
+            'isSubtitleTrackSelectionKnown: subtitleSelection.isKnown',
+          ),
+        );
+      }
     });
 
     test('passes playback source start position to media_kit media', () {

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -1323,7 +1323,7 @@ void main() {
       expect(reader, contains('type == "sub"'));
       expect(reader, contains('TrackNodeString'));
       expect(reader, contains('label.empty() ? language : label'));
-      expect(reader, contains('normalized_label.empty() ? id'));
+      expect(reader, contains('normalized_label.empty() ? track_id'));
       final normalizerStart = backend.indexOf(
         'std::string NormalizeTrackString',
       );

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -332,7 +332,7 @@ void main() {
       expect(
         linuxEventValue,
         contains(
-          'fl_value_set_string_take(event, "schemaVersion", fl_value_new_int(1));',
+          'fl_value_set_string_take(event, "schemaVersion", fl_value_new_int(2));',
         ),
       );
       expect(
@@ -350,7 +350,7 @@ void main() {
       expect(
         windowsEventValue,
         contains(
-          '{flutter::EncodableValue("schemaVersion"), flutter::EncodableValue(1)}',
+          '{flutter::EncodableValue("schemaVersion"), flutter::EncodableValue(2)}',
         ),
       );
       expect(
@@ -1204,6 +1204,181 @@ void main() {
           mapping,
           isNot(contains('} else {\n            snapshot.kind = "END_FILE"')),
         );
+      }
+    });
+
+    test('linux libmpv emits safely refreshed normalized track lists', () {
+      final backend = File(
+        'linux/desktop_libmpv_backend.cc',
+      ).readAsStringSync();
+
+      expect(backend, contains('using mpv_free_node_contents_fn'));
+      expect(
+        backend,
+        contains('LoadSymbol(g_api.library, "mpv_free_node_contents")'),
+      );
+      expect(backend, contains('free_node_contents != nullptr'));
+
+      final readerStart = backend.indexOf(
+        'void PlayerInstance::ReadTrackLists',
+      );
+      final readerEnd = backend.indexOf(
+        'void PlayerInstance::StartEventThread',
+        readerStart,
+      );
+      expect(readerStart, isNonNegative);
+      expect(readerEnd, greaterThan(readerStart));
+      final reader = backend.substring(readerStart, readerEnd);
+      expect(reader, contains('"track-list", MPV_FORMAT_NODE, &node'));
+      expect(reader, contains('api->free_node_contents(&node)'));
+      expect(reader, contains('type == "audio"'));
+      expect(reader, contains('type == "sub"'));
+      expect(reader, contains('TrackNodeString'));
+      expect(reader, contains('label.empty() ? language : label'));
+      expect(reader, contains('normalized_label.empty() ? id'));
+      final normalizerStart = backend.indexOf(
+        'std::string NormalizeTrackString',
+      );
+      final normalizerEnd = backend.indexOf(
+        'void PlayerInstance::ReadTrackLists',
+        normalizerStart,
+      );
+      final normalizer = backend.substring(normalizerStart, normalizerEnd);
+      expect(normalizer, contains('std::find_if_not'));
+      expect(normalizer, contains('std::isspace'));
+      expect(normalizer, contains('return NormalizeTrackString'));
+
+      final eventStart = backend.indexOf('FlValue* BuildEventValue');
+      final eventEnd = backend.indexOf(
+        'static gboolean SendEventSnapshotOnGtkThread',
+        eventStart,
+      );
+      final event = backend.substring(eventStart, eventEnd);
+      expect(event, contains('fl_value_new_int(2)'));
+      expect(event, contains('"audioTracks"'));
+      expect(event, contains('"subtitleTracks"'));
+      expect(event, contains('"id"'));
+      expect(event, contains('"label"'));
+      expect(event, contains('"language"'));
+      expect(
+        event,
+        contains(
+          'fl_value_set_string_take(event, "aid", fl_value_new_string(snapshot.aid.c_str()));',
+        ),
+      );
+      expect(
+        event,
+        contains(
+          'fl_value_set_string_take(event, "sid", fl_value_new_string(snapshot.sid.c_str()));',
+        ),
+      );
+      expect(event, isNot(contains('if (!snapshot.aid.empty())')));
+      expect(event, isNot(contains('if (!snapshot.sid.empty())')));
+
+      final fileLoadedStart = backend.indexOf(
+        'case 8:   // MPV_EVENT_FILE_LOADED',
+      );
+      final fileLoadedEnd = backend.indexOf('case 21:', fileLoadedStart);
+      expect(
+        backend.substring(fileLoadedStart, fileLoadedEnd),
+        contains('ReadTrackLists(&snapshot)'),
+      );
+
+      for (final method in <String>['setAudioTrack', 'setSubtitleTrack']) {
+        final controlStart = backend.indexOf(
+          'g_strcmp0(method, "$method") == 0',
+        );
+        final controlEnd = backend.indexOf('} else if', controlStart + 1);
+        final control = backend.substring(controlStart, controlEnd);
+        expect(control, contains('player->ReadTrackLists(&snapshot)'));
+        expect(control, contains('player->QueueEvent(snapshot)'));
+      }
+    });
+
+    test('windows libmpv emits safely refreshed normalized track lists', () {
+      final backend = File(
+        'windows/runner/desktop_libmpv_backend.cpp',
+      ).readAsStringSync();
+
+      expect(backend, contains('using mpv_free_node_contents_fn'));
+      expect(
+        backend,
+        contains('LoadSymbol(g_api.library, "mpv_free_node_contents")'),
+      );
+      expect(backend, contains('free_node_contents != nullptr'));
+
+      final readerStart = backend.indexOf(
+        'void PlayerInstance::ReadTrackLists',
+      );
+      final readerEnd = backend.indexOf(
+        'void PlayerInstance::StartEventThread',
+        readerStart,
+      );
+      expect(readerStart, isNonNegative);
+      expect(readerEnd, greaterThan(readerStart));
+      final reader = backend.substring(readerStart, readerEnd);
+      expect(reader, contains('"track-list", MPV_FORMAT_NODE, &node'));
+      expect(reader, contains('api->free_node_contents(&node)'));
+      expect(reader, contains('type == "audio"'));
+      expect(reader, contains('type == "sub"'));
+      expect(reader, contains('TrackNodeString'));
+      expect(reader, contains('label.empty() ? language : label'));
+      expect(reader, contains('normalized_label.empty() ? id'));
+      final normalizerStart = backend.indexOf(
+        'std::string NormalizeTrackString',
+      );
+      final normalizerEnd = backend.indexOf(
+        'void PlayerInstance::ReadTrackLists',
+        normalizerStart,
+      );
+      final normalizer = backend.substring(normalizerStart, normalizerEnd);
+      expect(normalizer, contains('std::find_if_not'));
+      expect(normalizer, contains('std::isspace'));
+      expect(normalizer, contains('return NormalizeTrackString'));
+
+      final eventStart = backend.indexOf('class EventSinkState');
+      final eventEnd = backend.indexOf(
+        'class EventStreamHandler',
+        eventStart,
+      );
+      final event = backend.substring(eventStart, eventEnd);
+      expect(event, contains('flutter::EncodableValue(2)'));
+      expect(event, contains('"audioTracks"'));
+      expect(event, contains('"subtitleTracks"'));
+      expect(event, contains('"id"'));
+      expect(event, contains('"label"'));
+      expect(event, contains('"language"'));
+      expect(
+        event,
+        contains(
+          '{flutter::EncodableValue("aid"), flutter::EncodableValue(snapshot.aid)}',
+        ),
+      );
+      expect(
+        event,
+        contains(
+          '{flutter::EncodableValue("sid"), flutter::EncodableValue(snapshot.sid)}',
+        ),
+      );
+
+      final fileLoadedStart = backend.indexOf(
+        'event->event_id == MPV_EVENT_FILE_LOADED',
+      );
+      final fileLoadedEnd = backend.indexOf(
+        'event->event_id == MPV_EVENT_PLAYBACK_RESTART',
+        fileLoadedStart,
+      );
+      expect(
+        backend.substring(fileLoadedStart, fileLoadedEnd),
+        contains('ReadTrackLists(&snapshot)'),
+      );
+
+      for (final method in <String>['setAudioTrack', 'setSubtitleTrack']) {
+        final controlStart = backend.indexOf('method == "$method"');
+        final controlEnd = backend.indexOf('} else if', controlStart + 1);
+        final control = backend.substring(controlStart, controlEnd);
+        expect(control, contains('player->ReadTrackLists(&snapshot)'));
+        expect(control, contains('player->QueueEvent(std::move(snapshot))'));
       }
     });
 

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -1260,6 +1260,8 @@ void main() {
       expect(event, contains('"id"'));
       expect(event, contains('"label"'));
       expect(event, contains('"language"'));
+      expect(event, contains('if (snapshot.has_aid)'));
+      expect(event, contains('if (snapshot.has_sid)'));
       expect(
         event,
         contains(
@@ -1272,8 +1274,18 @@ void main() {
           'fl_value_set_string_take(event, "sid", fl_value_new_string(snapshot.sid.c_str()));',
         ),
       );
-      expect(event, isNot(contains('if (!snapshot.aid.empty())')));
-      expect(event, isNot(contains('if (!snapshot.sid.empty())')));
+      expect(
+        backend,
+        contains(
+          'snapshot->has_aid = StringProperty(this, "aid", &snapshot->aid);',
+        ),
+      );
+      expect(
+        backend,
+        contains(
+          'snapshot->has_sid = StringProperty(this, "sid", &snapshot->sid);',
+        ),
+      );
 
       final fileLoadedStart = backend.indexOf(
         'case 8:   // MPV_EVENT_FILE_LOADED',
@@ -1348,16 +1360,30 @@ void main() {
       expect(event, contains('"id"'));
       expect(event, contains('"label"'));
       expect(event, contains('"language"'));
+      expect(event, contains('if (snapshot.has_aid)'));
+      expect(event, contains('if (snapshot.has_sid)'));
       expect(
         event,
         contains(
-          '{flutter::EncodableValue("aid"), flutter::EncodableValue(snapshot.aid)}',
+          'event[flutter::EncodableValue("aid")] = flutter::EncodableValue(snapshot.aid)',
         ),
       );
       expect(
         event,
         contains(
-          '{flutter::EncodableValue("sid"), flutter::EncodableValue(snapshot.sid)}',
+          'event[flutter::EncodableValue("sid")] = flutter::EncodableValue(snapshot.sid)',
+        ),
+      );
+      expect(
+        backend,
+        contains(
+          'snapshot->has_aid = StringProperty(this, "aid", &snapshot->aid);',
+        ),
+      );
+      expect(
+        backend,
+        contains(
+          'snapshot->has_sid = StringProperty(this, "sid", &snapshot->sid);',
         ),
       );
 

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1299,59 +1299,141 @@ void main() {
       expect(requests.last.params, {'stream_id': '101', 'limit': '4'});
     });
 
-    testWidgets('shows audio track selector and applies selection', (
-      tester,
-    ) async {
-      final adapter = FakePlayerAdapter(
-        capabilities: PlaybackCapabilities.desktopLibmpv,
-        textureId: 42,
-      );
-      final orchestrator = PlaybackOrchestrator(
-        platform: PlaybackPlatform.desktop,
-        adapters: <PlaybackBackend, PlayerAdapter>{
-          PlaybackBackend.desktopLibmpv: adapter,
-        },
-        transcodeGateway: FakeTranscodeGateway(),
-      );
-      addTearDown(orchestrator.dispose);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: PlayerScreen(
-            args: const PlayerArgs(
-              streamUrl: 'https://example.com/movie.m3u8',
-              title: 'Multi Audio Fixture',
-              type: 'movie',
-            ),
-            orchestrator: orchestrator,
-            epgService: EpgService(clock: () => DateTime.utc(2026)),
+    final trackSelectorSystems =
+        <
+          ({
+            String name,
+            PlaybackPlatform platform,
+            PlaybackCapabilities capabilities,
+            Size size,
+          })
+        >[
+          (
+            name: 'Android TV Media3',
+            platform: PlaybackPlatform.android,
+            capabilities: PlaybackCapabilities.androidExoPlayer,
+            size: const Size(1920, 1080),
           ),
-        ),
+          (
+            name: 'Android phone Media3',
+            platform: PlaybackPlatform.android,
+            capabilities: PlaybackCapabilities.androidExoPlayer,
+            size: const Size(412, 915),
+          ),
+          (
+            name: 'Apple TV AVKit',
+            platform: PlaybackPlatform.apple,
+            capabilities: PlaybackCapabilities.appleAvKit,
+            size: const Size(1920, 1080),
+          ),
+          (
+            name: 'iPhone MediaKit',
+            platform: PlaybackPlatform.apple,
+            capabilities: PlaybackCapabilities.appleMediaKit,
+            size: const Size(430, 932),
+          ),
+          (
+            name: 'macOS MediaKit',
+            platform: PlaybackPlatform.desktop,
+            capabilities: PlaybackCapabilities.desktopMediaKit,
+            size: const Size(1440, 900),
+          ),
+          (
+            name: 'Linux libmpv',
+            platform: PlaybackPlatform.desktop,
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            size: const Size(1280, 720),
+          ),
+          (
+            name: 'Windows libmpv',
+            platform: PlaybackPlatform.desktop,
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            size: const Size(1366, 768),
+          ),
+        ];
+
+    for (final system in trackSelectorSystems) {
+      testWidgets(
+        '${system.name} shows both track selectors and applies selections',
+        (tester) async {
+          await tester.binding.setSurfaceSize(system.size);
+          addTearDown(() => tester.binding.setSurfaceSize(null));
+          final adapter = FakePlayerAdapter(
+            capabilities: system.capabilities,
+            textureId: 42,
+          );
+          final backend = system.capabilities.backend;
+          final orchestrator = PlaybackOrchestrator(
+            platform: system.platform,
+            adapters: <PlaybackBackend, PlayerAdapter>{backend: adapter},
+            transcodeGateway: FakeTranscodeGateway(),
+          );
+          addTearDown(orchestrator.dispose);
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: PlayerScreen(
+                args: const PlayerArgs(
+                  streamUrl: 'https://example.com/movie.m3u8',
+                  title: 'Track Fixture',
+                  type: 'movie',
+                ),
+                orchestrator: orchestrator,
+                epgService: EpgService(clock: () => DateTime.utc(2026)),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          adapter.emitState(
+            PlaybackState(
+              backend: backend,
+              status: PlaybackStatus.ready,
+              duration: const Duration(hours: 1),
+              audioTracks: const <PlaybackTrack>[
+                PlaybackTrack(
+                  id: 'audio-eng',
+                  label: 'English',
+                  language: 'eng',
+                ),
+                PlaybackTrack(
+                  id: 'audio-spa',
+                  label: 'Spanish',
+                  language: 'spa',
+                ),
+              ],
+              subtitleTracks: const <PlaybackTrack>[
+                PlaybackTrack(
+                  id: 'sub-eng',
+                  label: 'English CC',
+                  language: 'eng',
+                ),
+              ],
+              selectedAudioTrackId: 'audio-eng',
+            ),
+          );
+          await tester.pump();
+
+          expect(tester.takeException(), isNull);
+          expect(find.byIcon(Icons.audiotrack), findsOneWidget);
+          expect(find.byIcon(Icons.subtitles), findsOneWidget);
+          await tester.tap(find.byIcon(Icons.audiotrack));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Spanish').last);
+          await tester.pumpAndSettle();
+          await tester.tap(find.byIcon(Icons.subtitles));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('English CC').last);
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          expect(adapter.setAudioTrackCalls, <String?>['audio-spa']);
+          expect(adapter.setSubtitleTrackCalls, <String?>['sub-eng']);
+        },
       );
-      await tester.pump();
-
-      adapter.emitState(
-        const PlaybackState(
-          backend: PlaybackBackend.desktopLibmpv,
-          status: PlaybackStatus.ready,
-          duration: Duration(hours: 1),
-          audioTracks: <PlaybackTrack>[
-            PlaybackTrack(id: 'audio-eng', label: 'English', language: 'eng'),
-            PlaybackTrack(id: 'audio-spa', label: 'Spanish', language: 'spa'),
-          ],
-          selectedAudioTrackId: 'audio-eng',
-        ),
-      );
-      await tester.pump();
-
-      expect(find.byIcon(Icons.audiotrack), findsOneWidget);
-      await tester.tap(find.byIcon(Icons.audiotrack));
-      await tester.pumpAndSettle();
-      await tester.tap(find.text('Spanish').last);
-      await tester.pumpAndSettle();
-
-      expect(adapter.setAudioTrackCalls, <String?>['audio-spa']);
-    });
+    }
 
     testWidgets('backs out of the route when playback error is visible', (
       tester,

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -771,6 +771,39 @@ void main() {
       expect(find.text('English'), findsWidgets);
     });
 
+    testWidgets('marks Disable selected after audio disable is confirmed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TrackSelector(
+            audioTracks: const [
+              PlaybackTrack(id: '1', label: 'English'),
+              PlaybackTrack(id: '2', label: 'Spanish'),
+            ],
+            subtitleTracks: const [],
+            selectedAudioTrackId: null,
+            selectedSubtitleTrackId: null,
+            isAudioTrackSelectionKnown: true,
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.audiotrack));
+      await tester.pumpAndSettle();
+
+      final disableTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Disable'),
+      );
+      final englishTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'English'),
+      );
+      expect(disableTile.selected, isTrue);
+      expect(englishTile.selected, isFalse);
+    });
+
     testWidgets('opens subtitle track dialog on tap', (tester) async {
       await tester.pumpWidget(
         MaterialApp(
@@ -790,6 +823,72 @@ void main() {
       await tester.tap(find.byIcon(Icons.subtitles));
       await tester.pumpAndSettle();
       expect(find.text('English CC'), findsWidgets);
+    });
+
+    testWidgets(
+      'does not mark Off selected while subtitle selection is unknown',
+      (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: TrackSelector(
+              audioTracks: const [],
+              subtitleTracks: const [
+                PlaybackTrack(id: '1', label: 'English CC'),
+              ],
+              selectedAudioTrackId: null,
+              selectedSubtitleTrackId: null,
+              onAudioTrackSelected: (_) {},
+              onSubtitleTrackSelected: (_) {},
+            ),
+          ),
+        );
+
+        await tester.tap(find.byIcon(Icons.subtitles));
+        await tester.pumpAndSettle();
+
+        final offTile = tester.widget<ListTile>(
+          find.widgetWithText(ListTile, 'Off'),
+        );
+        final englishTile = tester.widget<ListTile>(
+          find.widgetWithText(ListTile, 'English CC'),
+        );
+        expect(offTile.selected, isFalse);
+        expect(englishTile.selected, isFalse);
+      },
+    );
+
+    testWidgets('marks Off selected after subtitle disable is confirmed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: TrackSelector(
+            audioTracks: const [],
+            subtitleTracks: const [
+              PlaybackTrack(id: '1', label: 'English CC'),
+            ],
+            selectedAudioTrackId: null,
+            selectedSubtitleTrackId: null,
+            isSubtitleTrackSelectionKnown: true,
+            onAudioTrackSelected: (_) {},
+            onSubtitleTrackSelected: (_) {},
+          ),
+        ),
+      );
+
+      await tester.tap(find.byIcon(Icons.subtitles));
+      await tester.pumpAndSettle();
+
+      final offTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Off'),
+      );
+      final englishTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'English CC'),
+      );
+      expect(offTile.selected, isTrue);
+      expect(englishTile.selected, isFalse);
     });
 
     testWidgets('calls onAudioTrackSelected when track chosen', (tester) async {
@@ -1431,6 +1530,150 @@ void main() {
           expect(tester.takeException(), isNull);
           expect(adapter.setAudioTrackCalls, <String?>['audio-spa']);
           expect(adapter.setSubtitleTrackCalls, <String?>['sub-eng']);
+        },
+      );
+    }
+
+    for (final systemName in <String>['Linux libmpv', 'Windows libmpv']) {
+      testWidgets(
+        '$systemName confirms disabled tracks without losing track lists',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 42,
+          );
+          final orchestrator = PlaybackOrchestrator(
+            platform: PlaybackPlatform.desktop,
+            adapters: <PlaybackBackend, PlayerAdapter>{
+              PlaybackBackend.desktopLibmpv: adapter,
+            },
+            transcodeGateway: FakeTranscodeGateway(),
+          );
+          addTearDown(orchestrator.dispose);
+          const audioTracks = <PlaybackTrack>[
+            PlaybackTrack(id: 'audio-eng', label: 'English'),
+            PlaybackTrack(id: 'audio-spa', label: 'Spanish'),
+          ];
+          const subtitleTracks = <PlaybackTrack>[
+            PlaybackTrack(id: 'sub-eng', label: 'English CC'),
+          ];
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: PlayerScreen(
+                args: const PlayerArgs(
+                  streamUrl: 'https://example.com/movie.m3u8',
+                  title: 'Track Fixture',
+                  type: 'movie',
+                ),
+                orchestrator: orchestrator,
+                epgService: EpgService(clock: () => DateTime.utc(2026)),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          adapter.emitState(
+            const PlaybackState(
+              backend: PlaybackBackend.desktopLibmpv,
+              status: PlaybackStatus.ready,
+              audioTracks: audioTracks,
+              subtitleTracks: subtitleTracks,
+              selectedAudioTrackId: 'audio-eng',
+              selectedSubtitleTrackId: 'sub-eng',
+              isAudioTrackSelectionKnown: true,
+              isSubtitleTrackSelectionKnown: true,
+            ),
+          );
+          await tester.pump();
+
+          await tester.tap(find.byIcon(Icons.audiotrack));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Disable'));
+          await tester.pumpAndSettle();
+          expect(adapter.setAudioTrackCalls, <String?>[null]);
+
+          adapter.emitState(
+            const PlaybackState(
+              backend: PlaybackBackend.desktopLibmpv,
+              status: PlaybackStatus.playing,
+              audioTracks: audioTracks,
+              subtitleTracks: subtitleTracks,
+              selectedSubtitleTrackId: 'sub-eng',
+              isAudioTrackSelectionKnown: true,
+              isSubtitleTrackSelectionKnown: true,
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+          expect(
+            tester
+                .widget<PlaybackControls>(find.byType(PlaybackControls))
+                .isAudioTrackSelectionKnown,
+            isTrue,
+          );
+          expect(
+            tester
+                .widget<TrackSelector>(find.byType(TrackSelector))
+                .isAudioTrackSelectionKnown,
+            isTrue,
+          );
+          expect(
+            tester
+                .widget<TrackSelector>(find.byType(TrackSelector))
+                .selectedAudioTrackId,
+            isNull,
+          );
+          await tester.tap(find.byIcon(Icons.audiotrack));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester
+                .widget<ListTile>(find.widgetWithText(ListTile, 'Disable'))
+                .selected,
+            isTrue,
+          );
+          expect(find.text('English'), findsOneWidget);
+          expect(find.text('Spanish'), findsOneWidget);
+          tester.state<NavigatorState>(find.byType(Navigator)).pop();
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byIcon(Icons.subtitles));
+          await tester.pumpAndSettle();
+          await tester.tap(find.text('Off'));
+          await tester.pumpAndSettle();
+          expect(adapter.setSubtitleTrackCalls, <String?>[null]);
+
+          adapter.emitState(
+            const PlaybackState(
+              backend: PlaybackBackend.desktopLibmpv,
+              status: PlaybackStatus.playing,
+              audioTracks: audioTracks,
+              subtitleTracks: subtitleTracks,
+              isAudioTrackSelectionKnown: true,
+              isSubtitleTrackSelectionKnown: true,
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+          expect(
+            tester
+                .widget<PlaybackControls>(find.byType(PlaybackControls))
+                .isSubtitleTrackSelectionKnown,
+            isTrue,
+          );
+          await tester.tap(find.byIcon(Icons.subtitles));
+          await tester.pumpAndSettle();
+
+          expect(
+            tester
+                .widget<ListTile>(find.widgetWithText(ListTile, 'Off'))
+                .selected,
+            isTrue,
+          );
+          expect(find.text('English CC'), findsOneWidget);
         },
       );
     }

--- a/flutter_client/tvos/Runner/AvKitPlaybackPlugin.swift
+++ b/flutter_client/tvos/Runner/AvKitPlaybackPlugin.swift
@@ -137,6 +137,16 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
             emit(type: "stopped")
             result(nil)
 
+        case "setAudioTrack":
+            let args = call.arguments as? [String: Any]
+            selectTrack(characteristic: .audible, trackId: args?["trackId"] as? String)
+            result(nil)
+
+        case "setSubtitleTrack":
+            let args = call.arguments as? [String: Any]
+            selectTrack(characteristic: .legible, trackId: args?["trackId"] as? String)
+            result(nil)
+
         case "dispose":
             releasePlayer()
             result(nil)
@@ -166,7 +176,13 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
             emit(
                 type: s.player.rate > 0 ? "playing" : "ready",
                 positionMs: posMs,
-                videoAspectRatio: videoAspectRatio(for: item)
+                videoAspectRatio: videoAspectRatio(for: item),
+                audioTracks: playbackTracks(characteristic: .audible),
+                subtitleTracks: playbackTracks(characteristic: .legible),
+                selectedAudioTrackId: selectedTrackId(characteristic: .audible),
+                selectedSubtitleTrackId: selectedTrackId(characteristic: .legible),
+                includeSelectedAudioTrackId: true,
+                includeSelectedSubtitleTrackId: true
             )
         case .failed:
             let msg = item.error?.localizedDescription ?? "AVPlayer item failed"
@@ -184,6 +200,62 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
 
     fileprivate func handlePlaybackEnded() {
         emit(type: "end", positionMs: currentPositionMs())
+    }
+
+    private func selectTrack(characteristic: AVMediaCharacteristic, trackId: String?) {
+        guard let item = state?.item,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic) else {
+            return
+        }
+
+        if let trackId = trackId, let index = parseTrackIndex(trackId), index < group.options.count {
+            item.select(group.options[index], in: group)
+        } else {
+            item.select(nil, in: group)
+        }
+
+        emit(
+            type: state?.player.rate ?? 0 > 0 ? "playing" : "ready",
+            positionMs: currentPositionMs(),
+            audioTracks: playbackTracks(characteristic: .audible),
+            subtitleTracks: playbackTracks(characteristic: .legible),
+            selectedAudioTrackId: selectedTrackId(characteristic: .audible),
+            selectedSubtitleTrackId: selectedTrackId(characteristic: .legible),
+            includeSelectedAudioTrackId: true,
+            includeSelectedSubtitleTrackId: true
+        )
+    }
+
+    private func playbackTracks(characteristic: AVMediaCharacteristic) -> [[String: Any?]] {
+        guard let item = state?.item,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic) else {
+            return []
+        }
+        let prefix = characteristic == .audible ? "audio" : "subtitle"
+        return group.options.enumerated().map { index, option in
+            [
+                "id": "\(prefix):\(index)",
+                "label": option.displayName,
+                "language": option.locale?.identifier,
+            ]
+        }
+    }
+
+    private func selectedTrackId(characteristic: AVMediaCharacteristic) -> String? {
+        guard let item = state?.item,
+              let group = item.asset.mediaSelectionGroup(forMediaCharacteristic: characteristic),
+              let selected = item.selectedMediaOption(in: group),
+              let index = group.options.firstIndex(of: selected) else {
+            return nil
+        }
+        let prefix = characteristic == .audible ? "audio" : "subtitle"
+        return "\(prefix):\(index)"
+    }
+
+    private func parseTrackIndex(_ trackId: String) -> Int? {
+        let parts = trackId.split(separator: ":")
+        guard parts.count == 2 else { return nil }
+        return Int(parts[1])
     }
 
     private func currentPositionMs() -> Int64 {
@@ -204,6 +276,12 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         uri: String? = nil,
         positionMs: Int64? = nil,
         videoAspectRatio: Double? = nil,
+        audioTracks: [[String: Any?]]? = nil,
+        subtitleTracks: [[String: Any?]]? = nil,
+        selectedAudioTrackId: String? = nil,
+        selectedSubtitleTrackId: String? = nil,
+        includeSelectedAudioTrackId: Bool = false,
+        includeSelectedSubtitleTrackId: Bool = false,
         code: String? = nil,
         message: String? = nil,
         recoverable: Bool = false
@@ -213,6 +291,10 @@ class AvKitPlaybackPlugin: NSObject, FlutterStreamHandler {
         if let u  = uri         { event["uri"]         = u        }
         if let p  = positionMs  { event["positionMs"]  = p        }
         if let ar = videoAspectRatio { event["videoAspectRatio"] = ar }
+        if let a  = audioTracks { event["audioTracks"] = a        }
+        if let st = subtitleTracks { event["subtitleTracks"] = st }
+        if includeSelectedAudioTrackId { event["selectedAudioTrackId"] = selectedAudioTrackId ?? NSNull() }
+        if includeSelectedSubtitleTrackId { event["selectedSubtitleTrackId"] = selectedSubtitleTrackId ?? NSNull() }
         if let c  = code        { event["code"]        = c        }
         if let m  = message     { event["message"]     = m        }
         if recoverable          { event["recoverable"] = true      }

--- a/flutter_client/windows/runner/desktop_libmpv_backend.cpp
+++ b/flutter_client/windows/runner/desktop_libmpv_backend.cpp
@@ -8,8 +8,11 @@
 
 #include <windows.h>
 
+#include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <cstdint>
+#include <cstring>
 #include <functional>
 #include <map>
 #include <memory>
@@ -38,12 +41,32 @@ constexpr uint32_t kTextureHeight = 720;
 constexpr int kBytesPerPixel = 4;
 
 using mpv_handle = struct mpv_handle;
+struct mpv_node;
+struct mpv_node_list;
+union mpv_node_union {
+  char* string;
+  int flag;
+  int64_t int64;
+  double double_;
+  mpv_node_list* list;
+  void* ba;
+};
+struct mpv_node {
+  mpv_node_union u;
+  int format;
+};
+struct mpv_node_list {
+  int num;
+  mpv_node* values;
+  char** keys;
+};
 using mpv_create_fn = mpv_handle* (*)();
 using mpv_initialize_fn = int (*)(mpv_handle*);
 using mpv_command_fn = int (*)(mpv_handle*, const char**);
 using mpv_set_option_string_fn = int (*)(mpv_handle*, const char*, const char*);
 using mpv_get_property_fn = int (*)(mpv_handle*, const char*, int, void*);
 using mpv_free_fn = void (*)(void*);
+using mpv_free_node_contents_fn = void (*)(mpv_node*);
 using mpv_terminate_destroy_fn = void (*)(mpv_handle*);
 using mpv_observe_property_fn = int (*)(mpv_handle*, uint64_t, const char*, int);
 using mpv_unobserve_property_fn = int (*)(mpv_handle*, uint64_t);
@@ -79,6 +102,10 @@ struct mpv_event_end_file {
 constexpr int MPV_FORMAT_DOUBLE = 5;
 constexpr int MPV_FORMAT_FLAG = 3;
 constexpr int MPV_FORMAT_STRING = 1;
+constexpr int MPV_FORMAT_INT64 = 4;
+constexpr int MPV_FORMAT_NODE = 6;
+constexpr int MPV_FORMAT_NODE_ARRAY = 7;
+constexpr int MPV_FORMAT_NODE_MAP = 8;
 
 constexpr int MPV_EVENT_NONE = 0;
 constexpr int MPV_EVENT_SHUTDOWN = 1;
@@ -145,6 +172,7 @@ struct LibmpvApi {
   mpv_set_option_string_fn set_option_string = nullptr;
   mpv_get_property_fn get_property = nullptr;
   mpv_free_fn free = nullptr;
+  mpv_free_node_contents_fn free_node_contents = nullptr;
   mpv_terminate_destroy_fn terminate_destroy = nullptr;
   mpv_observe_property_fn observe_property = nullptr;
   mpv_unobserve_property_fn unobserve_property = nullptr;
@@ -160,7 +188,8 @@ struct LibmpvApi {
   bool client_available() const {
     return library != nullptr && create != nullptr && initialize != nullptr &&
            command != nullptr && set_option_string != nullptr &&
-           get_property != nullptr && free != nullptr && terminate_destroy != nullptr &&
+           get_property != nullptr && free != nullptr &&
+           free_node_contents != nullptr && terminate_destroy != nullptr &&
            observe_property != nullptr && unobserve_property != nullptr &&
            wakeup != nullptr && wait_event != nullptr;
   }
@@ -187,6 +216,14 @@ struct EventSnapshot {
   double speed = 0.0;
   std::string aid;
   std::string sid;
+  struct Track {
+    std::string id;
+    std::string label;
+    std::string language;
+  };
+  std::vector<Track> audio_tracks;
+  std::vector<Track> subtitle_tracks;
+  bool has_track_lists = false;
   std::string message;
   std::string code;
   bool recoverable = false;
@@ -245,7 +282,7 @@ class EventSinkState {
   void Send(const EventSnapshot& snapshot) {
     if (!sink_) return;
     flutter::EncodableMap event{
-        {flutter::EncodableValue("schemaVersion"), flutter::EncodableValue(1)},
+        {flutter::EncodableValue("schemaVersion"), flutter::EncodableValue(2)},
         {flutter::EncodableValue("handle"), flutter::EncodableValue(snapshot.handle)},
         {flutter::EncodableValue("sequence"), flutter::EncodableValue(snapshot.sequence)},
         {flutter::EncodableValue("kind"), flutter::EncodableValue(snapshot.kind)},
@@ -260,6 +297,27 @@ class EventSinkState {
         {flutter::EncodableValue("recoverable"), flutter::EncodableValue(snapshot.recoverable)},
     };
     if (snapshot.duration > 0.0) event[flutter::EncodableValue("durationMs")] = flutter::EncodableValue(static_cast<int64_t>(snapshot.duration * 1000.0));
+    if (snapshot.has_track_lists) {
+      auto encode_tracks = [](const std::vector<EventSnapshot::Track>& tracks) {
+        flutter::EncodableList values;
+        for (const EventSnapshot::Track& track : tracks) {
+          flutter::EncodableMap value{
+              {flutter::EncodableValue("id"), flutter::EncodableValue(track.id)},
+              {flutter::EncodableValue("label"), flutter::EncodableValue(track.label)},
+          };
+          if (!track.language.empty()) {
+            value[flutter::EncodableValue("language")] =
+                flutter::EncodableValue(track.language);
+          }
+          values.emplace_back(value);
+        }
+        return values;
+      };
+      event[flutter::EncodableValue("audioTracks")] =
+          flutter::EncodableValue(encode_tracks(snapshot.audio_tracks));
+      event[flutter::EncodableValue("subtitleTracks")] =
+          flutter::EncodableValue(encode_tracks(snapshot.subtitle_tracks));
+    }
     if (!snapshot.message.empty()) event[flutter::EncodableValue("message")] = flutter::EncodableValue(snapshot.message);
     if (!snapshot.code.empty()) event[flutter::EncodableValue("code")] = flutter::EncodableValue(snapshot.code);
     sink_->Success(flutter::EncodableValue(event));
@@ -425,6 +483,7 @@ struct PlayerInstance {
   void StartEventThread();
   void QueueEvent(EventSnapshot snapshot);
   void ReadSnapshotProperties(EventSnapshot* snapshot);
+  void ReadTrackLists(EventSnapshot* snapshot);
 
   LibmpvApi* api = nullptr;
   flutter::TextureRegistrar* texture_registrar = nullptr;
@@ -497,6 +556,8 @@ LibmpvApi& Api() {
   g_api.set_option_string = reinterpret_cast<mpv_set_option_string_fn>(LoadSymbol(g_api.library, "mpv_set_option_string"));
   g_api.get_property = reinterpret_cast<mpv_get_property_fn>(LoadSymbol(g_api.library, "mpv_get_property"));
   g_api.free = reinterpret_cast<mpv_free_fn>(LoadSymbol(g_api.library, "mpv_free"));
+  g_api.free_node_contents = reinterpret_cast<mpv_free_node_contents_fn>(
+      LoadSymbol(g_api.library, "mpv_free_node_contents"));
   g_api.terminate_destroy = reinterpret_cast<mpv_terminate_destroy_fn>(LoadSymbol(g_api.library, "mpv_terminate_destroy"));
   g_api.observe_property = reinterpret_cast<mpv_observe_property_fn>(LoadSymbol(g_api.library, "mpv_observe_property"));
   g_api.unobserve_property = reinterpret_cast<mpv_unobserve_property_fn>(LoadSymbol(g_api.library, "mpv_unobserve_property"));
@@ -748,6 +809,79 @@ void PlayerInstance::ReadSnapshotProperties(EventSnapshot* snapshot) {
   snapshot->sid = StringProperty(this, "sid");
 }
 
+std::string NormalizeTrackString(std::string value) {
+  const auto first = std::find_if_not(
+      value.begin(), value.end(),
+      [](unsigned char character) { return std::isspace(character) != 0; });
+  const auto last = std::find_if_not(
+      value.rbegin(), value.rend(),
+      [](unsigned char character) { return std::isspace(character) != 0; })
+                        .base();
+  return first < last ? std::string(first, last) : "";
+}
+
+const mpv_node* MapNodeValue(const mpv_node& node, const char* key) {
+  if (node.format != MPV_FORMAT_NODE_MAP || node.u.list == nullptr ||
+      node.u.list->keys == nullptr || node.u.list->values == nullptr) {
+    return nullptr;
+  }
+  for (int index = 0; index < node.u.list->num; ++index) {
+    if (node.u.list->keys[index] != nullptr &&
+        std::strcmp(node.u.list->keys[index], key) == 0) {
+      return &node.u.list->values[index];
+    }
+  }
+  return nullptr;
+}
+
+std::string TrackNodeString(const mpv_node* node) {
+  if (node == nullptr) return "";
+  if (node->format == MPV_FORMAT_STRING && node->u.string != nullptr) {
+    return NormalizeTrackString(node->u.string);
+  }
+  if (node->format == MPV_FORMAT_INT64) {
+    return std::to_string(node->u.int64);
+  }
+  return "";
+}
+
+void PlayerInstance::ReadTrackLists(EventSnapshot* snapshot) {
+  snapshot->audio_tracks.clear();
+  snapshot->subtitle_tracks.clear();
+  snapshot->has_track_lists = false;
+  if (api == nullptr || api->get_property == nullptr ||
+      api->free_node_contents == nullptr) {
+    return;
+  }
+
+  mpv_node node{};
+  if (api->get_property(handle, "track-list", MPV_FORMAT_NODE, &node) < 0) {
+    return;
+  }
+  snapshot->has_track_lists = true;
+  if (node.format == MPV_FORMAT_NODE_ARRAY && node.u.list != nullptr &&
+      node.u.list->values != nullptr) {
+    for (int index = 0; index < node.u.list->num; ++index) {
+      const mpv_node& item = node.u.list->values[index];
+      const std::string type = TrackNodeString(MapNodeValue(item, "type"));
+      const std::string id = TrackNodeString(MapNodeValue(item, "id"));
+      if (id.empty() || (type != "audio" && type != "sub")) continue;
+      const std::string language =
+          TrackNodeString(MapNodeValue(item, "lang"));
+      const std::string label = TrackNodeString(MapNodeValue(item, "title"));
+      const std::string normalized_label = label.empty() ? language : label;
+      EventSnapshot::Track track{
+          id, normalized_label.empty() ? id : normalized_label, language};
+      if (type == "audio") {
+        snapshot->audio_tracks.push_back(std::move(track));
+      } else if (type == "sub") {
+        snapshot->subtitle_tracks.push_back(std::move(track));
+      }
+    }
+  }
+  api->free_node_contents(&node);
+}
+
 void PlayerInstance::StartEventThread() {
   event_thread = std::thread([this]() {
     const char* doubles[] = {"time-pos", "duration", "speed", "video-params/aspect", "dwidth", "dheight"};
@@ -769,6 +903,7 @@ void PlayerInstance::StartEventThread() {
         snapshot.kind = "START_FILE";
       } else if (event->event_id == MPV_EVENT_FILE_LOADED) {
         snapshot.kind = "FILE_LOADED";
+        ReadTrackLists(&snapshot);
       } else if (event->event_id == MPV_EVENT_PLAYBACK_RESTART || event->event_id == MPV_EVENT_PROPERTY_CHANGE) {
         snapshot.kind = "PLAYBACK_RESTART";
       } else if (event->event_id == MPV_EVENT_VIDEO_RECONFIG) {
@@ -889,10 +1024,20 @@ void Control(const std::string& method, const flutter::EncodableMap* args) {
     const std::string track = StringArg(args, "trackId");
     const char* command[] = {"set", "aid", track.empty() ? "no" : track.c_str(), nullptr};
     player->api->command(player->handle, command);
+    EventSnapshot snapshot;
+    snapshot.kind = "PLAYBACK_RESTART";
+    player->ReadSnapshotProperties(&snapshot);
+    player->ReadTrackLists(&snapshot);
+    player->QueueEvent(std::move(snapshot));
   } else if (method == "setSubtitleTrack") {
     const std::string track = StringArg(args, "trackId");
     const char* command[] = {"set", "sid", track.empty() ? "no" : track.c_str(), nullptr};
     player->api->command(player->handle, command);
+    EventSnapshot snapshot;
+    snapshot.kind = "PLAYBACK_RESTART";
+    player->ReadSnapshotProperties(&snapshot);
+    player->ReadTrackLists(&snapshot);
+    player->QueueEvent(std::move(snapshot));
   } else if (method == "setPlaybackSpeed") {
     const std::string speed = std::to_string(DoubleArg(args, "speed", 1.0));
     const char* command[] = {"set", "speed", speed.c_str(), nullptr};

--- a/flutter_client/windows/runner/desktop_libmpv_backend.cpp
+++ b/flutter_client/windows/runner/desktop_libmpv_backend.cpp
@@ -216,6 +216,8 @@ struct EventSnapshot {
   double speed = 0.0;
   std::string aid;
   std::string sid;
+  bool has_aid = false;
+  bool has_sid = false;
   struct Track {
     std::string id;
     std::string label;
@@ -292,11 +294,11 @@ class EventSinkState {
         {flutter::EncodableValue("eof"), flutter::EncodableValue(snapshot.eof)},
         {flutter::EncodableValue("videoAspectRatio"), flutter::EncodableValue(snapshot.video_aspect_ratio)},
         {flutter::EncodableValue("speed"), flutter::EncodableValue(snapshot.speed)},
-        {flutter::EncodableValue("aid"), flutter::EncodableValue(snapshot.aid)},
-        {flutter::EncodableValue("sid"), flutter::EncodableValue(snapshot.sid)},
         {flutter::EncodableValue("recoverable"), flutter::EncodableValue(snapshot.recoverable)},
     };
     if (snapshot.duration > 0.0) event[flutter::EncodableValue("durationMs")] = flutter::EncodableValue(static_cast<int64_t>(snapshot.duration * 1000.0));
+    if (snapshot.has_aid) event[flutter::EncodableValue("aid")] = flutter::EncodableValue(snapshot.aid);
+    if (snapshot.has_sid) event[flutter::EncodableValue("sid")] = flutter::EncodableValue(snapshot.sid);
     if (snapshot.has_track_lists) {
       auto encode_tracks = [](const std::vector<EventSnapshot::Track>& tracks) {
         flutter::EncodableList values;
@@ -772,13 +774,13 @@ bool FlagProperty(PlayerInstance* player, const char* name, bool* value) {
   return true;
 }
 
-std::string StringProperty(PlayerInstance* player, const char* name) {
+bool StringProperty(PlayerInstance* player, const char* name, std::string* value) {
   char* current = nullptr;
   if (player == nullptr || player->api == nullptr || player->api->get_property == nullptr ||
-      player->api->free == nullptr || player->api->get_property(player->handle, name, MPV_FORMAT_STRING, &current) < 0 || current == nullptr) return "";
-  std::string value(current);
+      player->api->free == nullptr || player->api->get_property(player->handle, name, MPV_FORMAT_STRING, &current) < 0 || current == nullptr) return false;
+  *value = current;
   player->api->free(current);
-  return value;
+  return true;
 }
 
 void PlayerInstance::QueueEvent(EventSnapshot snapshot) {
@@ -805,8 +807,8 @@ void PlayerInstance::ReadSnapshotProperties(EventSnapshot* snapshot) {
     double height = 0.0;
     if (DoubleProperty(this, "dwidth", &width) && DoubleProperty(this, "dheight", &height) && height > 0.0) snapshot->video_aspect_ratio = width / height;
   }
-  snapshot->aid = StringProperty(this, "aid");
-  snapshot->sid = StringProperty(this, "sid");
+  snapshot->has_aid = StringProperty(this, "aid", &snapshot->aid);
+  snapshot->has_sid = StringProperty(this, "sid", &snapshot->sid);
 }
 
 std::string NormalizeTrackString(std::string value) {

--- a/flutter_client/windows/runner/desktop_libmpv_backend.cpp
+++ b/flutter_client/windows/runner/desktop_libmpv_backend.cpp
@@ -864,14 +864,16 @@ void PlayerInstance::ReadTrackLists(EventSnapshot* snapshot) {
     for (int index = 0; index < node.u.list->num; ++index) {
       const mpv_node& item = node.u.list->values[index];
       const std::string type = TrackNodeString(MapNodeValue(item, "type"));
-      const std::string id = TrackNodeString(MapNodeValue(item, "id"));
-      if (id.empty() || (type != "audio" && type != "sub")) continue;
+      const std::string track_id = TrackNodeString(MapNodeValue(item, "id"));
+      if (track_id.empty() || (type != "audio" && type != "sub")) continue;
       const std::string language =
           TrackNodeString(MapNodeValue(item, "lang"));
       const std::string label = TrackNodeString(MapNodeValue(item, "title"));
       const std::string normalized_label = label.empty() ? language : label;
       EventSnapshot::Track track{
-          id, normalized_label.empty() ? id : normalized_label, language};
+          track_id,
+          normalized_label.empty() ? track_id : normalized_label,
+          language};
       if (type == "audio") {
         snapshot->audio_tracks.push_back(std::move(track));
       } else if (type == "sub") {


### PR DESCRIPTION
## Summary

- represent track selection with independent known-state bits so null can mean confirmed disabled without losing initial unknown behavior
- render confirmed audio Disable and subtitle Off states while preserving available track lists
- omit unavailable aid and sid properties from Linux and Windows libmpv events while retaining explicit disabled values
- propagate confirmed selection state through Media3, AVKit, MediaKit, libmpv, and the player UI

## Testing

- focused player widget suite: 59 passed
- focused desktop reducer and backend suites: 45 passed
- focused Media3, MediaKit, and native policy suites: 40 passed
- `dart format --output=none --set-exit-if-changed ...`: passed
- `flutter analyze lib test`: passed
- `flutter test --concurrency=1`: 490 passed, 5 skipped, 3 inherited release workflow documentation failures matching the reviewed baseline
- exact-head GitHub CI Linux release build: passed
- exact-head GitHub CI Windows release build: passed
- exact-head GitHub CI analyze/test: 490 passed, 5 skipped, and only the same 3 inherited release documentation tests failed
- local `flutter build linux --release`: blocked before generation because gtk+-3.0 is unavailable in the environment

Closes #147