### PR TITLE
fix: secure Trakt device authorization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,8 +148,7 @@ jobs:
       - name: Build APK
         run: |
           flutter build apk --release \
-            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} \
-            --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
+            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }}
         env:
           ANDROID_KEYSTORE_PATH: ../../upload-keystore.jks
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
@@ -258,8 +257,7 @@ jobs:
       - name: Build iOS IPA (unsigned)
         run: |
           flutter build ipa --release --no-codesign \
-            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} \
-            --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
+            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }}
 
       - name: Stage artifact
         # flutter build ipa --no-codesign creates an xcarchive, not a Payload IPA.
@@ -371,8 +369,7 @@ jobs:
       - name: Build tvOS (unsigned)
         run: |
           flutter-tvos build tvos --release \
-            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} \
-            --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
+            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }}
 
       - name: Package IPA
         # flutter-tvos build tvos creates an xcarchive; package the .app manually.
@@ -457,8 +454,7 @@ jobs:
           FLUTTER_XCODE_DEVELOPMENT_TEAM: ""
         run: |
           flutter build macos --release \
-            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} \
-            --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
+            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }}
 
       - name: Sign app bundle
         # Notarization requires: Developer ID Application cert, Hardened Runtime
@@ -574,8 +570,7 @@ jobs:
       - name: Build Linux app
         run: |
           flutter build linux --release \
-            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} \
-            --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
+            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }}
 
       - name: Verify Linux bundle
         run: |
@@ -781,8 +776,7 @@ jobs:
       - name: Build Windows app
         run: |
           flutter build windows --release `
-            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }} `
-            --dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
+            --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }}
 
       - name: Verify Windows bundle
         run: |

--- a/flutter_client/README.md
+++ b/flutter_client/README.md
@@ -1,4 +1,4 @@
-# M3U TV — Flutter Client
+# M3U TV - Flutter Client
 
 Flutter app for M3U TV targeting Android TV, iOS, macOS, Linux, Windows, and Apple TV (tvOS).
 
@@ -20,7 +20,7 @@ flutter analyze lib test
 flutter test
 ```
 
-Scope `format`/`analyze` to `lib test` rather than `.` — if you've run an iOS/macOS build locally, `ios/build/` and `macos/build/` contain vendored SPM checkouts (e.g. `firebase_messaging`) with their own `pubspec.yaml`, which the analyzer treats as separate projects to fully lint/type-check. `analyzer.exclude` globs can't suppress this once a directory has its own `pubspec.yaml`, so directory scoping is the only reliable fix.
+Scope `format`/`analyze` to `lib test` rather than `.` - if you've run an iOS/macOS build locally, `ios/build/` and `macos/build/` contain vendored SPM checkouts (e.g. `firebase_messaging`) with their own `pubspec.yaml`, which the analyzer treats as separate projects to fully lint/type-check. `analyzer.exclude` globs can't suppress this once a directory has its own `pubspec.yaml`, so directory scoping is the only reliable fix.
 
 ## Platform commands
 
@@ -44,7 +44,7 @@ If you hit `Package product 'firebase-core' requires minimum platform version 15
 export FLUTTER_SWIFT_PACKAGE_MANAGER=false
 ```
 
-This is a Flutter SDK limitation, not a project misconfig: Flutter hardcodes the auto-generated `FlutterGeneratedPluginSwiftPackage` wrapper's minimum iOS version to 13.0 regardless of `IPHONEOS_DEPLOYMENT_TARGET` (which is correctly 15.0 here), and `firebase_core`/`firebase_messaging` require 15.0. It regenerates on every `flutter clean`/`pub get`, so the error resurfaces even if you haven't touched anything. Disabling SPM routes all plugins — Firebase included, via its still-published podspec — through CocoaPods instead, which honors the Podfile's real `platform :ios, '15.0'`. CI (`release.yml`) sets this env var for the `build-ios` job already.
+This is a Flutter SDK limitation, not a project misconfig: Flutter hardcodes the auto-generated `FlutterGeneratedPluginSwiftPackage` wrapper's minimum iOS version to 13.0 regardless of `IPHONEOS_DEPLOYMENT_TARGET` (which is correctly 15.0 here), and `firebase_core`/`firebase_messaging` require 15.0. It regenerates on every `flutter clean`/`pub get`, so the error resurfaces even if you haven't touched anything. Disabling SPM routes all plugins - Firebase included, via its still-published podspec - through CocoaPods instead, which honors the Podfile's real `platform :ios, '15.0'`. CI (`release.yml`) sets this env var for the `build-ios` job already.
 
 ### macOS / Linux / Windows
 
@@ -68,57 +68,53 @@ flutter-tvos build tvos --simulator --debug   # build only
 
 ## Release builds
 
-All release builds require the Trakt credentials passed via `--dart-define`.
-Set the environment variables first (see [Trakt setup](#trakt-setup)), then use the commands below.
+All release builds require the public Trakt client id passed via `--dart-define`.
+Set the environment variable first (see [Trakt setup](#trakt-setup)), then use the commands below.
 
 ### Android TV / Android (release APK / App Bundle)
 
 ```bash
 # App Bundle (Play Store / sideload)
 flutter build appbundle --release \
-  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-  --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET
+  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID
 
 # APK (direct sideload)
 flutter build apk --release \
-  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-  --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET
+  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID
 ```
 
-`release.yml` builds iOS and tvOS on every tag push too, but only as **unsigned** sideload artifacts attached to the GitHub Release (see `build-ios`/`build-tvos` jobs) — it does not submit to App Store Connect. Actual App Store/TestFlight submission for iOS and tvOS is a manual step you run locally, below.
+`release.yml` builds iOS and tvOS on every tag push too, but only as **unsigned** sideload artifacts attached to the GitHub Release (see `build-ios`/`build-tvos` jobs) - it does not submit to App Store Connect. Actual App Store/TestFlight submission for iOS and tvOS is a manual step you run locally, below.
 
 ### iOS (manual App Store submission)
 
-`--dart-define` values are baked into `ios/Flutter/Generated.xcconfig` only as a side effect of a CLI `flutter build`/`flutter run` — if you skip straight to Xcode's **Archive** action without running one first, the archive silently ships without the Trakt credentials (whatever was last written to that file, possibly nothing).
+`--dart-define` values are baked into `ios/Flutter/Generated.xcconfig` only as a side effect of a CLI `flutter build`/`flutter run` - if you skip straight to Xcode's **Archive** action without running one first, the archive silently ships without the Trakt credentials (whatever was last written to that file, possibly nothing).
 
 Build, archive, and export in one step from the CLI:
 
 ```bash
 flutter build ipa --release \
   --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-  --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET \
   --export-options-plist=ios/ExportOptions.plist
 ```
 
-This produces `build/ios/ipa/Runner.ipa` — upload it with [Transporter](https://apps.apple.com/app/transporter/id1450874784) or `xcrun altool --upload-app`.
+This produces `build/ios/ipa/Runner.ipa` - upload it with [Transporter](https://apps.apple.com/app/transporter/id1450874784) or `xcrun altool --upload-app`.
 
 Prefer Xcode's Organizer instead? Run the `flutter build ipa` command above first (so the defines are baked in and the archive already exists at `build/ios/archive/Runner.xcarchive`), then open it in Xcode and **Distribute App → App Store Connect**. Do not archive directly from a bare Xcode session that skipped the CLI step.
 
-`ios/ExportOptions.plist` (method `app-store-connect`, your Team ID) is checked into the repo. Use `app-store-connect`, not the older `app-store` value — Xcode 26 treats it as deprecated and `flutter build ipa`'s IPA-export step fails silently on it (`xcodebuild -exportArchive` alone still works either way, but the wrapper doesn't).
+`ios/ExportOptions.plist` (method `app-store-connect`, your Team ID) is checked into the repo. Use `app-store-connect`, not the older `app-store` value - Xcode 26 treats it as deprecated and `flutter build ipa`'s IPA-export step fails silently on it (`xcodebuild -exportArchive` alone still works either way, but the wrapper doesn't).
 
 ### Apple TV / tvOS (manual App Store submission)
 
-This project signs the tvOS target **Manually**, pinned to the `M3U TV (tvOS)` distribution profile (Signing & Capabilities in Xcode) — that's the config that has actually produced working App Store submissions. `flutter-tvos build tvos --release`, however, always forces `CODE_SIGN_STYLE=Automatic` on the `xcodebuild` invocation it runs internally, with no way to opt out — so running it end-to-end **will fail** with `Runner has conflicting provisioning settings`, unrelated to whether your Apple ID is signed into Xcode.
+This project signs the tvOS target **Manually**, pinned to the `M3U TV (tvOS)` distribution profile (Signing & Capabilities in Xcode) - that's the config that has actually produced working App Store submissions. `flutter-tvos build tvos --release`, however, always forces `CODE_SIGN_STYLE=Automatic` on the `xcodebuild` invocation it runs internally, with no way to opt out - so running it end-to-end **will fail** with `Runner has conflicting provisioning settings`, unrelated to whether your Apple ID is signed into Xcode.
 
 Run it anyway, for one reason only: the Dart AOT compile step (where `--dart-define` values get baked in) completes and writes `tvos/Flutter/App.framework` to disk *before* that incompatible `xcodebuild` call runs, so the framework comes out correct even though the command as a whole reports failure:
 
 ```bash
 flutter-tvos build tvos --release \
