### PR TITLE
feat(desktop): add native local notifications

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -273,6 +273,7 @@ class AppShellState extends ConsumerState<AppShell>
     _backExitTimer?.cancel();
     _tvNotificationSub?.cancel().ignore();
     _notificationActivationSub?.cancel().ignore();
+    _desktopNotificationDispatcher.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _playerOrchestrator?.dispose().ignore();
     for (final node in _sidebarFocusNodes) {

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -26,6 +26,7 @@ import 'package:m3u_tv/playback/playback_orchestrator.dart';
 import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/aiostreams_api_service.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/desktop_notification_presenter.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/services/tv_notification_service.dart';
@@ -80,6 +81,7 @@ class AppShell extends ConsumerStatefulWidget {
     this.playbackOrchestratorBuilder,
     this.playerRouteBuilder,
     this.systemUiPolicy,
+    this.desktopNotificationPresenter,
   });
 
   final StatefulNavigationShell navigationShell;
@@ -88,6 +90,7 @@ class AppShell extends ConsumerStatefulWidget {
   final PlaybackOrchestrator Function()? playbackOrchestratorBuilder;
   final Widget Function(PlayerArgs args)? playerRouteBuilder;
   final SystemUiPolicy? systemUiPolicy;
+  final DesktopNotificationPresenter? desktopNotificationPresenter;
 
   @override
   ConsumerState<AppShell> createState() => AppShellState();
@@ -108,6 +111,7 @@ class AppShellState extends ConsumerState<AppShell>
   StreamSubscription<TvNotificationItem>? _tvNotificationSub;
   StreamSubscription<TvNotificationDestination>? _notificationActivationSub;
   final _toastKey = GlobalKey<NotificationToastOverlayState>();
+  late final DesktopNotificationDispatcher _desktopNotificationDispatcher;
 
   PlayerArgs? _playerArgs;
   PlaybackOrchestrator? _playerOrchestrator;
@@ -148,6 +152,12 @@ class AppShellState extends ConsumerState<AppShell>
     _appState = widget.appState ?? AppStateController();
     _ownsAppState = widget.appState == null;
     _systemUiPolicy = widget.systemUiPolicy ?? SystemUiPolicy();
+    _desktopNotificationDispatcher = DesktopNotificationDispatcher(
+      presenter:
+          widget.desktopNotificationPresenter ??
+          NativeDesktopNotificationPresenter(),
+      onFallback: _enqueueNotificationToast,
+    );
     _unreadCount = _appState.unreadNotificationCount;
     _appState.addListener(_onAppStateChanged);
     _tvNotificationSub = _appState.tvNotifications.listen(_onTvNotification);
@@ -158,6 +168,19 @@ class AppShellState extends ConsumerState<AppShell>
       unawaited(_appState.boot());
     }
     _initSidebarFocusNodes();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    unawaited(
+      _desktopNotificationDispatcher.initialize(
+        defaultActionName: AppLocalizations.of(
+          context,
+        ).notificationsDesktopOpen,
+        onActivation: _appState.handleNotificationActivation,
+      ),
+    );
   }
 
   Future<bool> _handleSystemBack() async {
@@ -222,6 +245,10 @@ class AppShellState extends ConsumerState<AppShell>
   }
 
   void _onTvNotification(TvNotificationItem item) {
+    unawaited(_desktopNotificationDispatcher.dispatch(item));
+  }
+
+  void _enqueueNotificationToast(TvNotificationItem item) {
     if (!mounted) return;
     _toastKey.currentState?.enqueue(item);
   }

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -10,6 +10,7 @@
   "navNotifications": "Mitteilungen",
   "navSettings": "Einstellungen",
   "navMore": "Mehr",
