### PR TITLE
fix(player): preserve desktop video aspect ratio

### DIFF
--- a/flutter_client/linux/desktop_libmpv_backend.cc
+++ b/flutter_client/linux/desktop_libmpv_backend.cc
@@ -958,6 +958,7 @@ FlMethodResponse* Load(FlValue* args) {
   api.set_option_string(handle, "vo", "libmpv");
   api.set_option_string(handle, "hwdec", "auto-safe");
   api.set_option_string(handle, "idle", "yes");
+  api.set_option_string(handle, "keepaspect", "no");
   std::string user_agent = StringArg(args, "userAgent");
   if (!user_agent.empty()) api.set_option_string(handle, "user-agent", user_agent.c_str());
   std::string headers = HeaderString(args);

--- a/flutter_client/test/playback/player_aspect_ratio_test.dart
+++ b/flutter_client/test/playback/player_aspect_ratio_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/playback/player_adapter.dart';
+
+void main() {
+  group('playback aspect ratio', () {
+    test('uses explicit display ratio for non-square pixels', () {
+      expect(
+        playbackAspectRatioFromValues(
+          aspectRatio: 4 / 3,
+          width: 720,
+          height: 576,
+        ),
+        closeTo(4 / 3, 0.0001),
+      );
+    });
+
+    test('derives standard and ultrawide ratios from display dimensions', () {
+      expect(
+        playbackAspectRatioFromValues(width: 1920, height: 1080),
+        closeTo(16 / 9, 0.0001),
+      );
+      expect(
+        playbackAspectRatioFromValues(width: 1440, height: 1080),
+        closeTo(4 / 3, 0.0001),
+      );
+      expect(
+        playbackAspectRatioFromValues(width: 3840, height: 1608),
+        closeTo(3840 / 1608, 0.0001),
+      );
+    });
+  });
+}

--- a/flutter_client/test/playback/production_backend_policy_test.dart
+++ b/flutter_client/test/playback/production_backend_policy_test.dart
@@ -208,6 +208,34 @@ void main() {
       },
     );
 
+    test('desktop libmpv delegates aspect correction to Flutter', () {
+      final linuxBackend = File(
+        'linux/desktop_libmpv_backend.cc',
+      ).readAsStringSync();
+      final windowsBackend = File(
+        'windows/runner/desktop_libmpv_backend.cpp',
+      ).readAsStringSync();
+      final playerScreen = File(
+        'lib/features/player/player_screen.dart',
+      ).readAsStringSync();
+      const keepAspectOption =
+          'api.set_option_string(handle, "keepaspect", "no");';
+
+      for (final backend in <String>[linuxBackend, windowsBackend]) {
+        expect(backend, contains('constexpr uint32_t kTextureWidth = 1280;'));
+        expect(backend, contains('constexpr uint32_t kTextureHeight = 720;'));
+        final keepAspectIndex = backend.indexOf(keepAspectOption);
+        final initializeIndex = backend.indexOf('api.initialize(handle)');
+        expect(keepAspectIndex, isNonNegative);
+        expect(initializeIndex, greaterThan(keepAspectIndex));
+        expect(backend.split(keepAspectOption), hasLength(2));
+        expect(backend, contains('"video-params/aspect"'));
+      }
+
+      expect(playerScreen, contains('aspectRatio: _videoAspectRatio'));
+      expect(playerScreen, contains('aspectRatio: aspectRatio'));
+    });
+
     test('desktop libmpv load applies resume start position', () {
       final linuxBackend = File(
         'linux/desktop_libmpv_backend.cc',

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1148,15 +1148,46 @@ void main() {
           const PlaybackState(
             backend: PlaybackBackend.desktopLibmpv,
             status: PlaybackStatus.ready,
+            videoAspectRatio: 16 / 9,
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final initialTextureSize = tester.getSize(find.byType(Texture));
+        expect(initialTextureSize.width, moreOrLessEquals(1600));
+        expect(initialTextureSize.height, moreOrLessEquals(900));
+
+        adapter.emitState(
+          const PlaybackState(
+            backend: PlaybackBackend.desktopLibmpv,
+            status: PlaybackStatus.ready,
             videoAspectRatio: 4 / 3,
           ),
         );
         await tester.pump();
         await tester.pump();
 
-        final textureSize = tester.getSize(find.byType(Texture));
-        expect(textureSize.width, moreOrLessEquals(1200));
-        expect(textureSize.height, moreOrLessEquals(900));
+        final fourThreeTextureSize = tester.getSize(find.byType(Texture));
+        expect(fourThreeTextureSize.width, moreOrLessEquals(1200));
+        expect(fourThreeTextureSize.height, moreOrLessEquals(900));
+
+        adapter.emitState(
+          const PlaybackState(
+            backend: PlaybackBackend.desktopLibmpv,
+            status: PlaybackStatus.ready,
+            videoAspectRatio: 3840 / 1608,
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        final ultrawideTextureSize = tester.getSize(find.byType(Texture));
+        expect(ultrawideTextureSize.width, moreOrLessEquals(1600));
+        expect(
+          ultrawideTextureSize.height,
+          moreOrLessEquals(670, epsilon: 0.01),
+        );
       },
     );
 

--- a/flutter_client/windows/runner/desktop_libmpv_backend.cpp
+++ b/flutter_client/windows/runner/desktop_libmpv_backend.cpp
@@ -622,6 +622,7 @@ ProbeMap Load(const flutter::EncodableMap* args, HWND hwnd,
   api.set_option_string(handle, "vo", "libmpv");
   api.set_option_string(handle, "hwdec", "auto-safe");
   api.set_option_string(handle, "idle", "yes");
+  api.set_option_string(handle, "keepaspect", "no");
   const std::string user_agent = StringArg(args, "userAgent");
   if (!user_agent.empty()) api.set_option_string(handle, "user-agent", user_agent.c_str());
   const std::string headers = HeaderString(args);


### PR DESCRIPTION
## Summary

- disable libmpv internal aspect correction for the fixed 1280x720 Linux and Windows software textures
- keep the reported source display ratio as the single aspect correction applied by Flutter
- add regression coverage for 16:9, 4:3, 3840x1608 ultrawide, and explicit non-square-pixel display ratios
- verify Linux and Windows parity without changing Android, Apple, or MediaKit playback paths

## Root cause

The native desktop backends rendered into a fixed 16:9 software texture while libmpv preserved the source aspect ratio inside that texture. Flutter then constrained the same texture using the reported source display ratio, effectively applying aspect correction twice.

## Verification

- `dart format --output=show --set-exit-if-changed lib test`
- `flutter analyze lib test`
- `flutter test --concurrency=1`: 481 passed, 5 skipped
- `./android/gradlew -p android :app:testDebugUnitTest`
- Linux release build and runtime bundle dependency checks
- independent code review found no security concerns or logic errors

## Manual acceptance

Real-device playback should still be checked with normal 16:9, 4:3 or anamorphic, and 3840x1608 ultrawide media on Windows and Linux. Other supported platforms remain unchanged by this desktop-specific fix.

Closes #157