-  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-  --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET
+  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID
 ```
 
-Ignore the failure output — a fresh `tvos/Flutter/App.framework` with the Trakt credentials compiled in is what you need, and it's already there. Then open `tvos/Runner.xcworkspace` in Xcode and **Product → Archive → Distribute App**, exactly as before; the project's own "Embed App.framework" build phase picks up the file that's already on disk and doesn't re-run flutter-tvos itself, so the Manual-signing Archive path is untouched by any of this.
+Ignore the failure output. A fresh `tvos/Flutter/App.framework` with the Trakt client id compiled in is what you need, and it's already there. Then open `tvos/Runner.xcworkspace` in Xcode and **Product → Archive → Distribute App**, exactly as before; the project's own "Embed App.framework" build phase picks up the file that's already on disk and doesn't re-run flutter-tvos itself, so the Manual-signing Archive path is untouched by any of this.
 
 If you'd rather not rely on flutter-tvos's `build tvos` reporting a "failure" that isn't one, the fully-CLI archive/export path also works once you're archiving (not just building):
 
@@ -137,46 +133,43 @@ xcodebuild -exportArchive \
 
 Upload `build/export/Runner.ipa` the same way as iOS. `tvos/ExportOptions.plist` is checked into the repo alongside the iOS one.
 
-If a plain `xcodebuild archive`/`-allowProvisioningUpdates` run (not `flutter-tvos build`) ever reports `Communication with Apple failed: Your team has no devices...`, that's not really about registering a device — `flutter-tvos` (and a bare `xcodebuild` invocation with no `DEVELOPMENT_TEAM` build setting) resolves the team from whichever certificate your local keychain happens to surface first, which can be a different team than this project's. Pass the right one explicitly and it goes away:
+If a plain `xcodebuild archive`/`-allowProvisioningUpdates` run (not `flutter-tvos build`) ever reports `Communication with Apple failed: Your team has no devices...`, that's not really about registering a device - `flutter-tvos` (and a bare `xcodebuild` invocation with no `DEVELOPMENT_TEAM` build setting) resolves the team from whichever certificate your local keychain happens to surface first, which can be a different team than this project's. Pass the right one explicitly and it goes away:
 
 ```bash
 export DEVELOPMENT_TEAM=5AMT94T836   # this project's team ID
 ```
 
-> **Run `flutter-tvos run -d <simulator-id>` at least once before opening Xcode for simulator debugging.** `flutter-tvos` swaps the entire `Flutter.xcframework` per build mode/environment (debug/release × device/simulator); a stale one left over from a prior release build breaks simulator runs in Xcode with a "no library for this platform" error. `flutter-tvos build tvos --release` (used above to bake in dart-defines) doesn't fix this itself — its own `xcodebuild` step always fails against this project's Manual-signing config, so it never gets to regenerate the simulator slice. If you need to go back to simulator debugging afterward, run `flutter-tvos run -d <simulator-id>` again to restore it. See the [tvOS setup section in the root README](../README.md#apple-tv-tvos) for one-time install instructions. Likewise, never run `pod install` by hand in `tvos/` — it reads the plugin list from `.flutter-plugins-dependencies`, which is only populated correctly as a side effect of `flutter-tvos build`/`run`; running `pod install` standalone (before that list is populated) silently strips tvOS-only pods like `sqflite_tvos` from `Podfile.lock`. If pods look wrong, re-run `flutter-tvos build tvos`/`run` — don't call `pod install` directly.
+> **Run `flutter-tvos run -d <simulator-id>` at least once before opening Xcode for simulator debugging.** `flutter-tvos` swaps the entire `Flutter.xcframework` per build mode/environment (debug/release × device/simulator); a stale one left over from a prior release build breaks simulator runs in Xcode with a "no library for this platform" error. `flutter-tvos build tvos --release` (used above to bake in dart-defines) doesn't fix this itself - its own `xcodebuild` step always fails against this project's Manual-signing config, so it never gets to regenerate the simulator slice. If you need to go back to simulator debugging afterward, run `flutter-tvos run -d <simulator-id>` again to restore it. See the [tvOS setup section in the root README](../README.md#apple-tv-tvos) for one-time install instructions. Likewise, never run `pod install` by hand in `tvos/` - it reads the plugin list from `.flutter-plugins-dependencies`, which is only populated correctly as a side effect of `flutter-tvos build`/`run`; running `pod install` standalone (before that list is populated) silently strips tvOS-only pods like `sqflite_tvos` from `Podfile.lock`. If pods look wrong, re-run `flutter-tvos build tvos`/`run` - don't call `pod install` directly.
 
-### macOS (via GitHub Actions — not the Mac App Store)
+### macOS (via GitHub Actions - not the Mac App Store)
 
-Unlike iOS/tvOS/Android, macOS release builds are never submitted to an app store by hand. Every `v*.*.*` tag push runs the `build-macos` job in `.github/workflows/release.yml` end-to-end: release build, code-sign with the Developer ID Application certificate, notarize via `notarytool`, staple the ticket, and publish the DMG straight to the GitHub Release — the same all-desktop-via-CI path Linux and Windows use below. There is no separate manual macOS release step.
+Unlike iOS/tvOS/Android, macOS release builds are never submitted to an app store by hand. Every `v*.*.*` tag push runs the `build-macos` job in `.github/workflows/release.yml` end-to-end: release build, code-sign with the Developer ID Application certificate, notarize via `notarytool`, staple the ticket, and publish the DMG straight to the GitHub Release - the same all-desktop-via-CI path Linux and Windows use below. There is no separate manual macOS release step.
 
 To build a local macOS release for testing only (not signed or notarized, so not distributable):
 
 ```bash
 flutter build macos --release \
-  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-  --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET
+  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID
 ```
 
 ### Linux
 
 ```bash
 flutter build linux --release \
-  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-  --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET
+  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID
 ```
 
 ### Windows
 
 ```bash
 flutter build windows --release \