+  "notificationsDesktopOpen": "Öffnen",
   "appBackToExit": "Zum Beenden erneut Zurück drücken",
   "appRecordingScheduled": "Aufnahme geplant: {title}",
   "@appRecordingScheduled": {

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -10,6 +10,7 @@
   "navNotifications": "Notifications",
   "navSettings": "Settings",
   "navMore": "More",
+  "notificationsDesktopOpen": "Open",
   "appBackToExit": "Press back again to exit",
   "appRecordingScheduled": "Recording scheduled: {title}",
   "@appRecordingScheduled": {

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -10,6 +10,7 @@
   "navNotifications": "Notificaciones",
   "navSettings": "Ajustes",
   "navMore": "Más",
+  "notificationsDesktopOpen": "Abrir",
   "appBackToExit": "Pulse atrás de nuevo para salir",
   "appRecordingScheduled": "Grabación programada: {title}",
   "@appRecordingScheduled": {

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -10,6 +10,7 @@
   "navNotifications": "Notifications",
   "navSettings": "Paramètres",
   "navMore": "Plus",
+  "notificationsDesktopOpen": "Ouvrir",
   "appBackToExit": "Appuyez à nouveau sur Retour pour quitter",
   "appRecordingScheduled": "Enregistrement programmé : {title}",
   "@appRecordingScheduled": {

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -164,6 +164,12 @@ abstract class AppLocalizations {
   /// **'More'**
   String get navMore;
 
+  /// No description provided for @notificationsDesktopOpen.
+  ///
+  /// In en, this message translates to:
+  /// **'Open'**
+  String get notificationsDesktopOpen;
+
   /// No description provided for @appBackToExit.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -39,6 +39,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get navMore => 'Mehr';
 
   @override
+  String get notificationsDesktopOpen => 'Öffnen';
+
+  @override
   String get appBackToExit => 'Zum Beenden erneut Zurück drücken';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -39,6 +39,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get navMore => 'More';
 
   @override
+  String get notificationsDesktopOpen => 'Open';
+
+  @override
   String get appBackToExit => 'Press back again to exit';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -39,6 +39,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get navMore => 'Más';
 
   @override
+  String get notificationsDesktopOpen => 'Abrir';
+
+  @override
   String get appBackToExit => 'Pulse atrás de nuevo para salir';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -39,6 +39,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get navMore => 'Plus';
 
   @override
+  String get notificationsDesktopOpen => 'Ouvrir';
+
+  @override
   String get appBackToExit => 'Appuyez à nouveau sur Retour pour quitter';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -39,6 +39,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get navMore => '更多';
 
   @override
+  String get notificationsDesktopOpen => '打开';
+
+  @override
   String get appBackToExit => '再次按返回键退出';
 
   @override

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -10,6 +10,7 @@
   "navNotifications": "通知",
   "navSettings": "设置",
   "navMore": "更多",
+  "notificationsDesktopOpen": "打开",
   "appBackToExit": "再次按返回键退出",
   "appRecordingScheduled": "录制已安排：{title}",
   "@appRecordingScheduled": {

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -155,8 +155,7 @@ class AppStateController extends ChangeNotifier {
   final Generation _pushLifecycleGeneration = Generation();
   Future<void>? _pushInitialization;
   StreamSubscription<String>? _pushTokenSubscription;
-  final Map<String, PushMessage> _pendingPushActivations =
-      <String, PushMessage>{};
+  final Set<String> _pendingNotificationActivations = <String>{};
   final StreamController<TvNotificationItem> _tvNotificationController =
       StreamController<TvNotificationItem>.broadcast();
   final StreamController<TvNotificationDestination>
@@ -447,7 +446,7 @@ class AppStateController extends ChangeNotifier {
     try {
       final session = await _reconcileUnreadNotifications(
         credentials,
-        present: _pendingPushActivations.isEmpty,
+        present: _pendingNotificationActivations.isEmpty,
         notificationGeneration: notificationGeneration,
       );
       if (_notificationSessionGeneration.isStale(notificationGeneration)) {
@@ -545,7 +544,7 @@ class AppStateController extends ChangeNotifier {
     try {
       await _reconcileUnreadNotifications(
         credentials,
-        present: _pendingPushActivations.isEmpty,
+        present: _pendingNotificationActivations.isEmpty,
         notificationGeneration: notificationGeneration,
       );
     } on Object catch (_) {
@@ -679,12 +678,15 @@ class AppStateController extends ChangeNotifier {
     }
   }
 
-  Future<void> handlePushActivation(PushMessage message) async {
-    final id = message.notificationId;
+  Future<void> handlePushActivation(PushMessage message) =>
+      handleNotificationActivation(message.notificationId);
+
+  Future<void> handleNotificationActivation(String? notificationId) async {
+    final id = canonicalNotificationId(notificationId);
     if (id == null) return;
     final credentials = authNotifier.credentials;
     if (credentials == null) {
-      _pendingPushActivations[id] = message;
+      _pendingNotificationActivations.add(id);
       return;
     }
     final notificationGeneration = _notificationSessionGeneration.current;
@@ -720,13 +722,14 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<void> _drainPendingPushActivations() async {
-    if (authNotifier.credentials == null || _pendingPushActivations.isEmpty) {
+    if (authNotifier.credentials == null ||
+        _pendingNotificationActivations.isEmpty) {
       return;
     }
-    final pending = _pendingPushActivations.values.toList(growable: false);
-    _pendingPushActivations.clear();
-    for (final message in pending) {
-      await handlePushActivation(message);
+    final pending = _pendingNotificationActivations.toList(growable: false);
+    _pendingNotificationActivations.clear();
+    for (final id in pending) {
+      await handleNotificationActivation(id);
     }
   }
 

--- a/flutter_client/lib/services/desktop_notification_presenter.dart
+++ b/flutter_client/lib/services/desktop_notification_presenter.dart
@@ -2,8 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter_local_notifications_linux/flutter_local_notifications_linux.dart';
-import 'package:flutter_local_notifications_windows/flutter_local_notifications_windows.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:m3u_tv/services/tv_notification_service.dart';
 
 typedef DesktopNotificationActivation =
@@ -63,7 +62,9 @@ class NativeDesktopNotificationPresenter
   bool _disposed = false;
 
   bool get _isSupported =>
-      _operatingSystem == 'linux' || _operatingSystem == 'windows';
+      _operatingSystem == 'linux' ||
+      _operatingSystem == 'windows' ||
+      _operatingSystem == 'macos';
 
   @override
   Future<void> initialize({
@@ -228,10 +229,54 @@ class WindowsDesktopNotificationBackend implements DesktopNotificationBackend {
   }) => _plugin.show(id: id, title: title, body: body, payload: payload);
 }
 
+class MacosDesktopNotificationBackend implements DesktopNotificationBackend {
+  MacosDesktopNotificationBackend({FlutterLocalNotificationsPlugin? plugin})
+    : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
+
+  static const _macosSettings = InitializationSettings(
+    macOS: DarwinInitializationSettings(),
+  );
+
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  @override
+  Future<void> initialize({
+    required String defaultActionName,
+    required void Function(String? payload) onActivation,
+  }) async {
+    final initialized = await _plugin.initialize(
+      settings: _macosSettings,
+      onDidReceiveNotificationResponse: (response) {
+        onActivation(response.payload);
+      },
+    );
+    if (initialized == false) {
+      throw StateError('macOS notification initialization failed');
+    }
+  }
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String? body,
+    required String payload,
+  }) => _plugin.show(
+    id: id,
+    title: title,
+    body: body,
+    notificationDetails: const NotificationDetails(
+      macOS: DarwinNotificationDetails(),
+    ),
+    payload: payload,
+  );
+}
+
 DesktopNotificationBackend _defaultBackend(String operatingSystem) =>
     switch (operatingSystem) {
       'linux' => LinuxDesktopNotificationBackend(),
       'windows' => WindowsDesktopNotificationBackend(),
+      'macos' => MacosDesktopNotificationBackend(),
       _ => _UnsupportedDesktopNotificationBackend(),
     };
 

--- a/flutter_client/lib/services/desktop_notification_presenter.dart
+++ b/flutter_client/lib/services/desktop_notification_presenter.dart
@@ -1,0 +1,244 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications_linux/flutter_local_notifications_linux.dart';
+import 'package:flutter_local_notifications_windows/flutter_local_notifications_windows.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart';
+
+typedef DesktopNotificationActivation =
+    Future<void> Function(String notificationId);
+
+abstract interface class DesktopNotificationPresenter {
+  Future<void> initialize({
+    required String defaultActionName,
+    required DesktopNotificationActivation onActivation,
+  });
+
+  Future<bool> present(TvNotificationItem item);
+}
+
+abstract interface class DesktopNotificationBackend {
+  Future<void> initialize({
+    required String defaultActionName,
+    required void Function(String? payload) onActivation,
+  });
+
+  Future<void> show({
+    required int id,
+    required String title,
+    required String? body,
+    required String payload,
+  });
+}
+
+class NativeDesktopNotificationPresenter
+    implements DesktopNotificationPresenter {
+  factory NativeDesktopNotificationPresenter({
+    String? operatingSystem,
+    DesktopNotificationBackend? backend,
+  }) {
+    final resolvedOperatingSystem = operatingSystem ?? _currentOperatingSystem;
+    return NativeDesktopNotificationPresenter._(
+      operatingSystem: resolvedOperatingSystem,
+      backend: backend ?? _defaultBackend(resolvedOperatingSystem),
+    );
+  }
+
+  NativeDesktopNotificationPresenter._({
+    required this._operatingSystem,
+    required this._backend,
+  });
+
+  final String _operatingSystem;
+  final DesktopNotificationBackend _backend;
+  final Set<String> _handledIds = <String>{};
+  Future<bool>? _initialization;
+
+  bool get _isSupported =>
+      _operatingSystem == 'linux' || _operatingSystem == 'windows';
+
+  @override
+  Future<void> initialize({
+    required String defaultActionName,
+    required DesktopNotificationActivation onActivation,
+  }) async {
+    if (!_isSupported) return;
+    _initialization ??= _initialize(
+      defaultActionName: defaultActionName,
+      onActivation: onActivation,
+    );
+    await _initialization;
+  }
+
+  Future<bool> _initialize({
+    required String defaultActionName,
+    required DesktopNotificationActivation onActivation,
+  }) async {
+    try {
+      await _backend.initialize(
+        defaultActionName: defaultActionName,
+        onActivation: (payload) {
+          final id = canonicalNotificationId(payload);
+          if (id != null) unawaited(onActivation(id));
+        },
+      );
+      return true;
+    } on Object catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  Future<bool> present(TvNotificationItem item) async {
+    if (!_isSupported) return false;
+    final initialization = _initialization;
+    if (initialization == null || !await initialization) return false;
+    if (!_handledIds.add(item.id)) return true;
+    try {
+      await _backend.show(
+        id: desktopNotificationId(item.id),
+        title: item.title,
+        body: item.body,
+        payload: item.id,
+      );
+      return true;
+    } on Object catch (_) {
+      return false;
+    }
+  }
+}
+
+class DesktopNotificationDispatcher {
+  DesktopNotificationDispatcher({
+    required this.presenter,
+    required this.onFallback,
+  });
+
+  final DesktopNotificationPresenter presenter;
+  final void Function(TvNotificationItem item) onFallback;
+
+  Future<void> initialize({
+    required String defaultActionName,
+    required DesktopNotificationActivation onActivation,
+  }) => presenter.initialize(
+    defaultActionName: defaultActionName,
+    onActivation: onActivation,
+  );
+
+  Future<void> dispatch(TvNotificationItem item) async {
+    if (!await presenter.present(item)) onFallback(item);
+  }
+}
+
+class LinuxDesktopNotificationBackend implements DesktopNotificationBackend {
+  LinuxDesktopNotificationBackend({
+    LinuxFlutterLocalNotificationsPlugin? plugin,
+  }) : _plugin = plugin ?? LinuxFlutterLocalNotificationsPlugin();
+
+  final LinuxFlutterLocalNotificationsPlugin _plugin;
+
+  @override
+  Future<void> initialize({
+    required String defaultActionName,
+    required void Function(String? payload) onActivation,
+  }) async {
+    final initialized = await _plugin.initialize(
+      settings: LinuxInitializationSettings(
+        defaultActionName: defaultActionName,
+      ),
+      onDidReceiveNotificationResponse: (response) {
+        onActivation(response.payload);
+      },
+    );
+    if (initialized == false) {
+      throw StateError('Linux notification initialization failed');
+    }
+  }
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String? body,
+    required String payload,
+  }) => _plugin.show(id: id, title: title, body: body, payload: payload);
+}
+
+class WindowsDesktopNotificationBackend implements DesktopNotificationBackend {
+  WindowsDesktopNotificationBackend({FlutterLocalNotificationsWindows? plugin})
+    : _plugin = plugin ?? FlutterLocalNotificationsWindows();
+
+  static const _windowsSettings = WindowsInitializationSettings(
+    appName: 'M3U TV',
+    appUserModelId: 'dev.sparkison.M3UTV',
+    guid: '6d47bd72-7948-4e9a-977b-2df18d38ab8c',
+  );
+
+  final FlutterLocalNotificationsWindows _plugin;
+
+  @override
+  Future<void> initialize({
+    required String defaultActionName,
+    required void Function(String? payload) onActivation,
+  }) async {
+    final initialized = await _plugin.initialize(
+      settings: _windowsSettings,
+      onDidReceiveNotificationResponse: (response) {
+        onActivation(response.payload);
+      },
+    );
+    if (!initialized) {
+      throw StateError('Windows notification initialization failed');
+    }
+  }
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String? body,
+    required String payload,
+  }) => _plugin.show(id: id, title: title, body: body, payload: payload);
+}
+
+DesktopNotificationBackend _defaultBackend(String operatingSystem) =>
+    switch (operatingSystem) {
+      'linux' => LinuxDesktopNotificationBackend(),
+      'windows' => WindowsDesktopNotificationBackend(),
+      _ => _UnsupportedDesktopNotificationBackend(),
+    };
+
+class _UnsupportedDesktopNotificationBackend
+    implements DesktopNotificationBackend {
+  @override
+  Future<void> initialize({
+    required String defaultActionName,
+    required void Function(String? payload) onActivation,
+  }) => Future<void>.error(UnsupportedError('Desktop notifications'));
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String? body,
+    required String payload,
+  }) => Future<void>.error(UnsupportedError('Desktop notifications'));
+}
+
+int desktopNotificationId(String canonicalId) {
+  final value = BigInt.parse(canonicalId.replaceAll('-', ''), radix: 16);
+  final folded = (value ^ (value >> 64)) & BigInt.from(0x7fffffff);
+  return folded.toInt();
+}
+
+String get _currentOperatingSystem {
+  if (kIsWeb) return 'web';
+  return switch (defaultTargetPlatform) {
+    TargetPlatform.android => 'android',
+    TargetPlatform.iOS => 'ios',
+    TargetPlatform.macOS => 'macos',
+    TargetPlatform.linux => 'linux',
+    TargetPlatform.windows => 'windows',
+    TargetPlatform.fuchsia => 'fuchsia',
+  };
+}

--- a/flutter_client/lib/services/desktop_notification_presenter.dart
+++ b/flutter_client/lib/services/desktop_notification_presenter.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications_linux/flutter_local_notifications_linux.dart';
@@ -15,6 +16,8 @@ abstract interface class DesktopNotificationPresenter {
   });
 
   Future<bool> present(TvNotificationItem item);
+
+  void dispose();
 }
 
 abstract interface class DesktopNotificationBackend {
@@ -49,10 +52,15 @@ class NativeDesktopNotificationPresenter
     required this._backend,
   });
 
+  static const _maxHandledIds = 500;
+
   final String _operatingSystem;
   final DesktopNotificationBackend _backend;
+  final Queue<String> _handledIdOrder = Queue<String>();
   final Set<String> _handledIds = <String>{};
   Future<bool>? _initialization;
+  String? _initializedActionName;
+  bool _disposed = false;
 
   bool get _isSupported =>
       _operatingSystem == 'linux' || _operatingSystem == 'windows';
@@ -62,8 +70,14 @@ class NativeDesktopNotificationPresenter
     required String defaultActionName,
     required DesktopNotificationActivation onActivation,
   }) async {
-    if (!_isSupported) return;
-    _initialization ??= _initialize(
+    if (!_isSupported || _disposed) return;
+    if (_initialization != null &&
+        _initializedActionName == defaultActionName) {
+      await _initialization;
+      return;
+    }
+    _initializedActionName = defaultActionName;
+    _initialization = _initialize(
       defaultActionName: defaultActionName,
       onActivation: onActivation,
     );
@@ -78,6 +92,7 @@ class NativeDesktopNotificationPresenter
       await _backend.initialize(
         defaultActionName: defaultActionName,
         onActivation: (payload) {
+          if (_disposed) return;
           final id = canonicalNotificationId(payload);
           if (id != null) unawaited(onActivation(id));
         },
@@ -90,10 +105,15 @@ class NativeDesktopNotificationPresenter
 
   @override
   Future<bool> present(TvNotificationItem item) async {
-    if (!_isSupported) return false;
+    if (!_isSupported || _disposed) return false;
     final initialization = _initialization;
     if (initialization == null || !await initialization) return false;
+    if (_disposed) return false;
     if (!_handledIds.add(item.id)) return true;
+    _handledIdOrder.addLast(item.id);
+    if (_handledIdOrder.length > _maxHandledIds) {
+      _handledIds.remove(_handledIdOrder.removeFirst());
+    }
     try {
       await _backend.show(
         id: desktopNotificationId(item.id),
@@ -105,6 +125,11 @@ class NativeDesktopNotificationPresenter
     } on Object catch (_) {
       return false;
     }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
   }
 }
 
@@ -128,6 +153,8 @@ class DesktopNotificationDispatcher {
   Future<void> dispatch(TvNotificationItem item) async {
     if (!await presenter.present(item)) onFallback(item);
   }
+
+  void dispose() => presenter.dispose();
 }
 
 class LinuxDesktopNotificationBackend implements DesktopNotificationBackend {
@@ -170,7 +197,7 @@ class WindowsDesktopNotificationBackend implements DesktopNotificationBackend {
 
   static const _windowsSettings = WindowsInitializationSettings(
     appName: 'M3U TV',
-    appUserModelId: 'dev.sparkison.M3UTV',
+    appUserModelId: 'dev.sparkison.tv',
     guid: '6d47bd72-7948-4e9a-977b-2df18d38ab8c',
   );
 

--- a/flutter_client/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/flutter_client/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import firebase_core
 import firebase_messaging
+import flutter_local_notifications
 import flutter_secure_storage_darwin
 import media_kit_libs_macos_video
 import media_kit_video
@@ -18,6 +19,7 @@ import wakelock_plus
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MediaKitLibsMacosVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitLibsMacosVideoPlugin"))
   MediaKitVideoPlugin.register(with: registry.registrar(forPlugin: "MediaKitVideoPlugin"))

--- a/flutter_client/macos/Podfile.lock
+++ b/flutter_client/macos/Podfile.lock
@@ -32,6 +32,8 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
+  - flutter_local_notifications (0.0.1):
+    - FlutterMacOS
   - flutter_secure_storage_darwin (10.0.0):
     - Flutter
     - FlutterMacOS
@@ -86,6 +88,7 @@ PODS:
 DEPENDENCIES:
   - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
   - firebase_messaging (from `Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos`)
+  - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - flutter_secure_storage_darwin (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
@@ -112,6 +115,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_core/macos
   firebase_messaging:
     :path: Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos
+  flutter_local_notifications:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   flutter_secure_storage_darwin:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_darwin/darwin
   FlutterMacOS:
@@ -137,6 +142,7 @@ SPEC CHECKSUMS:
   FirebaseCoreInternal: 6ab6a02c94446c026d2cf35cf5383842ebaa4992
   FirebaseInstallations: eb29ccbf64eaedf86fd5b2ccc7fabde567660b52
   FirebaseMessaging: 40017d7bc8457ee295b0f41d480a80fdabc9994e
+  flutter_local_notifications: 14e285ca39907db50704f7f46c9ab7a526bd7ead
   flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7

--- a/flutter_client/pubspec.lock
+++ b/flutter_client/pubspec.lock
@@ -387,8 +387,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  flutter_local_notifications_linux:
+  flutter_local_notifications:
     dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: "9375211fd7df9c070504ac4db7047c7fae857e238291433b770cfe696b5c357a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "22.2.0"
+  flutter_local_notifications_linux:
+    dependency: transitive
     description:
       name: flutter_local_notifications_linux
       sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
@@ -403,8 +411,16 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "12.1.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_local_notifications_windows:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: flutter_local_notifications_windows
       sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"

--- a/flutter_client/pubspec.lock
+++ b/flutter_client/pubspec.lock
@@ -387,6 +387,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications_linux:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.1"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "945a438a4779f3aca3a948718d8a4048cbe9f9c8c797492c00abd5d39112bf37"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.1.0"
+  flutter_local_notifications_windows:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter

--- a/flutter_client/pubspec.yaml
+++ b/flutter_client/pubspec.yaml
@@ -16,8 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.4.2
-  flutter_local_notifications_linux: ^8.0.1
-  flutter_local_notifications_windows: ^3.1.1
+  flutter_local_notifications: ^22.2.0
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^3.4.2

--- a/flutter_client/pubspec.yaml
+++ b/flutter_client/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.4.2
+  flutter_local_notifications_linux: ^8.0.1
+  flutter_local_notifications_windows: ^3.1.1
   flutter_localizations:
     sdk: flutter
   flutter_riverpod: ^3.4.2
@@ -72,4 +74,3 @@ flutter:
   assets:
     - assets/icons/
     - pubspec.yaml
-

--- a/flutter_client/test/release/desktop_notification_packaging_test.dart
+++ b/flutter_client/test/release/desktop_notification_packaging_test.dart
@@ -3,18 +3,31 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('desktop notification dependency is wired into Linux and Windows', () {
-    final pubspec = File('pubspec.yaml').readAsStringSync();
-    final lockfile = File('pubspec.lock').readAsStringSync();
-    final linuxCmake = File('linux/CMakeLists.txt').readAsStringSync();
-    final windowsCmake = File('windows/CMakeLists.txt').readAsStringSync();
+  test(
+    'desktop notification dependency is wired into Linux, Windows and macOS',
+    () {
+      final pubspec = File('pubspec.yaml').readAsStringSync();
+      final lockfile = File('pubspec.lock').readAsStringSync();
+      final linuxCmake = File('linux/CMakeLists.txt').readAsStringSync();
+      final windowsCmake = File('windows/CMakeLists.txt').readAsStringSync();
+      final macosRegistrant = File(
+        'macos/Flutter/GeneratedPluginRegistrant.swift',
+      ).readAsStringSync();
 
-    expect(pubspec, contains('flutter_local_notifications_linux: ^8.0.1'));
-    expect(pubspec, contains('flutter_local_notifications_windows: ^3.1.1'));
-    expect(lockfile, contains('flutter_local_notifications_linux:'));
-    expect(lockfile, contains('flutter_local_notifications_windows:'));
-    expect(linuxCmake, contains('generated_plugin_registrant.cc'));
-    expect(linuxCmake, contains('include(flutter/generated_plugins.cmake)'));
-    expect(windowsCmake, contains('include(flutter/generated_plugins.cmake)'));
-  });
+      expect(pubspec, contains('flutter_local_notifications: ^22.2.0'));
+      expect(lockfile, contains('flutter_local_notifications_linux:'));
+      expect(lockfile, contains('flutter_local_notifications_windows:'));
+      expect(linuxCmake, contains('generated_plugin_registrant.cc'));
+      expect(linuxCmake, contains('include(flutter/generated_plugins.cmake)'));
+      expect(
+        windowsCmake,
+        contains('include(flutter/generated_plugins.cmake)'),
+      );
+      expect(macosRegistrant, contains('import flutter_local_notifications'));
+      expect(
+        macosRegistrant,
+        contains('FlutterLocalNotificationsPlugin.register('),
+      );
+    },
+  );
 }

--- a/flutter_client/test/release/desktop_notification_packaging_test.dart
+++ b/flutter_client/test/release/desktop_notification_packaging_test.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('desktop notification dependency is wired into Linux and Windows', () {
+    final pubspec = File('pubspec.yaml').readAsStringSync();
+    final lockfile = File('pubspec.lock').readAsStringSync();
+    final linuxCmake = File('linux/CMakeLists.txt').readAsStringSync();
+    final windowsCmake = File('windows/CMakeLists.txt').readAsStringSync();
+
+    expect(pubspec, contains('flutter_local_notifications_linux: ^8.0.1'));
+    expect(pubspec, contains('flutter_local_notifications_windows: ^3.1.1'));
+    expect(lockfile, contains('flutter_local_notifications_linux:'));
+    expect(lockfile, contains('flutter_local_notifications_windows:'));
+    expect(linuxCmake, contains('generated_plugin_registrant.cc'));
+    expect(linuxCmake, contains('include(flutter/generated_plugins.cmake)'));
+    expect(windowsCmake, contains('include(flutter/generated_plugins.cmake)'));
+  });
+}

--- a/flutter_client/test/services/desktop_notification_presenter_test.dart
+++ b/flutter_client/test/services/desktop_notification_presenter_test.dart
@@ -1,0 +1,254 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/desktop_notification_presenter.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart';
+
+void main() {
+  group('NativeDesktopNotificationPresenter', () {
+    for (final operatingSystem in <String>['linux', 'windows']) {
+      test(
+        '$operatingSystem initializes and presents native content',
+        () async {
+          final backend = _FakeDesktopNotificationBackend();
+          final presenter = NativeDesktopNotificationPresenter(
+            operatingSystem: operatingSystem,
+            backend: backend,
+          );
+
+          await presenter.initialize(
+            defaultActionName: 'Open',
+            onActivation: (_) async {},
+          );
+          final presented = await presenter.present(_notification);
+
+          expect(presented, isTrue);
+          expect(backend.initializeCalls, 1);
+          expect(backend.defaultActionName, 'Open');
+          expect(backend.shown, <_ShownNotification>[
+            _ShownNotification(
+              id: desktopNotificationId(_notification.id),
+              title: _notification.title,
+              body: _notification.body,
+              payload: _notification.id,
+            ),
+          ]);
+        },
+      );
+    }
+
+    for (final operatingSystem in <String>[
+      'android',
+      'ios',
+      'tvos',
+      'macos',
+      'web',
+    ]) {
+      test('$operatingSystem is a native presentation no-op', () async {
+        final backend = _FakeDesktopNotificationBackend();
+        final presenter = NativeDesktopNotificationPresenter(
+          operatingSystem: operatingSystem,
+          backend: backend,
+        );
+
+        await presenter.initialize(
+          defaultActionName: 'Open',
+          onActivation: (_) async {},
+        );
+
+        expect(await presenter.present(_notification), isFalse);
+        expect(backend.initializeCalls, 0);
+        expect(backend.shown, isEmpty);
+      });
+    }
+
+    test('initialization failure preserves toast fallback', () async {
+      final backend = _FakeDesktopNotificationBackend()..failInitialize = true;
+      final fallback = <TvNotificationItem>[];
+      final dispatcher = DesktopNotificationDispatcher(
+        presenter: NativeDesktopNotificationPresenter(
+          operatingSystem: 'linux',
+          backend: backend,
+        ),
+        onFallback: fallback.add,
+      );
+
+      await dispatcher.initialize(
+        defaultActionName: 'Open',
+        onActivation: (_) async {},
+      );
+      await dispatcher.dispatch(_notification);
+
+      expect(backend.shown, isEmpty);
+      expect(fallback, <TvNotificationItem>[_notification]);
+    });
+
+    test('presentation failure preserves toast fallback', () async {
+      final backend = _FakeDesktopNotificationBackend()..failShow = true;
+      final fallback = <TvNotificationItem>[];
+      final dispatcher = DesktopNotificationDispatcher(
+        presenter: NativeDesktopNotificationPresenter(
+          operatingSystem: 'windows',
+          backend: backend,
+        ),
+        onFallback: fallback.add,
+      );
+
+      await dispatcher.initialize(
+        defaultActionName: 'Open',
+        onActivation: (_) async {},
+      );
+      await dispatcher.dispatch(_notification);
+
+      expect(backend.shown, isEmpty);
+      expect(fallback, <TvNotificationItem>[_notification]);
+    });
+
+    test(
+      'successful native presentation suppresses fallback exactly once',
+      () async {
+        final backend = _FakeDesktopNotificationBackend();
+        final fallback = <TvNotificationItem>[];
+        final dispatcher = DesktopNotificationDispatcher(
+          presenter: NativeDesktopNotificationPresenter(
+            operatingSystem: 'linux',
+            backend: backend,
+          ),
+          onFallback: fallback.add,
+        );
+
+        await dispatcher.initialize(
+          defaultActionName: 'Open',
+          onActivation: (_) async {},
+        );
+        await dispatcher.dispatch(_notification);
+        await dispatcher.dispatch(_notification);
+
+        expect(backend.shown, hasLength(1));
+        expect(fallback, isEmpty);
+      },
+    );
+
+    test('non-desktop dispatcher selects toast fallback', () async {
+      final fallback = <TvNotificationItem>[];
+      final dispatcher = DesktopNotificationDispatcher(
+        presenter: NativeDesktopNotificationPresenter(
+          operatingSystem: 'android',
+          backend: _FakeDesktopNotificationBackend(),
+        ),
+        onFallback: fallback.add,
+      );
+
+      await dispatcher.initialize(
+        defaultActionName: 'Open',
+        onActivation: (_) async {},
+      );
+      await dispatcher.dispatch(_notification);
+
+      expect(fallback, <TvNotificationItem>[_notification]);
+    });
+
+    test('activation accepts only a canonical ID payload', () async {
+      final backend = _FakeDesktopNotificationBackend();
+      final activated = <String>[];
+      final presenter = NativeDesktopNotificationPresenter(
+        operatingSystem: 'linux',
+        backend: backend,
+      );
+      await presenter.initialize(
+        defaultActionName: 'Open',
+        onActivation: (id) async => activated.add(id),
+      );
+
+      backend
+        ..activate(_notification.id.toUpperCase())
+        ..activate('not-a-notification-id')
+        ..activate(null);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(activated, <String>[_notification.id]);
+    });
+
+    test('notification ID mapping is stable and bounded', () {
+      final first = desktopNotificationId(_notification.id);
+
+      expect(desktopNotificationId(_notification.id), first);
+      expect(first, inInclusiveRange(0, 0x7fffffff));
+      expect(
+        desktopNotificationId('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'),
+        isNot(first),
+      );
+    });
+  });
+}
+
+const _notification = TvNotificationItem(
+  id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  channel: 'general',
+  title: 'Authoritative title',
+  body: 'Authoritative body',
+  status: 'info',
+);
+
+class _ShownNotification {
+  const _ShownNotification({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.payload,
+  });
+
+  final int id;
+  final String title;
+  final String? body;
+  final String payload;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _ShownNotification &&
+      other.id == id &&
+      other.title == title &&
+      other.body == body &&
+      other.payload == payload;
+
+  @override
+  int get hashCode => Object.hash(id, title, body, payload);
+}
+
+class _FakeDesktopNotificationBackend implements DesktopNotificationBackend {
+  int initializeCalls = 0;
+  String? defaultActionName;
+  bool failInitialize = false;
+  bool failShow = false;
+  void Function(String? payload)? _onActivation;
+  final List<_ShownNotification> shown = <_ShownNotification>[];
+
+  @override
+  Future<void> initialize({
+    required String defaultActionName,
+    required void Function(String? payload) onActivation,
+  }) async {
+    initializeCalls += 1;
+    this.defaultActionName = defaultActionName;
+    _onActivation = onActivation;
+    if (failInitialize) throw StateError('initialization failed');
+  }
+
+  @override
+  Future<void> show({
+    required int id,
+    required String title,
+    required String? body,
+    required String payload,
+  }) async {
+    if (failShow) throw StateError('presentation failed');
+    shown.add(
+      _ShownNotification(
+        id: id,
+        title: title,
+        body: body,
+        payload: payload,
+      ),
+    );
+  }
+
+  void activate(String? payload) => _onActivation?.call(payload);
+}

--- a/flutter_client/test/services/desktop_notification_presenter_test.dart
+++ b/flutter_client/test/services/desktop_notification_presenter_test.dart
@@ -167,6 +167,82 @@ void main() {
       expect(activated, <String>[_notification.id]);
     });
 
+    test('re-initializes the backend when the action name changes', () async {
+      final backend = _FakeDesktopNotificationBackend();
+      final presenter = NativeDesktopNotificationPresenter(
+        operatingSystem: 'linux',
+        backend: backend,
+      );
+
+      await presenter.initialize(
+        defaultActionName: 'Open',
+        onActivation: (_) async {},
+      );
+      await presenter.initialize(
+        defaultActionName: 'Open',
+        onActivation: (_) async {},
+      );
+      expect(backend.initializeCalls, 1);
+
+      await presenter.initialize(
+        defaultActionName: 'Öffnen',
+        onActivation: (_) async {},
+      );
+
+      expect(backend.initializeCalls, 2);
+      expect(backend.defaultActionName, 'Öffnen');
+    });
+
+    test('dispose suppresses further presentation and activation', () async {
+      final backend = _FakeDesktopNotificationBackend();
+      final activated = <String>[];
+      final presenter = NativeDesktopNotificationPresenter(
+        operatingSystem: 'linux',
+        backend: backend,
+      );
+      await presenter.initialize(
+        defaultActionName: 'Open',
+        onActivation: (id) async => activated.add(id),
+      );
+
+      presenter.dispose();
+      backend.activate(_notification.id);
+      await Future<void>.delayed(Duration.zero);
+      final presented = await presenter.present(_notification);
+
+      expect(activated, isEmpty);
+      expect(presented, isFalse);
+      expect(backend.shown, isEmpty);
+    });
+
+    test('handled ID de-duplication is bounded', () async {
+      final backend = _FakeDesktopNotificationBackend();
+      final presenter = NativeDesktopNotificationPresenter(
+        operatingSystem: 'linux',
+        backend: backend,
+      );
+      await presenter.initialize(
+        defaultActionName: 'Open',
+        onActivation: (_) async {},
+      );
+
+      final overflow = List<TvNotificationItem>.generate(
+        501,
+        (index) => _notificationWithId(
+          'bbbbbbbb-bbbb-4bbb-8bbb-${index.toRadixString(16).padLeft(12, '0')}',
+        ),
+      );
+      for (final item in overflow) {
+        await presenter.present(item);
+      }
+      expect(backend.shown, hasLength(501));
+
+      // The oldest handled ID should have been evicted, so it presents again.
+      await presenter.present(overflow.first);
+
+      expect(backend.shown, hasLength(502));
+    });
+
     test('notification ID mapping is stable and bounded', () {
       final first = desktopNotificationId(_notification.id);
 
@@ -182,6 +258,14 @@ void main() {
 
 const _notification = TvNotificationItem(
   id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  channel: 'general',
+  title: 'Authoritative title',
+  body: 'Authoritative body',
+  status: 'info',
+);
+
+TvNotificationItem _notificationWithId(String id) => TvNotificationItem(
+  id: id,
   channel: 'general',
   title: 'Authoritative title',
   body: 'Authoritative body',

--- a/flutter_client/test/services/desktop_notification_presenter_test.dart
+++ b/flutter_client/test/services/desktop_notification_presenter_test.dart
@@ -4,7 +4,7 @@ import 'package:m3u_tv/services/tv_notification_service.dart';
 
 void main() {
   group('NativeDesktopNotificationPresenter', () {
-    for (final operatingSystem in <String>['linux', 'windows']) {
+    for (final operatingSystem in <String>['linux', 'windows', 'macos']) {
       test(
         '$operatingSystem initializes and presents native content',
         () async {
@@ -35,13 +35,7 @@ void main() {
       );
     }
 
-    for (final operatingSystem in <String>[
-      'android',
-      'ios',
-      'tvos',
-      'macos',
-      'web',
-    ]) {
+    for (final operatingSystem in <String>['android', 'ios', 'tvos', 'web']) {
       test('$operatingSystem is a native presentation no-op', () async {
         final backend = _FakeDesktopNotificationBackend();
         final presenter = NativeDesktopNotificationPresenter(

--- a/flutter_client/test/services/notification_lifecycle_test.dart
+++ b/flutter_client/test/services/notification_lifecycle_test.dart
@@ -201,6 +201,27 @@ void main() {
       },
     );
 
+    test('ID-only activation uses authoritative unread state', () async {
+      final item = _item(id: _notificationId, channel: 'dvr');
+      final api = _FakeTvNotificationService(<TvNotificationItem>[item]);
+      final controller = _controller(api);
+      addTearDown(controller.dispose);
+      final destinations = <TvNotificationDestination>[];
+      final subscription = controller.notificationActivations.listen(
+        destinations.add,
+      );
+      addTearDown(subscription.cancel);
+
+      await controller.handleNotificationActivation(_notificationId);
+      await controller.handleNotificationActivation('malformed');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(api.fetchCalls, 1);
+      expect(destinations, <TvNotificationDestination>[
+        TvNotificationDestination.dvr,
+      ]);
+    });
+
     test('admin-only content fails closed for standard credentials', () async {
       final api = _FakeTvNotificationService(<TvNotificationItem>[
         const TvNotificationItem(

--- a/flutter_client/windows/flutter/generated_plugins.cmake
+++ b/flutter_client/windows/flutter/generated_plugins.cmake
@@ -11,6 +11,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  flutter_local_notifications_windows
   jni
 )
 


### PR DESCRIPTION
## Summary
- Present persisted and filtered TV notifications through native Linux and Windows desktop APIs.
- Fall back to the existing in-app toast when desktop initialization or presentation is unavailable or fails.
- Route ID-only native activation through the existing authoritative unread REST lookup and fixed destination mapping.
- Keep Firebase mobile push registration and all non-desktop presentation behavior unchanged.

## Runtime limitations
- Desktop notifications require the M3U TV process and its Reverb or REST synchronization to remain active. This does not provide terminated-process delivery.
- Linux notification tap callbacks require the app to be running because DBus activation is not implemented.
- Windows basic notifications work without MSIX. Active-notification retrieval and cancellation are not used and are not guaranteed without package identity.

## Verification
- RED: focused tests failed before implementation because the presenter, ID activation method, dependency, and desktop wiring were absent.
- `flutter pub get` passed.
- `dart format --output=none --set-exit-if-changed lib test` passed.
- `flutter analyze lib test` passed.
- Focused notification and packaging tests: 31 passed.
- `flutter test --concurrency=1`: 493 passed, 5 skipped.
- `./android/gradlew -p android :app:testDebugUnitTest`: BUILD SUCCESSFUL, 197 tasks, using the CI Firebase stub and removing it afterward.
- Linux release build and CI bundle assertions passed.
- Exact-head Linux and Windows CI builds passed.
- `git diff --check`, cached diff check, conflict-marker scan, credential scan, and changed-text U+2013/U+2014 scan passed.

Closes #101