-  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-  --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET
+  --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID
 ```
 
 ## Updating icons and splash screens
 
 All platform icons and splash screens are generated from the SVG source at `../logo.svg`.
-Do not hand-edit the generated PNGs — run the script instead.
+Do not hand-edit the generated PNGs - run the script instead.
 
 ### Prerequisites
 
@@ -193,9 +186,9 @@ bash scripts/setup-icons.sh
 This script:
 1. Renders `logo.svg` → transparent PNGs at the required sizes
 2. Builds `assets/icons/icon.png` (opaque, for iOS/macOS/Windows) and `adaptive-icon.png` / `splash-icon.png` (transparent)
-3. Runs `dart run flutter_launcher_icons` — Android, iOS, macOS, Web, Windows, Linux
-4. Runs `dart run flutter_native_splash:create` — Android + iOS splash screens
-5. Generates the **tvOS layered icons** (Back / Middle / Front layers for the parallax effect) and the **Top Shelf image** — these are not covered by `flutter_launcher_icons`
+3. Runs `dart run flutter_launcher_icons` - Android, iOS, macOS, Web, Windows, Linux
+4. Runs `dart run flutter_native_splash:create` - Android + iOS splash screens
+5. Generates the **tvOS layered icons** (Back / Middle / Front layers for the parallax effect) and the **Top Shelf image** - these are not covered by `flutter_launcher_icons`
 
 After running, rebuild the tvOS target in Xcode to pick up the refreshed icons.
 
@@ -203,13 +196,13 @@ After running, rebuild the tvOS target in Xcode to pick up the refreshed icons.
 
 | Asset | Size |
 |---|---|
-| App Icon — Large (focused) | 1280 × 768 px per layer |
-| App Icon — Small (home shelf) | 400 × 240 px (1x), 800 × 480 px (2x) per layer |
+| App Icon - Large (focused) | 1280 × 768 px per layer |
+| App Icon - Small (home shelf) | 400 × 240 px (1x), 800 × 480 px (2x) per layer |
 | Top Shelf Image | 2320 × 720 px (Wide) |
 
 ## Generating store screenshots
 
-Store-ready screenshots and marketing assets are generated from the source images in `screenshots/app-screenshots/` and the SVG logo at `../logo.svg`. Do not hand-edit the output files — run the script instead.
+Store-ready screenshots and marketing assets are generated from the source images in `screenshots/app-screenshots/` and the SVG logo at `../logo.svg`. Do not hand-edit the output files - run the script instead.
 
 ### Prerequisites
 
@@ -228,7 +221,7 @@ Output is written to `screenshots/store/` with the following structure:
 | Platform | Directory | Notes |
 |---|---|---|
 | Apple tvOS | `apple/tvos/1920x1080/` | Required for all submissions |
-| Apple tvOS 4K | `apple/tvos/3840x2160/` | Optional — copied from source |
+| Apple tvOS 4K | `apple/tvos/3840x2160/` | Optional - copied from source |
 | Apple iPhone 6.7" | `apple/ios/6.7in-1290x2796/` | Required for iPhone 14+/15+ |
 | Apple iPhone 6.5" | `apple/ios/6.5in-1242x2688/` | Required for older iPhones |
 | Apple iPhone 5.5" | `apple/ios/5.5in-1242x2208/` | Optional legacy device class |
@@ -236,8 +229,8 @@ Output is written to `screenshots/store/` with the following structure:
 | Android TV | `google/android-tv/1920x1080/` | Required |
 | Android TV (legacy) | `google/android-tv/1280x720/` | Optional |
 | Android Phone | `google/android-phone/1080x2340/` | |
-| Google Play Feature Graphic | `google/android-feature-graphic/feature-graphic.png` | Required — single 1024 × 500 image |
-| Android TV Banner | `google/android-tv-banner/tv-banner.png` | Required for TV listing — 1280 × 720 |
+| Google Play Feature Graphic | `google/android-feature-graphic/feature-graphic.png` | Required - single 1024 × 500 image |
+| Android TV Banner | `google/android-tv-banner/tv-banner.png` | Required for TV listing - 1280 × 720 |
 
 The feature graphic and TV banner are generated from `../logo.svg` on the app's diagonal gradient background (`#1a1528` → `#09090b`) rather than from screenshots.
 
@@ -251,7 +244,7 @@ The feature graphic and TV banner are generated from `../logo.svg` on the app's 
 
 ## Trakt setup
 
-Trakt credentials are injected at compile time via `--dart-define` and are never stored in source control.
+Trakt uses a public client id for device authorization in this app. It is injected at compile time via `--dart-define` and is not stored in source control.
 
 1. Register an app at <https://trakt.tv/oauth/applications>
    - Redirect URI: `urn:ietf:wg:oauth:2.0:oob`
@@ -259,32 +252,28 @@ Trakt credentials are injected at compile time via `--dart-define` and are never
 2. Add to your shell profile (`~/.zshrc` or `~/.zprofile`):
    ```bash
    export TRAKT_CLIENT_ID="your_client_id"
-   export TRAKT_CLIENT_SECRET="your_client_secret"
    ```
 3. Re-source your profile: `source ~/.zshrc`
-4. Pass the defines on every `flutter run` / `flutter build`:
+4. Pass the define on every `flutter run` / `flutter build`:
    ```bash
    flutter run \
      --dart-define=TRAKT_CLIENT_ID=$TRAKT_CLIENT_ID \
-     --dart-define=TRAKT_CLIENT_SECRET=$TRAKT_CLIENT_SECRET \
      -d <device-id>
    ```
 
-For CI (GitHub Actions), store `TRAKT_CLIENT_ID` and `TRAKT_CLIENT_SECRET` as repository secrets and reference them in your workflow:
+For CI (GitHub Actions), store `TRAKT_CLIENT_ID` as a repository secret and reference it in your workflow:
 
 ```yaml
 --dart-define=TRAKT_CLIENT_ID=${{ secrets.TRAKT_CLIENT_ID }}
---dart-define=TRAKT_CLIENT_SECRET=${{ secrets.TRAKT_CLIENT_SECRET }}
 ```
 
 ## Developer dart-defines
 
-These compile-time flags are for local development and debugging. Pass them via `--dart-define` — they default to off and are never required for normal builds.
+These compile-time flags are for local development and debugging. Pass them via `--dart-define` - they default to off and are never required for normal builds.
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `TRAKT_CLIENT_ID` | _(empty)_ | Trakt API client ID — required for Trakt scrobbling. See [Trakt setup](#trakt-setup). |
-| `TRAKT_CLIENT_SECRET` | _(empty)_ | Trakt API client secret — required for Trakt scrobbling. See [Trakt setup](#trakt-setup). |
+| `TRAKT_CLIENT_ID` | _(empty)_ | Trakt API client ID - required for Trakt scrobbling. See [Trakt setup](#trakt-setup). |
 | `M3U_TV_SHOW_PLAYBACK_DIAGNOSTICS` | `false` | Renders the in-player backend diagnostics panel and fallback reason badge. Useful when debugging playback fallback behaviour. |
 
 Example enabling diagnostics on a debug run:
@@ -304,7 +293,7 @@ lib/
   l10n/           ARB source files + generated AppLocalizations
   navigation/     Router, route names, PlayerArgs
   playback/       Platform playback adapters and orchestrator
-  providers/      Riverpod providers (app_providers.dart — single source of truth)
+  providers/      Riverpod providers (app_providers.dart - single source of truth)
   services/       Domain models, Xtream API, EPG, AppStateController
   shared/         Reusable UI widgets
 tvos/             Apple TV (tvOS) Xcode runner
@@ -321,7 +310,7 @@ State is managed with **Riverpod 2**. The key split:
 | Concern | Who handles it |
 |---|---|
 | Reactive data reads (channels, isConfigured, etc.) | Riverpod providers in `lib/providers/app_providers.dart` |
-| Business logic / mutations (connect, disconnect, etc.) | `AppStateController` — called via callbacks passed from `AppShell` |
+| Business logic / mutations (connect, disconnect, etc.) | `AppStateController` - called via callbacks passed from `AppShell` |
 | Service instances (EPG, favorites, etc.) | `AppStateController` owns them; providers expose stable refs via `ref.read` |
 
 **The rule:** feature screens extend `ConsumerStatefulWidget` and read all display data via `ref.watch(someProvider)`. They never hold or accept an `AppStateController` reference. Actions arrive as typed callbacks in the constructor.
@@ -334,7 +323,7 @@ The app is fully localized using Flutter `gen_l10n`. Supported languages: **Engl
 
 ### Adding or updating strings
 
-1. Edit `lib/l10n/app_en.arb` (source of truth) — add the new key and English value.
+1. Edit `lib/l10n/app_en.arb` (source of truth) - add the new key and English value.
 2. Add the translated key to all other ARB files (`app_de.arb`, `app_es.arb`, `app_fr.arb`, `app_zh.arb`).
 3. Regenerate:
    ```bash

--- a/flutter_client/lib/services/trakt_service.dart
+++ b/flutter_client/lib/services/trakt_service.dart
@@ -1,15 +1,19 @@
+// ignore_for_file: prefer_initializing_formals
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 
+import 'package:m3u_tv/services/async_lifecycle.dart';
 import 'package:m3u_tv/services/secure_storage.dart';
 
-// Register your app at https://trakt.tv/oauth/applications and fill in these
-// values before publishing. The secret is required for the device token exchange.
-const _kClientId = String.fromEnvironment('TRAKT_CLIENT_ID');
-const _kClientSecret = String.fromEnvironment('TRAKT_CLIENT_SECRET');
+// Register your public app at https://trakt.tv/oauth/applications and pass the
+// client id with TRAKT_CLIENT_ID when building.
+const _clientIdFromEnvironment = String.fromEnvironment('TRAKT_CLIENT_ID');
 
 const _kApi = 'https://api.trakt.tv';
 const _kKeyAccess = 'trakt_access_token';
@@ -30,34 +34,91 @@ class TraktPendingAuth {
   final String deviceCode;
 }
 
+typedef TraktTransport = Future<TraktResponse> Function(TraktRequest request);
+typedef TraktCodeVerifierFactory = String Function();
+
+String _generateCodeVerifier() {
+  final random = Random.secure();
+  final bytes = List<int>.generate(32, (_) => random.nextInt(256));
+  return base64UrlEncode(bytes).replaceAll('=', '');
+}
+
+String _codeChallenge(String verifier) => base64UrlEncode(
+  sha256.convert(ascii.encode(verifier)).bytes,
+).replaceAll('=', '');
+
+class TraktRequest {
+  const TraktRequest({
+    required this.path,
+    required this.body,
+    this.accessToken,
+  });
+
+  final String path;
+  final Map<String, Object> body;
+  final String? accessToken;
+}
+
+class TraktResponse {
+  const TraktResponse(this.statusCode, this.body);
+
+  final int statusCode;
+  final Map<String, Object?> body;
+}
+
 /// Manages Trakt OAuth via the TV device-code flow.
 ///
 /// Call `init` once after construction to restore a persisted session.
-/// Call `startDeviceAuth` to begin the flow — the UI should display
+/// Call `startDeviceAuth` to begin the flow. The UI should display
 /// `pending.userCode` and `pending.verificationUrl` and show a spinner.
 /// The service polls automatically and transitions to
 /// `TraktAuthStatus.connected` on success.
 class TraktService extends ChangeNotifier {
-  TraktService({required this._storage});
+  // Keep the public constructor parameter names stable for callers.
+  TraktService({
+    required SecureStorage storage,
+    String clientId = _clientIdFromEnvironment,
+    TraktTransport? transport,
+    TraktCodeVerifierFactory? codeVerifierFactory,
+  }) : _storage = storage,
+       _clientId = clientId,
+       _transport = transport,
+       _codeVerifierFactory = codeVerifierFactory ?? _generateCodeVerifier;
 
   final SecureStorage _storage;
+  final String _clientId;
+  final TraktTransport? _transport;
+  final TraktCodeVerifierFactory _codeVerifierFactory;
   final _http = HttpClient();
 
   TraktAuthStatus _status = TraktAuthStatus.disconnected;
   TraktPendingAuth? _pending;
   Timer? _pollTimer;
   String? _accessToken;
+  String? _codeVerifier;
+  Duration _pollInterval = Duration.zero;
+  DateTime? _deviceCodeExpiresAt;
+  final _tokenQueue = SerialQueue();
+  var _authAttempt = 0;
+  var _disposed = false;
 
   TraktAuthStatus get status => _status;
   TraktPendingAuth? get pending => _pending;
 
-  // False when the developer hasn't yet filled in the client credentials.
-  bool get isConfigured => _kClientId.isNotEmpty;
+  @visibleForTesting
+  Duration get pollIntervalForTesting => _pollInterval;
+
+  // False when the public client id was not supplied.
+  bool get isConfigured => _clientId.isNotEmpty;
 
   Future<void> init() async {
-    _accessToken = await _storage.read(_kKeyAccess);
+    final attempt = _authAttempt;
+    final accessToken = await _storage.read(_kKeyAccess);
+    if (_disposed || attempt != _authAttempt) return;
+    _accessToken = accessToken;
     if (_accessToken == null) return;
     final expiryStr = await _storage.read(_kKeyExpiry);
+    if (_disposed || attempt != _authAttempt) return;
     final expiry = int.tryParse(expiryStr ?? '');
     final nowEpoch = DateTime.now().millisecondsSinceEpoch ~/ 1000;
     if (expiry != null && expiry > nowEpoch + 60) {
@@ -65,58 +126,112 @@ class TraktService extends ChangeNotifier {
     } else {
       await _tryRefresh();
     }
+    if (_disposed || attempt != _authAttempt) return;
     notifyListeners();
   }
 
   Future<void> startDeviceAuth() async {
-    if (!isConfigured) return;
+    if (!isConfigured || _disposed) return;
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    final attempt = ++_authAttempt;
+    final verifier = _codeVerifierFactory();
+    _codeVerifier = verifier;
+    _pending = null;
     _status = TraktAuthStatus.pending;
     notifyListeners();
     try {
-      final data = await _post('/oauth/device/code', {'client_id': _kClientId});
+      final data = await _post('/oauth/device/code', {
+        'client_id': _clientId,
+        'code_challenge': _codeChallenge(verifier),
+        'code_challenge_method': 'S256',
+      });
+      if (_disposed || attempt != _authAttempt) return;
       _pending = TraktPendingAuth(
         userCode: '${data['user_code'] ?? ''}',
         verificationUrl: '${data['verification_url'] ?? ''}',
         deviceCode: '${data['device_code'] ?? ''}',
       );
       final interval = (data['interval'] as num?)?.toInt() ?? 5;
+      final expiresIn = (data['expires_in'] as num?)?.toInt() ?? 600;
+      _pollInterval = Duration(seconds: interval);
+      _deviceCodeExpiresAt = DateTime.now().add(
+        Duration(seconds: expiresIn),
+      );
       notifyListeners();
-      _pollTimer = Timer.periodic(Duration(seconds: interval), (_) => _poll());
+      _schedulePoll(attempt);
     } on Object catch (_) {
+      if (_disposed || attempt != _authAttempt) return;
+      _clearPendingAttempt();
       _status = TraktAuthStatus.disconnected;
-      _pending = null;
       notifyListeners();
     }
   }
 
-  Future<void> _poll() async {
-    if (_status == TraktAuthStatus.connected) return;
+  @visibleForTesting
+  Future<void> pollForTesting() => _poll(_authAttempt);
+
+  void _schedulePoll(int attempt) {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    if (_disposed ||
+        attempt != _authAttempt ||
+        _status != TraktAuthStatus.pending) {
+      return;
+    }
+    final expiresAt = _deviceCodeExpiresAt;
+    if (expiresAt == null) return;
+    final remaining = expiresAt.difference(DateTime.now());
+    if (remaining <= Duration.zero) {
+      cancelAuth();
+      return;
+    }
+    final delay = remaining < _pollInterval ? remaining : _pollInterval;
+    _pollTimer = Timer(delay, () => unawaited(_poll(attempt)));
+  }
+
+  Future<void> _poll(int attempt) async {
+    if (_disposed || attempt != _authAttempt) return;
+    if (_status != TraktAuthStatus.pending) return;
+    final expiresAt = _deviceCodeExpiresAt;
+    if (expiresAt == null || !DateTime.now().isBefore(expiresAt)) {
+      cancelAuth();
+      return;
+    }
+    _pollTimer?.cancel();
+    _pollTimer = null;
     final code = _pending?.deviceCode;
-    if (code == null) return;
+    final verifier = _codeVerifier;
+    if (code == null || verifier == null) return;
     try {
       final data = await _post(
         '/oauth/device/token',
         {
           'code': code,
-          'client_id': _kClientId,
-          'client_secret': _kClientSecret,
+          'client_id': _clientId,
+          'code_verifier': verifier,
         },
         isPollEndpoint: true,
       );
-      await _saveTokens(data);
+      if (_disposed || attempt != _authAttempt) return;
+      await _saveTokens(data, expectedAttempt: attempt);
     } on _TraktPendingException {
-      // authorization_pending — keep polling
+      _schedulePoll(attempt);
+    } on _TraktSlowDownException {
+      _pollInterval += const Duration(seconds: 5);
+      _schedulePoll(attempt);
     } on Object catch (_) {
-      // Guard against a stale poll that fires after _saveTokens already
-      // completed (timer cancel and token write are async — a queued callback
-      // can still execute and receive a 409 "already used" from Trakt).
-      if (_status != TraktAuthStatus.connected) {
+      // A queued callback from an old attempt must not cancel current auth.
+      if (!_disposed &&
+          attempt == _authAttempt &&
+          _status != TraktAuthStatus.connected) {
         cancelAuth();
       }
     }
   }
 
   Future<void> _tryRefresh() async {
+    final attempt = _authAttempt;
     final refresh = await _storage.read(_kKeyRefresh);
     if (refresh == null || refresh.isEmpty) {
       await _clearStorage();
@@ -125,46 +240,97 @@ class TraktService extends ChangeNotifier {
     try {
       final data = await _post('/oauth/token', {
         'refresh_token': refresh,
-        'client_id': _kClientId,
-        'client_secret': _kClientSecret,
+        'client_id': _clientId,
         'grant_type': 'refresh_token',
       });
-      await _saveTokens(data);
+      if (_disposed || attempt != _authAttempt) return;
+      await _saveTokens(data, expectedAttempt: attempt);
     } on Object catch (_) {
+      if (_disposed || attempt != _authAttempt) return;
       await _clearStorage();
     }
   }
 
-  Future<void> _saveTokens(Map<String, Object?> data) async {
+  Future<void> _saveTokens(
+    Map<String, Object?> data, {
+    required int expectedAttempt,
+  }) => _tokenQueue.run(() async {
+    if (_disposed || expectedAttempt != _authAttempt) return;
     _pollTimer?.cancel();
     _pollTimer = null;
-    _accessToken = '${data['access_token'] ?? ''}';
+    final previous = await _readStoredTokens();
+    if (_disposed || expectedAttempt != _authAttempt) return;
+    final accessToken = '${data['access_token'] ?? ''}';
+    final refreshToken = '${data['refresh_token'] ?? ''}';
     final expiresIn = (data['expires_in'] as num?)?.toInt() ?? 7776000;
     final expiry = (DateTime.now().millisecondsSinceEpoch ~/ 1000) + expiresIn;
-    await _storage.write(_kKeyAccess, _accessToken!);
-    await _storage.write(_kKeyRefresh, '${data['refresh_token'] ?? ''}');
-    await _storage.write(_kKeyExpiry, '$expiry');
+    try {
+      await _storage.write(_kKeyAccess, accessToken);
+      if (_disposed || expectedAttempt != _authAttempt) {
+        await _restoreStoredTokens(previous);
+        return;
+      }
+      await _storage.write(_kKeyRefresh, refreshToken);
+      if (_disposed || expectedAttempt != _authAttempt) {
+        await _restoreStoredTokens(previous);
+        return;
+      }
+      await _storage.write(_kKeyExpiry, '$expiry');
+      if (_disposed || expectedAttempt != _authAttempt) {
+        await _restoreStoredTokens(previous);
+        return;
+      }
+    } on Object {
+      await _restoreStoredTokens(previous);
+      rethrow;
+    }
+    _clearPendingAttempt();
+    _accessToken = accessToken;
     _status = TraktAuthStatus.connected;
-    _pending = null;
     notifyListeners();
-  }
+  });
 
   void cancelAuth() {
-    _pollTimer?.cancel();
-    _pollTimer = null;
-    _pending = null;
+    _clearPendingAttempt();
     _status = TraktAuthStatus.disconnected;
-    notifyListeners();
+    if (!_disposed) notifyListeners();
   }
 
   Future<void> disconnect() async {
+    _clearPendingAttempt();
+    await _tokenQueue.run(() async {
+      _accessToken = null;
+      await _clearStorage();
+      _status = TraktAuthStatus.disconnected;
+      if (!_disposed) notifyListeners();
+    });
+  }
+
+  void _clearPendingAttempt() {
+    _authAttempt += 1;
     _pollTimer?.cancel();
     _pollTimer = null;
     _pending = null;
-    _accessToken = null;
-    await _clearStorage();
-    _status = TraktAuthStatus.disconnected;
-    notifyListeners();
+    _codeVerifier = null;
+    _pollInterval = Duration.zero;
+    _deviceCodeExpiresAt = null;
+  }
+
+  Future<Map<String, String?>> _readStoredTokens() async => {
+    _kKeyAccess: await _storage.read(_kKeyAccess),
+    _kKeyRefresh: await _storage.read(_kKeyRefresh),
+    _kKeyExpiry: await _storage.read(_kKeyExpiry),
+  };
+
+  Future<void> _restoreStoredTokens(Map<String, String?> tokens) async {
+    for (final entry in tokens.entries) {
+      final value = entry.value;
+      if (value == null) {
+        await _storage.delete(entry.key);
+      } else {
+        await _storage.write(entry.key, value);
+      }
+    }
   }
 
   Future<void> _clearStorage() async {
@@ -177,9 +343,9 @@ class TraktService extends ChangeNotifier {
   ///
   /// [action] is one of `'start'`, `'pause'`, or `'stop'`.
   /// Pass [seriesTitle], [season], and [episode] for TV episodes; omit for movies.
-  /// [progress] is 0–100.
+  /// [progress] is 0 to 100.
   ///
-  /// Errors are silently ignored — scrobbling is best-effort.
+  /// Errors are silently ignored because scrobbling is best-effort.
   Future<void> scrobble({
     required String action,
     required String title,
@@ -217,9 +383,9 @@ class TraktService extends ChangeNotifier {
     }
     try {
       await _post('/scrobble/$action', body, accessToken: token);
-      debugPrint('[Trakt] scrobble/$action OK — ${jsonEncode(body)}');
-    } on Object catch (e) {
-      debugPrint('[Trakt] scrobble/$action FAILED: $e — ${jsonEncode(body)}');
+      debugPrint('[Trakt] scrobble succeeded');
+    } on Object catch (_) {
+      debugPrint('[Trakt] scrobble failed');
     }
   }
 
@@ -229,12 +395,23 @@ class TraktService extends ChangeNotifier {
     String? accessToken,
     bool isPollEndpoint = false,
   }) async {
+    final transport = _transport;
+    if (transport != null) {
+      final res = await transport(
+        TraktRequest(path: path, body: body, accessToken: accessToken),
+      );
+      return _handleResponse(
+        statusCode: res.statusCode,
+        body: res.body,
+        isPollEndpoint: isPollEndpoint,
+      );
+    }
     final encoded = utf8.encode(jsonEncode(body));
     final req = await _http.postUrl(Uri.parse('$_kApi$path'));
     req
       ..headers.contentType = ContentType.json
       ..headers.set('trakt-api-version', '2')
-      ..headers.set('trakt-api-key', _kClientId);
+      ..headers.set('trakt-api-key', _clientId);
     if (accessToken != null) {
       req.headers.set('Authorization', 'Bearer $accessToken');
     }
@@ -243,23 +420,50 @@ class TraktService extends ChangeNotifier {
       ..add(encoded);
     final res = await req.close();
     final text = await utf8.decodeStream(res);
-    if (isPollEndpoint && (res.statusCode == 400 || res.statusCode == 404)) {
-      // 400 = authorization_pending; 404 = device code expired / already used
-      throw _TraktPendingException();
+    final bodyJson = text.isEmpty
+        ? const <String, Object?>{}
+        : jsonDecode(text) as Map<String, Object?>;
+    return _handleResponse(
+      statusCode: res.statusCode,
+      body: bodyJson,
+      isPollEndpoint: isPollEndpoint,
+    );
+  }
+
+  Map<String, Object?> _handleResponse({
+    required int statusCode,
+    required Map<String, Object?> body,
+    required bool isPollEndpoint,
+  }) {
+    if (isPollEndpoint) {
+      final error = body['error'];
+      if (statusCode == 429 || error == 'slow_down') {
+        throw _TraktSlowDownException();
+      }
+      if (statusCode == 400 &&
+          (error == null || error == 'authorization_pending')) {
+        throw _TraktPendingException();
+      }
     }
-    if (res.statusCode >= 400) {
-      throw Exception('Trakt HTTP ${res.statusCode}: $text');
+    if (statusCode >= 400) {
+      throw const _TraktHttpException();
     }
-    if (text.isEmpty) return const {};
-    return jsonDecode(text) as Map<String, Object?>;
+    return body;
   }
 
   @override
   void dispose() {
-    _pollTimer?.cancel();
+    _disposed = true;
+    _clearPendingAttempt();
     _http.close();
     super.dispose();
   }
 }
 
 class _TraktPendingException implements Exception {}
+
+class _TraktSlowDownException implements Exception {}
+
+class _TraktHttpException implements Exception {
+  const _TraktHttpException();
+}

--- a/flutter_client/pubspec.lock
+++ b/flutter_client/pubspec.lock
@@ -218,7 +218,7 @@ packages:
     source: hosted
     version: "1.15.1"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/flutter_client/pubspec.yaml
+++ b/flutter_client/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   cached_network_image: ^3.4.1
+  crypto: ^3.0.7
   cupertino_icons: ^1.0.8
   dpad: ^3.0.0
   firebase_core: ^4.12.1

--- a/flutter_client/test/release/release_matrix_documentation_test.dart
+++ b/flutter_client/test/release/release_matrix_documentation_test.dart
@@ -36,6 +36,35 @@ void main() {
     expect(workflow, contains('run: flutter test'));
   });
 
+  test('release builds use only the public Trakt client id', () {
+    final releaseWorkflow = readFile(releaseWorkflowPath);
+
+    expect(releaseWorkflow, isNot(contains('TRAKT_CLIENT_SECRET')));
+    expect(releaseWorkflow, isNot(contains('secrets.TRAKT_CLIENT_SECRET')));
+    expect(
+      releaseWorkflow,
+      isNot(contains('--dart-define=TRAKT_CLIENT_SECRET')),
+    );
+
+    for (final stepName in <String>[
+      'Build APK',
+      'Build iOS IPA (unsigned)',
+      'Build tvOS (unsigned)',
+      'Build macOS app (unsigned)',
+      'Build Linux app',
+      'Build Windows app',
+    ]) {
+      final step = workflowStep(releaseWorkflow, stepName);
+      expect(step, contains('--dart-define=TRAKT_CLIENT_ID'));
+      expect(
+        step,
+        isNot(contains('TRAKT_CLIENT_SECRET')),
+        reason:
+            '$stepName must not compile a client secret into release output',
+      );
+    }
+  });
+
   test('CI executes native Android playback speed unit tests', () {
     final ciWorkflow = readFile(ciWorkflowPath);
     final releaseWorkflow = readFile(releaseWorkflowPath);

--- a/flutter_client/test/services/trakt_service_test.dart
+++ b/flutter_client/test/services/trakt_service_test.dart
@@ -1,0 +1,754 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/secure_storage.dart';
+import 'package:m3u_tv/services/trakt_service.dart';
+
+void main() {
+  const clientId = 'public-client-id';
+  const accessKey = 'trakt_access_token';
+  const refreshKey = 'trakt_refresh_token';
+  const expiryKey = 'trakt_token_expiry';
+  const rfcVerifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+  const rfcChallenge = 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM';
+
+  group('TraktService device authentication', () {
+    test('device code request sends public client PKCE fields', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+      ]);
+      final service = _service(
+        transport,
+        codeVerifierFactory: () => rfcVerifier,
+      );
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+
+      expect(service.status, TraktAuthStatus.pending);
+      expect(service.pending?.userCode, 'USER-CODE');
+      expect(transport.requests, hasLength(1));
+      expect(transport.requests.single.path, '/oauth/device/code');
+      expect(transport.requests.single.body, const <String, Object>{
+        'client_id': clientId,
+        'code_challenge': rfcChallenge,
+        'code_challenge_method': 'S256',
+      });
+      expect(transport.requests.single.body, isNot(contains('client_secret')));
+    });
+
+    test('device token polling sends no secret and persists tokens', () async {
+      final storage = InMemorySecureStorage();
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        _tokenResponse(
+          accessToken: 'access-token-sentinel',
+          refreshToken: 'refresh-token-sentinel',
+        ),
+      ]);
+      final service = _service(
+        transport,
+        storage: storage,
+        codeVerifierFactory: () => rfcVerifier,
+      );
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      expect(service.status, TraktAuthStatus.connected);
+      expect(service.pending, isNull);
+      final tokenRequest = transport.requests.singleWhere(
+        (request) => request.path == '/oauth/device/token',
+      );
+      expect(tokenRequest.body, const <String, Object>{
+        'code': 'DEVICE-CODE',
+        'client_id': clientId,
+        'code_verifier': rfcVerifier,
+      });
+      expect(tokenRequest.body, isNot(contains('client_secret')));
+      expect(await storage.read(accessKey), 'access-token-sentinel');
+      expect(await storage.read(refreshKey), 'refresh-token-sentinel');
+      expect(await storage.read(expiryKey), isNotNull);
+    });
+
+    test('creates a fresh RFC 7636 verifier for every auth attempt', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600, deviceCode: 'DEVICE-ONE'),
+        const TraktResponse(400, <String, Object?>{
+          'error': 'authorization_pending',
+        }),
+        _deviceCodeResponse(interval: 3600, deviceCode: 'DEVICE-TWO'),
+        const TraktResponse(400, <String, Object?>{
+          'error': 'authorization_pending',
+        }),
+      ]);
+      final service = _service(transport);
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      final tokenRequests = transport.requests
+          .where((request) => request.path == '/oauth/device/token')
+          .toList();
+      expect(tokenRequests, hasLength(2));
+      expect(
+        tokenRequests[0].body['code_verifier'],
+        isNot(tokenRequests[1].body['code_verifier']),
+      );
+      for (final request in tokenRequests) {
+        final verifier = request.body['code_verifier']! as String;
+        expect(verifier.length, inInclusiveRange(43, 128));
+        expect(verifier, matches(RegExp(r'^[A-Za-z0-9\-._~]+$')));
+      }
+    });
+
+    test(
+      'an old device response cannot replace a newer PKCE attempt',
+      () async {
+        const firstVerifier =
+            'first-verifier-abcdefghijklmnopqrstuvwxyz0123456789-._~';
+        const secondVerifier =
+            'second-verifier-abcdefghijklmnopqrstuvwxyz0123456789-._~';
+        final verifiers = <String>[firstVerifier, secondVerifier];
+        final firstResponse = Completer<TraktResponse>();
+        final transport = _ControlledTraktTransport(firstResponse.future);
+        final service = TraktService(
+          storage: InMemorySecureStorage(),
+          clientId: clientId,
+          transport: transport.call,
+          codeVerifierFactory: () => verifiers.removeAt(0),
+        );
+        addTearDown(service.dispose);
+
+        final oldAttempt = service.startDeviceAuth();
+        await service.startDeviceAuth();
+        firstResponse.complete(
+          _deviceCodeResponse(interval: 3600, deviceCode: 'OLD-DEVICE'),
+        );
+        await oldAttempt;
+        await service.pollForTesting();
+
+        expect(service.pending?.deviceCode, 'NEW-DEVICE');
+        final tokenRequest = transport.requests.singleWhere(
+          (request) => request.path == '/oauth/device/token',
+        );
+        expect(tokenRequest.body['code'], 'NEW-DEVICE');
+        expect(tokenRequest.body['code_verifier'], secondVerifier);
+      },
+    );
+
+    test('cancel and dispose prevent reuse of a pending verifier', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        _deviceCodeResponse(interval: 3600),
+      ]);
+      final service = _service(
+        transport,
+        codeVerifierFactory: () => rfcVerifier,
+      );
+
+      await service.startDeviceAuth();
+      service.cancelAuth();
+      await service.pollForTesting();
+      await service.startDeviceAuth();
+      service.dispose();
+      await service.pollForTesting();
+
+      expect(
+        transport.requests.where(
+          (request) => request.path == '/oauth/device/token',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('pending device token response keeps polling state', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        const TraktResponse(400, <String, Object?>{
+          'error': 'authorization_pending',
+          'device_code': 'DEVICE-CODE',
+        }),
+      ]);
+      final service = _service(transport);
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      expect(service.status, TraktAuthStatus.pending);
+      expect(service.pending?.deviceCode, 'DEVICE-CODE');
+    });
+
+    test('slow down response increases the polling interval', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 10),
+        const TraktResponse(400, <String, Object?>{
+          'error': 'slow_down',
+        }),
+      ]);
+      final service = _service(transport);
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      expect(service.status, TraktAuthStatus.pending);
+      expect(service.pollIntervalForTesting, const Duration(seconds: 15));
+    });
+
+    test('device authorization stops locally when its code expires', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 10, expiresIn: 0),
+      ]);
+      final service = _service(transport);
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+
+      expect(service.status, TraktAuthStatus.disconnected);
+      expect(service.pending, isNull);
+      expect(
+        transport.requests.where(
+          (request) => request.path == '/oauth/device/token',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('expired device token response cancels pending auth', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        const TraktResponse(400, <String, Object?>{
+          'error': 'expired_token',
+          'device_code': 'DEVICE-CODE',
+        }),
+      ]);
+      final service = _service(transport);
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      expect(service.status, TraktAuthStatus.disconnected);
+      expect(service.pending, isNull);
+    });
+
+    test('denied device token response cancels pending auth', () async {
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        const TraktResponse(400, <String, Object?>{
+          'error': 'access_denied',
+        }),
+      ]);
+      final service = _service(transport);
+      addTearDown(service.dispose);
+
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      expect(service.status, TraktAuthStatus.disconnected);
+      expect(service.pending, isNull);
+    });
+
+    test(
+      'cancel auth clears pending state without deleting stored tokens',
+      () async {
+        final storage = InMemorySecureStorage();
+        await storage.write(accessKey, 'stored-access-token');
+        await storage.write(refreshKey, 'stored-refresh-token');
+        await storage.write(expiryKey, '${_futureEpoch()}');
+        final transport = _FakeTraktTransport([
+          _deviceCodeResponse(interval: 3600),
+        ]);
+        final service = _service(transport, storage: storage);
+        addTearDown(service.dispose);
+
+        await service.startDeviceAuth();
+        service.cancelAuth();
+
+        expect(service.status, TraktAuthStatus.disconnected);
+        expect(service.pending, isNull);
+        expect(await storage.read(accessKey), 'stored-access-token');
+        expect(await storage.read(refreshKey), 'stored-refresh-token');
+        expect(await storage.read(expiryKey), isNotNull);
+      },
+    );
+  });
+
+  group('TraktService session lifecycle', () {
+    test('init stops cleanly when disposed during storage read', () async {
+      final storage = _BlockingAccessReadSecureStorage();
+      final service = TraktService(
+        storage: storage,
+        clientId: clientId,
+      );
+
+      final initializing = service.init();
+      await storage.accessReadStarted.future;
+      service.dispose();
+      storage.releaseAccess('stored-access-token');
+
+      await expectLater(initializing, completes);
+    });
+
+    test('init restores a valid stored session', () async {
+      final storage = InMemorySecureStorage();
+      await storage.write(accessKey, 'stored-access-token');
+      await storage.write(refreshKey, 'stored-refresh-token');
+      await storage.write(expiryKey, '${_futureEpoch()}');
+      final service = _service(_FakeTraktTransport([]), storage: storage);
+      addTearDown(service.dispose);
+
+      await service.init();
+
+      expect(service.status, TraktAuthStatus.connected);
+      expect(await storage.read(accessKey), 'stored-access-token');
+      expect(await storage.read(refreshKey), 'stored-refresh-token');
+    });
+
+    test(
+      'expired session refresh sends no secret and replaces tokens',
+      () async {
+        final storage = InMemorySecureStorage();
+        await storage.write(accessKey, 'old-access-token');
+        await storage.write(refreshKey, 'old-refresh-token');
+        await storage.write(expiryKey, '${_pastEpoch()}');
+        final transport = _FakeTraktTransport([
+          _tokenResponse(
+            accessToken: 'new-access-token',
+            refreshToken: 'new-refresh-token',
+          ),
+        ]);
+        final service = _service(transport, storage: storage);
+        addTearDown(service.dispose);
+
+        await service.init();
+
+        expect(service.status, TraktAuthStatus.connected);
+        expect(transport.requests.single.path, '/oauth/token');
+        expect(transport.requests.single.body, const <String, Object>{
+          'refresh_token': 'old-refresh-token',
+          'client_id': clientId,
+          'grant_type': 'refresh_token',
+        });
+        expect(
+          transport.requests.single.body,
+          isNot(contains('client_secret')),
+        );
+        expect(
+          transport.requests.single.body,
+          isNot(contains('code_verifier')),
+        );
+        expect(await storage.read(accessKey), 'new-access-token');
+        expect(await storage.read(refreshKey), 'new-refresh-token');
+      },
+    );
+
+    test('failed refresh clears stored tokens', () async {
+      final storage = InMemorySecureStorage();
+      await storage.write(accessKey, 'old-access-token');
+      await storage.write(refreshKey, 'old-refresh-token');
+      await storage.write(expiryKey, '${_pastEpoch()}');
+      final transport = _FakeTraktTransport([
+        const TraktResponse(400, <String, Object?>{
+          'error': 'invalid_grant',
+          'refresh_token': 'old-refresh-token',
+        }),
+      ]);
+      final service = _service(transport, storage: storage);
+      addTearDown(service.dispose);
+
+      await service.init();
+
+      expect(service.status, TraktAuthStatus.disconnected);
+      expect(await storage.read(accessKey), isNull);
+      expect(await storage.read(refreshKey), isNull);
+      expect(await storage.read(expiryKey), isNull);
+    });
+
+    test('disconnect clears connected state and stored tokens', () async {
+      final storage = InMemorySecureStorage();
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        _tokenResponse(
+          accessToken: 'access-token-sentinel',
+          refreshToken: 'refresh-token-sentinel',
+        ),
+      ]);
+      final service = _service(transport, storage: storage);
+      addTearDown(service.dispose);
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      await service.disconnect();
+
+      expect(service.status, TraktAuthStatus.disconnected);
+      expect(service.pending, isNull);
+      expect(await storage.read(accessKey), isNull);
+      expect(await storage.read(refreshKey), isNull);
+      expect(await storage.read(expiryKey), isNull);
+    });
+
+    test(
+      'cancel keeps prior tokens when a save is already in progress',
+      () async {
+        final storage = _BlockingWriteSecureStorage({
+          accessKey: 'stored-access-token',
+          refreshKey: 'stored-refresh-token',
+          expiryKey: '${_futureEpoch()}',
+        });
+        final transport = _FakeTraktTransport([
+          _deviceCodeResponse(interval: 3600),
+          _tokenResponse(
+            accessToken: 'stale-access-token',
+            refreshToken: 'stale-refresh-token',
+          ),
+        ]);
+        final service = TraktService(
+          storage: storage,
+          clientId: clientId,
+          transport: transport.call,
+          codeVerifierFactory: () => rfcVerifier,
+        );
+        addTearDown(service.dispose);
+        await service.startDeviceAuth();
+
+        final poll = service.pollForTesting();
+        await storage.writeStarted.future;
+        service.cancelAuth();
+        storage.releaseWrite();
+        await poll;
+
+        expect(service.status, TraktAuthStatus.disconnected);
+        expect(await storage.read(accessKey), 'stored-access-token');
+        expect(await storage.read(refreshKey), 'stored-refresh-token');
+        expect(await storage.read(expiryKey), isNotNull);
+      },
+    );
+
+    test('disconnect wins against a token save already in progress', () async {
+      final storage = _BlockingWriteSecureStorage();
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        _tokenResponse(
+          accessToken: 'stale-access-token',
+          refreshToken: 'stale-refresh-token',
+        ),
+      ]);
+      final service = TraktService(
+        storage: storage,
+        clientId: clientId,
+        transport: transport.call,
+        codeVerifierFactory: () => rfcVerifier,
+      );
+      addTearDown(service.dispose);
+      await service.startDeviceAuth();
+
+      final poll = service.pollForTesting();
+      await storage.writeStarted.future;
+      final disconnect = service.disconnect();
+      storage.releaseWrite();
+      await Future.wait([poll, disconnect]);
+
+      expect(service.status, TraktAuthStatus.disconnected);
+      expect(await storage.read(accessKey), isNull);
+      expect(await storage.read(refreshKey), isNull);
+      expect(await storage.read(expiryKey), isNull);
+    });
+
+    test('failed token save restores the previous credential set', () async {
+      final storage = _FailOnceSecureStorage(
+        {
+          accessKey: 'stored-access-token',
+          refreshKey: 'stored-refresh-token',
+          expiryKey: '${_futureEpoch()}',
+        },
+        failKey: refreshKey,
+      );
+      final transport = _FakeTraktTransport([
+        _deviceCodeResponse(interval: 3600),
+        _tokenResponse(
+          accessToken: 'replacement-access-token',
+          refreshToken: 'replacement-refresh-token',
+        ),
+      ]);
+      final service = TraktService(
+        storage: storage,
+        clientId: clientId,
+        transport: transport.call,
+        codeVerifierFactory: () => rfcVerifier,
+      );
+      addTearDown(service.dispose);
+      await service.startDeviceAuth();
+      await service.pollForTesting();
+
+      expect(service.status, TraktAuthStatus.disconnected);
+      expect(await storage.read(accessKey), 'stored-access-token');
+      expect(await storage.read(refreshKey), 'stored-refresh-token');
+      expect(await storage.read(expiryKey), isNotNull);
+
+      final restored = _service(_FakeTraktTransport([]), storage: storage);
+      addTearDown(restored.dispose);
+      await restored.init();
+      expect(restored.status, TraktAuthStatus.connected);
+    });
+  });
+
+  group('TraktService scrobble redaction', () {
+    test(
+      'scrobble success sends media payload but logs no sensitive values',
+      () async {
+        final logs = <String>[];
+        final previousDebugPrint = debugPrint;
+        debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+        addTearDown(() => debugPrint = previousDebugPrint);
+        final storage = InMemorySecureStorage();
+        await storage.write(accessKey, 'access-token-sentinel');
+        await storage.write(refreshKey, 'refresh-token-sentinel');
+        await storage.write(expiryKey, '${_futureEpoch()}');
+        final transport = _FakeTraktTransport([
+          const TraktResponse(201, <String, Object?>{}),
+        ]);
+        final service = _service(transport, storage: storage);
+        addTearDown(service.dispose);
+        await service.init();
+
+        await service.scrobble(
+          action: 'start',
+          title: 'Sensitive Movie Title',
+          tmdbId: 123456,
+          imdbId: 'tt7654321',
+          progress: 42.5,
+        );
+
+        expect(transport.requests.single.path, '/scrobble/start');
+        expect(transport.requests.single.accessToken, 'access-token-sentinel');
+        expect(
+          transport.requests.single.body.toString(),
+          contains('Sensitive Movie Title'),
+        );
+        _expectLogsRedacted(logs.join('\n'));
+      },
+    );
+
+    test('scrobble failure logs no error body or media values', () async {
+      final logs = <String>[];
+      final previousDebugPrint = debugPrint;
+      debugPrint = (message, {wrapWidth}) => logs.add(message ?? '');
+      addTearDown(() => debugPrint = previousDebugPrint);
+      final storage = InMemorySecureStorage();
+      await storage.write(accessKey, 'access-token-sentinel');
+      await storage.write(refreshKey, 'refresh-token-sentinel');
+      await storage.write(expiryKey, '${_futureEpoch()}');
+      final transport = _FakeTraktTransport([
+        const TraktResponse(500, <String, Object?>{
+          'error_description': 'Sensitive Movie Title response body leak',
+          'access_token': 'access-token-sentinel',
+        }),
+      ]);
+      final service = _service(transport, storage: storage);
+      addTearDown(service.dispose);
+      await service.init();
+
+      await service.scrobble(
+        action: 'pause',
+        title: 'Episode Title Secret',
+        seriesTitle: 'Sensitive Show Title',
+        season: 2,
+        episode: 7,
+        tmdbId: 987654,
+        progress: 88.25,
+      );
+
+      _expectLogsRedacted(logs.join('\n'));
+    });
+  });
+}
+
+TraktService _service(
+  _FakeTraktTransport transport, {
+  SecureStorage? storage,
+  String Function()? codeVerifierFactory,
+}) {
+  return TraktService(
+    storage: storage ?? InMemorySecureStorage(),
+    clientId: 'public-client-id',
+    transport: transport.call,
+    codeVerifierFactory: codeVerifierFactory,
+  );
+}
+
+TraktResponse _deviceCodeResponse({
+  required int interval,
+  String deviceCode = 'DEVICE-CODE',
+  int expiresIn = 600,
+}) {
+  return TraktResponse(200, <String, Object?>{
+    'user_code': 'USER-CODE',
+    'verification_url': 'https://trakt.tv/activate',
+    'device_code': deviceCode,
+    'interval': interval,
+    'expires_in': expiresIn,
+  });
+}
+
+TraktResponse _tokenResponse({
+  required String accessToken,
+  required String refreshToken,
+}) {
+  return TraktResponse(200, <String, Object?>{
+    'access_token': accessToken,
+    'refresh_token': refreshToken,
+    'expires_in': 3600,
+  });
+}
+
+int _futureEpoch() => DateTime.now().millisecondsSinceEpoch ~/ 1000 + 3600;
+
+int _pastEpoch() => DateTime.now().millisecondsSinceEpoch ~/ 1000 - 60;
+
+void _expectLogsRedacted(String logs) {
+  for (final sensitiveValue in <String>[
+    'access-token-sentinel',
+    'refresh-token-sentinel',
+    'Sensitive Movie Title',
+    'Episode Title Secret',
+    'Sensitive Show Title',
+    'tt7654321',
+    '123456',
+    '987654',
+    '42.5',
+    '88.25',
+    'DEVICE-CODE',
+    'response body leak',
+  ]) {
+    expect(logs, isNot(contains(sensitiveValue)), reason: sensitiveValue);
+  }
+}
+
+class _FakeTraktTransport {
+  _FakeTraktTransport(this._responses);
+
+  final List<TraktResponse> _responses;
+  final requests = <TraktRequest>[];
+
+  Future<TraktResponse> call(TraktRequest request) async {
+    requests.add(request);
+    if (_responses.isEmpty) {
+      return const TraktResponse(500, <String, Object?>{});
+    }
+    return _responses.removeAt(0);
+  }
+}
+
+class _BlockingAccessReadSecureStorage implements SecureStorage {
+  final accessReadStarted = Completer<void>();
+  final _access = Completer<String?>();
+
+  void releaseAccess(String? value) => _access.complete(value);
+
+  @override
+  Future<String?> read(String key) {
+    if (key == 'trakt_access_token') {
+      accessReadStarted.complete();
+      return _access.future;
+    }
+    if (key == 'trakt_token_expiry') {
+      return Future<String?>.value('${_futureEpoch()}');
+    }
+    return Future<String?>.value();
+  }
+
+  @override
+  Future<void> write(String key, String value) async {}
+
+  @override
+  Future<void> delete(String key) async {}
+}
+
+class _BlockingWriteSecureStorage implements SecureStorage {
+  _BlockingWriteSecureStorage([Map<String, String>? initialValues])
+    : _values = {...?initialValues};
+
+  final Map<String, String> _values;
+  final writeStarted = Completer<void>();
+  final _writeReleased = Completer<void>();
+  var _blockFirstWrite = true;
+
+  void releaseWrite() => _writeReleased.complete();
+
+  @override
+  Future<String?> read(String key) async => _values[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    if (_blockFirstWrite) {
+      _blockFirstWrite = false;
+      writeStarted.complete();
+      await _writeReleased.future;
+    }
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    _values.remove(key);
+  }
+}
+
+class _FailOnceSecureStorage implements SecureStorage {
+  _FailOnceSecureStorage(
+    Map<String, String> initialValues, {
+    required this.failKey,
+  }) : _values = {...initialValues};
+
+  final Map<String, String> _values;
+  final String failKey;
+  var _hasFailed = false;
+
+  @override
+  Future<String?> read(String key) async => _values[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    if (key == failKey && !_hasFailed) {
+      _hasFailed = true;
+      throw StateError('injected write failure');
+    }
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    _values.remove(key);
+  }
+}
+
+class _ControlledTraktTransport {
+  _ControlledTraktTransport(this.firstDeviceResponse);
+
+  final Future<TraktResponse> firstDeviceResponse;
+  final requests = <TraktRequest>[];
+  var _deviceRequestCount = 0;
+
+  Future<TraktResponse> call(TraktRequest request) async {
+    requests.add(request);
+    if (request.path == '/oauth/device/code') {
+      _deviceRequestCount += 1;
+      if (_deviceRequestCount == 1) return firstDeviceResponse;
+      return _deviceCodeResponse(interval: 3600, deviceCode: 'NEW-DEVICE');
+    }
+    if (request.path == '/oauth/device/token') {
+      return const TraktResponse(400, <String, Object?>{
+        'error': 'authorization_pending',
+      });
+    }
+    return const TraktResponse(500, <String, Object?>{});
+  }
+}


### PR DESCRIPTION
## Summary

- replace the distributed Trakt client secret with a public Device Flow PKCE exchange
- keep each PKCE verifier private, in memory, and isolated to one authorization attempt
- handle pending, slow down, denial, expiry, cancellation, disposal, and storage rollback safely
- remove sensitive scrobble payload and error details from diagnostics
- remove the Trakt client secret from every release platform command and update setup documentation
- add request-contract, lifecycle, redaction, and release-workflow regression coverage

## Verification

- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze lib test`: no issues
- `flutter test --concurrency=1`: 500 passed, 5 skipped
- `./android/gradlew --no-daemon --console=plain -p android :app:testDebugUnitTest`: BUILD SUCCESSFUL, 197 tasks
- `flutter build apk --release --dart-define=TRAKT_CLIENT_ID=<public-client-id>`: 63.6 MB APK built
- `flutter build linux --release --dart-define=TRAKT_CLIENT_ID=<public-client-id>`: release bundle built
- release binary scans found the public client ID and found no client-secret define, secret field, test verifier, test token, or sensitive test title
- mutation checks rejected broken OAuth 400 handling, expiry, stale-attempt, persistence-race, rollback, and disposal variants

## Manual validation

A real Trakt account activation was not performed. Request composition and the authorization lifecycle are covered through the production transport seam.

Closes #138
