### PR TITLE
fix(player): reuse orchestrator across live channel switches

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -118,6 +118,17 @@ class AppShellState extends ConsumerState<AppShell>
   bool _playerHasFailed = false;
   FocusNode? _focusBeforePlayer;
 
+  // Bumped only when a brand-new player session starts (not on in-session
+  // source switches, e.g. skip-previous/skip-next), so PlayerScreen's key
+  // stays stable across a channel switch and its State survives via
+  // didUpdateWidget instead of being torn down and rebuilt. This matters
+  // because the Android Media3 and Apple AVKit native plugins each hold a
+  // single global player behind their MethodChannel — remounting PlayerScreen
+  // per channel would dispose the *previous* orchestrator after the *new*
+  // one has already started loading, and that deferred dispose tears down
+  // whatever the native side currently has loaded (the new channel).
+  int _playerSessionId = 0;
+
   // Channels the user was browsing when the live player opened (filtered
   // category/favorites/search list), so skip-previous/skip-next in
   // PlaybackControls stays within that view instead of always cycling the
@@ -414,10 +425,6 @@ class AppShellState extends ConsumerState<AppShell>
 
   void _openPlayerDirect(PlayerArgs rawArgs) {
     final args = _applyProxyPlayback(rawArgs);
-    final oldOrch = _playerOrchestrator;
-    final newOrch =
-        widget.playbackOrchestratorBuilder?.call() ??
-        buildPlaybackOrchestrator();
     // Save the focused node so we can restore it precisely after the player
     // closes. _contentFocusNode.requestFocus() alone is unreliable: when
     // PlayerScreen disposes _screenFocusNode, Flutter's _willDisposeFocusNode
@@ -428,16 +435,29 @@ class AppShellState extends ConsumerState<AppShell>
     final focus = FocusManager.instance.primaryFocus;
     _focusBeforePlayer = _isInContentScope(focus) ? focus : null;
     unawaited(_systemUiPolicy.applyPlayer());
+
+    if (_playerOrchestrator != null) {
+      // A player is already open (e.g. skip-previous/skip-next) — reuse its
+      // orchestrator/session rather than building a new one. PlayerScreen's
+      // key is unchanged, so the framework updates the existing State via
+      // didUpdateWidget instead of disposing it, keeping exactly one native
+      // player instance alive for the whole session.
+      setState(() {
+        _playerArgs = args;
+        _playerHasFailed = false;
+      });
+      return;
+    }
+
+    _playerSessionId += 1;
+    final newOrch =
+        widget.playbackOrchestratorBuilder?.call() ??
+        buildPlaybackOrchestrator();
     setState(() {
       _playerArgs = args;
       _playerOrchestrator = newOrch;
       _playerHasFailed = false;
     });
-    if (oldOrch != null) {
-      WidgetsBinding.instance.addPostFrameCallback(
-        (_) => oldOrch.dispose().ignore(),
-      );
-    }
   }
 
   bool _isInContentScope(FocusNode? node) {
@@ -459,6 +479,7 @@ class AppShellState extends ConsumerState<AppShell>
       _playerOrchestrator = null;
       _playerHasFailed = false;
     });
+    _playerChannelContext = const <Channel>[];
     WidgetsBinding.instance.addPostFrameCallback((_) {
       orch?.dispose().ignore();
       if (!mounted) return;
@@ -922,7 +943,7 @@ class AppShellState extends ConsumerState<AppShell>
             child:
                 widget.playerRouteBuilder?.call(args) ??
                 PlayerScreen(
-                  key: ValueKey(args.streamUrl),
+                  key: ValueKey(_playerSessionId),
                   args: args,
                   orchestrator: orch,
                   epgService: _appState.epgService,

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dpad/dpad.dart';
+import 'package:flutter/foundation.dart' show mapEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -142,7 +143,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   @override
   void didUpdateWidget(covariant PlayerScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.args.streamUrl == widget.args.streamUrl) return;
+    if (_isSamePlaybackSession(oldWidget.args, widget.args)) return;
 
     if (_traktScrobbleActive) _scrobbleFor(oldWidget.args, 'stop');
     _traktScrobbleActive = false;
@@ -175,6 +176,20 @@ class _PlayerScreenState extends State<PlayerScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted && _overlayVisible) _controlsFocusNode.requestFocus();
     });
+  }
+
+  // Two channels can share a stream URL while differing in stream ID,
+  // headers, EPG ID, or metadata (e.g. a proxied/transcoded URL keyed by
+  // query params that get stripped, or distinct catchup sources pointing at
+  // the same base live URL) — comparing streamUrl alone would silently skip
+  // the switch and leave the previous channel's state in place.
+  bool _isSamePlaybackSession(PlayerArgs a, PlayerArgs b) {
+    return a.streamUrl == b.streamUrl &&
+        a.streamId == b.streamId &&
+        a.type == b.type &&
+        a.epgChannelId == b.epgChannelId &&
+        mapEquals(a.headers, b.headers) &&
+        mapEquals(a.metadata, b.metadata);
   }
 
   void _startPositionTimer() {

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -125,9 +125,56 @@ class _PlayerScreenState extends State<PlayerScreen> {
         }
       }
     });
-    _startPlayback();
+    _stateSubscription = widget.orchestrator.onState.listen(_handleState);
+    _errorSubscription = widget.orchestrator.onError.listen(_handleError);
+    _openSource(widget.args);
     _startLoadingTimeout();
     _scheduleOverlayHide();
+  }
+
+  // Live-TV skip-previous/skip-next replaces `args` on an already-mounted
+  // PlayerScreen (AppShell keeps the same orchestrator/State alive across a
+  // channel switch — see app_shell.dart's `_playerSessionId` — so the single
+  // native player behind Media3/AVKit is never torn down mid-switch). Reset
+  // everything initState/_openSource would normally set up for a fresh
+  // mount, but reuse the existing stream subscriptions rather than doubling
+  // them up on the same orchestrator.
+  @override
+  void didUpdateWidget(covariant PlayerScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.args.streamUrl == widget.args.streamUrl) return;
+
+    if (_traktScrobbleActive) _scrobbleFor(oldWidget.args, 'stop');
+    _traktScrobbleActive = false;
+    _failureReported = false;
+    _lastValidProgress = 0;
+    _stopPositionTimer();
+    _progressTimer?.cancel();
+    _epgTimer?.cancel();
+    _epgFetch = null;
+
+    setState(() {
+      _status = PlaybackStatus.idle;
+      _currentPosition = Duration.zero;
+      _duration = Duration.zero;
+      _errorMessage = null;
+      _fallbackReason = null;
+      _isPlaying = false;
+      _videoAspectRatio = 16 / 9;
+      _audioTracks = const <PlaybackTrack>[];
+      _subtitleTracks = const <PlaybackTrack>[];
+      _selectedAudioTrackId = null;
+      _selectedSubtitleTrackId = null;
+      _epgData = null;
+      _overlayVisible = true;
+    });
+
+    _openSource(widget.args);
+    _startLoadingTimeout();
+    _scheduleOverlayHide();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted && _overlayVisible) _controlsFocusNode.requestFocus();
+    });
   }
 
   void _startPositionTimer() {
@@ -148,10 +195,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _positionTimer = null;
   }
 
-  void _scrobble(String action) {
+  void _scrobble(String action) => _scrobbleFor(widget.args, action);
+
+  void _scrobbleFor(PlayerArgs args, String action) {
     final service = widget.traktService;
     if (service == null || service.status != TraktAuthStatus.connected) return;
-    if (_isLive || widget.args.type == 'catchup') return;
+    if (args.type == 'live' || args.type == 'catchup') return;
     final duration = _duration.inSeconds;
     var progress = duration > 0
         ? (_currentPosition.inSeconds / duration * 100).clamp(0.0, 100.0)
@@ -164,7 +213,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
       progress = _lastValidProgress;
     }
     if (progress > 0) _lastValidProgress = progress;
-    final args = widget.args;
     unawaited(
       service.scrobble(
         action: action,
@@ -216,13 +264,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
     });
   }
 
-  void _startPlayback() {
-    _stateSubscription = widget.orchestrator.onState.listen(_handleState);
-    _errorSubscription = widget.orchestrator.onError.listen(_handleError);
-
-    final source = widget.args.toPlaybackSource();
-
-    unawaited(_openAndSeek(source));
+  void _openSource(PlayerArgs args) {
+    unawaited(_openAndSeek(args.toPlaybackSource()));
   }
 
   Future<void> _openAndSeek(PlaybackSource source) async {
@@ -414,7 +457,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _epgFetch = fetch;
     try {
       final programs = await fetch;
-      if (_disposed || !mounted) return;
+      // The player may have switched to a different channel while this was
+      // in flight (didUpdateWidget cancels the timer but can't cancel this
+      // future) — don't let a stale response overwrite the new channel's EPG.
+      if (_disposed || !mounted || widget.args.epgChannelId != channelId) {
+        return;
+      }
       widget.epgService.mergePrograms(programs);
       final refreshed = widget.epgService.lookup(channelId);
       if (mounted) {

--- a/flutter_client/lib/playback/playback_orchestrator.dart
+++ b/flutter_client/lib/playback/playback_orchestrator.dart
@@ -84,12 +84,19 @@ class PlaybackOrchestrator {
 
   Future<void> open(PlaybackSource source) async {
     _ensureNotDisposed();
-    _playbackGeneration += 1;
-    _cancelBufferingTimer();
     _activeRecoveryAttempts = 0;
     _recovering = false;
+    // _stopActiveAdapter() bumps _playbackGeneration itself — capture the
+    // value it lands on rather than bumping again here, then bail out after
+    // every subsequent await if a *newer* open() call (e.g. a second
+    // skip-channel press before this one finished loading) has bumped it
+    // again. Without this, two concurrent open() calls can both reach
+    // adapter.load() and whichever assigns _activeAdapter/_activeSource last
+    // wins regardless of which one the native side actually kept loaded.
     await _stopActiveAdapter();
+    final generation = _playbackGeneration;
     await _cleanupSessions();
+    if (generation != _playbackGeneration) return;
     _activeAdapter = null;
     _activeBackend = null;
     _activeSource = null;
@@ -98,6 +105,7 @@ class PlaybackOrchestrator {
     PlaybackBackend? previousBackend;
     var attempt = 0;
     for (final backend in _nativeBackends()) {
+      if (generation != _playbackGeneration) return;
       final failure = await _tryLoadBackend(
         backend: backend,
         source: source,
@@ -105,6 +113,7 @@ class PlaybackOrchestrator {
             ? 'direct:${backend.name}:ready'
             : 'fallback:${backend.name}:preferred ${previousBackend?.name ?? 'none'} unsupported',
       );
+      if (generation != _playbackGeneration) return;
       attempt += 1;
       if (failure == null) return;
       if (_platform == PlaybackPlatform.android &&
@@ -116,6 +125,7 @@ class PlaybackOrchestrator {
       lastRecoverableFailure = failure;
     }
 
+    if (generation != _playbackGeneration) return;
     await _openServerTranscode(source, lastFailure: lastRecoverableFailure);
   }
 

--- a/flutter_client/lib/playback/playback_orchestrator.dart
+++ b/flutter_client/lib/playback/playback_orchestrator.dart
@@ -84,19 +84,20 @@ class PlaybackOrchestrator {
 
   Future<void> open(PlaybackSource source) async {
     _ensureNotDisposed();
+    // Assigned synchronously, before any await, so this call's generation is
+    // guaranteed unique — capturing it *after* an await (as this used to)
+    // lets a second concurrent open() call (e.g. a fast second skip-channel
+    // press) bump the counter first and land on the same value, so the
+    // older call is never recognized as stale. Every subsequent await below
+    // re-checks against this value and bails (cleaning up only what *this*
+    // call itself started) if a newer open()/stop() has since taken over.
+    final generation = _beginGeneration();
     _activeRecoveryAttempts = 0;
     _recovering = false;
-    // _stopActiveAdapter() bumps _playbackGeneration itself — capture the
-    // value it lands on rather than bumping again here, then bail out after
-    // every subsequent await if a *newer* open() call (e.g. a second
-    // skip-channel press before this one finished loading) has bumped it
-    // again. Without this, two concurrent open() calls can both reach
-    // adapter.load() and whichever assigns _activeAdapter/_activeSource last
-    // wins regardless of which one the native side actually kept loaded.
     await _stopActiveAdapter();
-    final generation = _playbackGeneration;
+    if (!_isCurrentGeneration(generation)) return;
     await _cleanupSessions();
-    if (generation != _playbackGeneration) return;
+    if (!_isCurrentGeneration(generation)) return;
     _activeAdapter = null;
     _activeBackend = null;
     _activeSource = null;
@@ -105,15 +106,16 @@ class PlaybackOrchestrator {
     PlaybackBackend? previousBackend;
     var attempt = 0;
     for (final backend in _nativeBackends()) {
-      if (generation != _playbackGeneration) return;
+      if (!_isCurrentGeneration(generation)) return;
       final failure = await _tryLoadBackend(
         backend: backend,
         source: source,
         successDiagnostic: attempt == 0
             ? 'direct:${backend.name}:ready'
             : 'fallback:${backend.name}:preferred ${previousBackend?.name ?? 'none'} unsupported',
+        generation: generation,
       );
-      if (generation != _playbackGeneration) return;
+      if (!_isCurrentGeneration(generation)) return;
       attempt += 1;
       if (failure == null) return;
       if (_platform == PlaybackPlatform.android &&
@@ -125,8 +127,11 @@ class PlaybackOrchestrator {
       lastRecoverableFailure = failure;
     }
 
-    if (generation != _playbackGeneration) return;
-    await _openServerTranscode(source, lastFailure: lastRecoverableFailure);
+    await _openServerTranscode(
+      source,
+      generation: generation,
+      lastFailure: lastRecoverableFailure,
+    );
   }
 
   Future<void> play() => _requireActiveAdapter().play();
@@ -141,6 +146,7 @@ class PlaybackOrchestrator {
       _requireActiveAdapter().setPlaybackSpeed(speed);
 
   Future<void> stop() async {
+    _beginGeneration();
     await _stopActiveAdapter();
     await _cleanupSessions();
   }
@@ -180,6 +186,7 @@ class PlaybackOrchestrator {
     required PlaybackBackend backend,
     required PlaybackSource source,
     required String successDiagnostic,
+    required int generation,
   }) async {
     final adapter = _adapters[backend];
     if (adapter == null) return null;
@@ -189,13 +196,34 @@ class PlaybackOrchestrator {
     _activeSource = source;
     try {
       await adapter.load(source);
+      if (!_isCurrentGeneration(generation)) {
+        // A newer open()/stop() call has since taken over. This adapter
+        // just started playing content nobody asked for anymore — stop it
+        // rather than leaving it running unsupervised, but only touch the
+        // shared fields if they still point at THIS call's own source. A
+        // newer call may reuse the identical adapter+backend (there's only
+        // one adapter instance per backend), so checking adapter/backend
+        // identity alone can't tell the two calls apart — checking source
+        // identity too can, since each call builds its own PlaybackSource.
+        if (identical(_activeAdapter, adapter) &&
+            _activeBackend == backend &&
+            identical(_activeSource, source)) {
+          _activeAdapter = null;
+          _activeBackend = null;
+          _activeSource = null;
+        }
+        await adapter.stop();
+        return null;
+      }
       _activeSource = source;
       _diagnostics
         ..add(successDiagnostic)
         ..add('active-backend:${backend.name}:ready');
       return null;
     } on PlaybackException catch (error) {
-      if (identical(_activeAdapter, adapter) && _activeBackend == backend) {
+      if (identical(_activeAdapter, adapter) &&
+          _activeBackend == backend &&
+          identical(_activeSource, source)) {
         _activeAdapter = null;
         _activeBackend = null;
         _activeSource = null;
@@ -215,6 +243,7 @@ class PlaybackOrchestrator {
 
   Future<void> _openServerTranscode(
     PlaybackSource source, {
+    required int generation,
     required PlaybackException? lastFailure,
   }) async {
     final adapter = _adapters[PlaybackBackend.serverTranscode];
@@ -240,6 +269,7 @@ class PlaybackOrchestrator {
         _serverRequestFromSource(source),
       );
     } on TranscodeUnavailableException catch (error) {
+      if (!_isCurrentGeneration(generation)) return;
       _emitError(
         PlaybackError(
           backend: PlaybackBackend.serverTranscode,
@@ -250,6 +280,7 @@ class PlaybackOrchestrator {
       );
       return;
     } on Object catch (error) {
+      if (!_isCurrentGeneration(generation)) return;
       _emitError(
         PlaybackError(
           backend: PlaybackBackend.serverTranscode,
@@ -261,6 +292,14 @@ class PlaybackOrchestrator {
       return;
     }
 
+    if (!_isCurrentGeneration(generation)) {
+      // Superseded while starting the transcode — this call's session was
+      // never made active, so tear it down directly rather than through
+      // _cleanupSessions(), which would risk stopping a newer call's
+      // already-active session instead.
+      unawaited(_stopServerTranscode(response));
+      return;
+    }
     _activeServerTranscode = response;
     if (response.status == BroadcastStatus.stalled.value ||
         response.status == BroadcastStatus.failed.value) {
@@ -284,7 +323,11 @@ class PlaybackOrchestrator {
     try {
       broadcast = await _startBroadcastIfNeeded(source);
     } on Object catch (error) {
-      await _cleanupSessions();
+      if (_isCurrentGeneration(generation)) {
+        await _cleanupSessions();
+      } else {
+        unawaited(_abandonServerTranscode(response, null));
+      }
       _emitError(
         PlaybackError(
           backend: PlaybackBackend.serverTranscode,
@@ -293,6 +336,14 @@ class PlaybackOrchestrator {
           recoverable: true,
         ),
       );
+      return;
+    }
+
+    if (!_isCurrentGeneration(generation)) {
+      unawaited(_abandonServerTranscode(response, broadcast));
+      if (identical(_activeServerTranscode, response)) {
+        _activeServerTranscode = null;
+      }
       return;
     }
     if (broadcast != null) {
@@ -323,10 +374,33 @@ class PlaybackOrchestrator {
     _activeSource = transcodedSource;
     try {
       await adapter.load(transcodedSource);
+      if (!_isCurrentGeneration(generation)) {
+        // Same reasoning as _tryLoadBackend: the server-transcode adapter is
+        // also a single shared instance, so adapter/backend identity alone
+        // can't distinguish this call from a newer one that reused it —
+        // check source identity too.
+        if (identical(_activeAdapter, adapter) &&
+            _activeBackend == PlaybackBackend.serverTranscode &&
+            identical(_activeSource, transcodedSource)) {
+          _activeAdapter = null;
+          _activeBackend = null;
+          _activeSource = null;
+        }
+        await adapter.stop();
+        if (identical(_activeBroadcast, broadcast) && broadcast != null) {
+          _activeBroadcast = null;
+        }
+        if (identical(_activeServerTranscode, response)) {
+          _activeServerTranscode = null;
+        }
+        unawaited(_abandonServerTranscode(response, broadcast));
+        return;
+      }
       _diagnostics.add('active-backend:serverTranscode:ready');
     } on PlaybackException catch (error) {
       if (identical(_activeAdapter, adapter) &&
-          _activeBackend == PlaybackBackend.serverTranscode) {
+          _activeBackend == PlaybackBackend.serverTranscode &&
+          identical(_activeSource, transcodedSource)) {
         _activeAdapter = null;
         _activeBackend = null;
         _activeSource = null;
@@ -334,6 +408,22 @@ class PlaybackOrchestrator {
       await _cleanupSessions();
       _emitError(PlaybackError.fromException(error));
     }
+  }
+
+  // Tears down a transcode/broadcast pair that a superseded open() call
+  // started, without going through _cleanupSessions() (which operates on
+  // whatever is *currently* active and could belong to a newer call by now).
+  Future<void> _abandonServerTranscode(
+    TranscodeResponse response,
+    BroadcastSession? broadcast,
+  ) async {
+    if (broadcast != null) {
+      await _transcodeGateway.stopBroadcast(broadcast.networkId);
+      _diagnostics.add(
+        'cleanup:broadcast:stopped:${broadcast.networkId}:abandoned',
+      );
+    }
+    await _stopServerTranscode(response);
   }
 
   StreamRequest _serverRequestFromSource(PlaybackSource source) {
@@ -360,8 +450,12 @@ class PlaybackOrchestrator {
     return _transcodeGateway.startBroadcast(_serverRequestFromSource(source));
   }
 
+  // Does NOT bump _playbackGeneration itself — callers that represent the
+  // start of a new logical operation (open(), stop()) must bump exactly
+  // once, synchronously, before calling this. If this bumped on every call,
+  // open()'s own generation check would immediately see itself as stale
+  // right after calling this, even with no concurrent call in sight.
   Future<void> _stopActiveAdapter() async {
-    _playbackGeneration += 1;
     _cancelBufferingTimer();
     final adapter = _activeAdapter;
     if (adapter == null) return;
@@ -370,6 +464,11 @@ class PlaybackOrchestrator {
     _activeSource = null;
     await adapter.stop();
   }
+
+  int _beginGeneration() => _playbackGeneration += 1;
+
+  bool _isCurrentGeneration(int generation) =>
+      generation == _playbackGeneration;
 
   Future<void> _cleanupSessions() async {
     final broadcast = _activeBroadcast;
@@ -463,6 +562,7 @@ class PlaybackOrchestrator {
       return;
     }
     if (_activeRecoveryAttempts >= 1) {
+      _beginGeneration();
       await _stopActiveAdapter();
       await _cleanupSessions();
       _emitError(error);
@@ -485,11 +585,13 @@ class PlaybackOrchestrator {
       await adapter.load(source);
     } on PlaybackException catch (retryError) {
       if (_disposed || generation != _playbackGeneration) return;
+      _beginGeneration();
       await _stopActiveAdapter();
       await _cleanupSessions();
       _emitError(PlaybackError.fromException(retryError));
     } on Object catch (retryError) {
       if (_disposed || generation != _playbackGeneration) return;
+      _beginGeneration();
       await _stopActiveAdapter();
       await _cleanupSessions();
       _emitError(

--- a/flutter_client/test/playback/playback_orchestrator_test.dart
+++ b/flutter_client/test/playback/playback_orchestrator_test.dart
@@ -687,6 +687,150 @@ void main() {
       },
       timeout: const Timeout(Duration(seconds: 3)),
     );
+
+    test(
+      'a slower older open() cannot win after a faster newer one completes',
+      () async {
+        // Regression test for a race a reviewer found: rapid channel
+        // switching starts a second open() before the first's adapter.load()
+        // resolves. If the first call's late success is allowed to run its
+        // normal "activate" path, it silently replaces the channel the user
+        // switched to with the one they switched away from.
+        final adapter = _GatedPlayerAdapter(
+          capabilities: PlaybackCapabilities.androidExoPlayer,
+        );
+        final transcode = _FakeTranscodeGateway();
+        final orchestrator = _orchestrator(
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.androidExoPlayer: adapter,
+          },
+          transcodeGateway: transcode,
+        );
+
+        const older = PlaybackSource(
+          uri: 'https://provider.example/live/older.ts',
+          isLive: true,
+        );
+        const newer = PlaybackSource(
+          uri: 'https://provider.example/live/newer.ts',
+          isLive: true,
+        );
+
+        adapter.holdLoad(older.uri);
+        final olderOpen = orchestrator.open(older);
+        await pumpEventQueue();
+        expect(adapter.loadedUris, <String>[older.uri]);
+
+        // A newer open() call for a different channel starts and completes
+        // in full while the older one is still stuck loading.
+        await orchestrator.open(newer);
+        expect(adapter.loadedUris, <String>[older.uri, newer.uri]);
+        final diagnosticsAfterNewer = List<String>.from(
+          orchestrator.diagnostics,
+        );
+
+        // Only now does the older call's load() finally resolve.
+        adapter.releaseLoad(older.uri);
+        await olderOpen;
+        await pumpEventQueue();
+
+        // The older load succeeded on the adapter, but arrived stale: the
+        // orchestrator must stop it rather than let it silently become
+        // "active" again, and must not re-run the activation diagnostics
+        // newer() already recorded.
+        expect(adapter.stoppedUris, contains(older.uri));
+        expect(orchestrator.diagnostics, diagnosticsAfterNewer);
+
+        await orchestrator.dispose();
+      },
+    );
+
+    test(
+      'a slower older server-transcode response cannot win after a faster '
+      'newer one loads',
+      () async {
+        // Regression test for the same race in the server-transcode
+        // fallback path: _openServerTranscode previously never checked the
+        // generation at all, so a delayed startServerTranscode() response
+        // for an abandoned channel could still get loaded after a newer
+        // channel's transcode had already started playing.
+        final serverPlayer = _FakePlayerAdapter(
+          capabilities: PlaybackCapabilities.serverTranscode,
+        );
+        final transcode = _GatedTranscodeGateway();
+        final orchestrator = PlaybackOrchestrator(
+          platform: PlaybackPlatform.android,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.serverTranscode: serverPlayer,
+          },
+          transcodeGateway: transcode,
+        );
+
+        const older = PlaybackSource(
+          uri: 'https://provider.example/live/older-source.ts',
+          isLive: true,
+        );
+        const newer = PlaybackSource(
+          uri: 'https://provider.example/live/newer-source.ts',
+          isLive: true,
+        );
+
+        final olderOpen = orchestrator.open(older);
+        await pumpEventQueue();
+        expect(transcode.startedUrls, <String>[older.uri]);
+
+        final newerOpen = orchestrator.open(newer);
+        await pumpEventQueue();
+        transcode.resolve(
+          newer.uri,
+          const TranscodeResponse(
+            streamId: 'newest-hls',
+            streamUrl:
+                'https://m3u-editor.example/hls/newest-hls/playlist.m3u8',
+            mode: TranscodeMode.server,
+            status: 'running',
+            sessionId: 'session-newest',
+          ),
+        );
+        await newerOpen;
+        await pumpEventQueue();
+
+        expect(serverPlayer.loadedSources, hasLength(1));
+        expect(
+          serverPlayer.loadedSources.single.uri,
+          'https://m3u-editor.example/hls/newest-hls/playlist.m3u8',
+        );
+
+        // Now resolve the older (stale) transcode request.
+        transcode.resolve(
+          older.uri,
+          const TranscodeResponse(
+            streamId: 'older-hls',
+            streamUrl: 'https://m3u-editor.example/hls/older-hls/playlist.m3u8',
+            mode: TranscodeMode.server,
+            status: 'running',
+            sessionId: 'session-older',
+          ),
+        );
+        await olderOpen;
+        await pumpEventQueue();
+
+        // The stale response must never reach the adapter — only
+        // "newest-hls" should ever have been loaded — and its now-orphaned
+        // server-transcode session must be torn down.
+        expect(serverPlayer.loadedSources, hasLength(1));
+        expect(
+          serverPlayer.loadedSources.single.uri,
+          'https://m3u-editor.example/hls/newest-hls/playlist.m3u8',
+        );
+        expect(
+          transcode.stoppedServerTranscodes,
+          contains('older-hls:session-older'),
+        );
+
+        await orchestrator.dispose();
+      },
+    );
   });
 }
 
@@ -783,6 +927,143 @@ class _FakeTranscodeGateway implements PlaybackTranscodeGateway {
     required String? sessionId,
   }) async {
     stoppedServerTranscodes.add('$streamId:$sessionId');
+  }
+}
+
+/// Gateway whose startServerTranscode() blocks per-URL until the test calls
+/// [resolve], so overlapping open() calls can be raced deterministically.
+class _GatedTranscodeGateway implements PlaybackTranscodeGateway {
+  final Map<String, Completer<TranscodeResponse>> _gates =
+      <String, Completer<TranscodeResponse>>{};
+  final List<String> startedUrls = <String>[];
+  final List<String> stoppedServerTranscodes = <String>[];
+  final List<String> stoppedBroadcasts = <String>[];
+
+  Completer<TranscodeResponse> _gateFor(String url) =>
+      _gates.putIfAbsent(url, Completer<TranscodeResponse>.new);
+
+  void resolve(String url, TranscodeResponse response) =>
+      _gateFor(url).complete(response);
+
+  @override
+  Future<TranscodeResponse> startServerTranscode(StreamRequest request) {
+    startedUrls.add(request.url);
+    return _gateFor(request.url).future;
+  }
+
+  @override
+  Future<BroadcastSession?> startBroadcast(StreamRequest request) async => null;
+
+  @override
+  Future<void> stopBroadcast(String networkId) async {
+    stoppedBroadcasts.add(networkId);
+  }
+
+  @override
+  Future<void> stopServerTranscode({
+    required String streamId,
+    required String? sessionId,
+  }) async {
+    stoppedServerTranscodes.add('$streamId:$sessionId');
+  }
+}
+
+/// Player adapter whose load() blocks per-URI until the test calls
+/// [releaseLoad], so overlapping open() calls can be raced deterministically.
+class _GatedPlayerAdapter implements PlayerAdapter {
+  _GatedPlayerAdapter({required this.capabilities});
+
+  @override
+  final PlaybackCapabilities capabilities;
+
+  final List<String> loadedUris = <String>[];
+  final List<String> stoppedUris = <String>[];
+  final Map<String, Completer<void>> _gates = <String, Completer<void>>{};
+  final Set<String> _held = <String>{};
+  String? _loadedUri;
+
+  final StreamController<PlaybackState> _stateController =
+      StreamController<PlaybackState>.broadcast();
+  final StreamController<PlaybackError> _errorController =
+      StreamController<PlaybackError>.broadcast();
+
+  PlaybackState _state = const PlaybackState.idle(
+    backend: PlaybackBackend.androidExoPlayer,
+  );
+
+  @override
+  Stream<PlaybackState> get onState => _stateController.stream;
+
+  @override
+  Stream<PlaybackError> get onError => _errorController.stream;
+
+  Completer<void> _gateFor(String uri) =>
+      _gates.putIfAbsent(uri, Completer<void>.new);
+
+  // Only URIs explicitly held block inside load() — every other URI
+  // resolves immediately, so a test only needs to gate the specific call
+  // it wants to race.
+  void holdLoad(String uri) {
+    _held.add(uri);
+    _gateFor(uri);
+  }
+
+  void releaseLoad(String uri) => _gateFor(uri).complete();
+
+  @override
+  Future<void> load(PlaybackSource source) async {
+    loadedUris.add(source.uri);
+    if (_held.contains(source.uri)) {
+      await _gateFor(source.uri).future;
+    }
+    _loadedUri = source.uri;
+    _emit(
+      PlaybackState(
+        backend: capabilities.backend,
+        status: PlaybackStatus.ready,
+        source: source,
+        position: source.startPosition,
+      ),
+    );
+  }
+
+  @override
+  Future<void> play() async =>
+      _emit(_state.copyWith(status: PlaybackStatus.playing));
+
+  @override
+  Future<void> pause() async =>
+      _emit(_state.copyWith(status: PlaybackStatus.paused));
+
+  @override
+  Future<void> seek(Duration position) async =>
+      _emit(_state.copyWith(position: position));
+
+  @override
+  Future<void> stop() async {
+    if (_loadedUri != null) stoppedUris.add(_loadedUri!);
+    _loadedUri = null;
+    _emit(_state.copyWith(status: PlaybackStatus.stopped));
+  }
+
+  @override
+  Future<void> setAudioTrack(String? trackId) async {}
+
+  @override
+  Future<void> setSubtitleTrack(String? trackId) async {}
+
+  @override
+  Future<void> setPlaybackSpeed(double speed) async {}
+
+  @override
+  Future<void> dispose() async {
+    await _stateController.close();
+    await _errorController.close();
+  }
+
+  void _emit(PlaybackState state) {
+    _state = state;
+    _stateController.add(state);
   }
 }
 

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -613,6 +613,82 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
   });
 
+  testWidgets(
+    'live channel skip-next reuses the orchestrator instead of rebuilding it',
+    (tester) async {
+      // Regression test: the Android Media3 and Apple AVKit native plugins
+      // each hold a single global player behind their MethodChannel. Building
+      // a fresh PlaybackOrchestrator per channel switch (as skip-next used
+      // to) let the previous orchestrator's deferred dispose tear down the
+      // channel the user had just switched to, once its load already landed.
+      // AppShell must now reuse the existing orchestrator across an
+      // in-session channel switch instead of building a new one.
+      var builderCallCount = 0;
+      final adapter = _NavigationPlayerAdapter();
+      final appState = _testAppState(
+        xtreamService: _NavigationXtreamService(
+          liveChannels: const <Channel>[
+            Channel(
+              id: 101,
+              name: 'Route News',
+              streamUrl: 'http://example.com/live/101.m3u8',
+              categoryId: 'live',
+            ),
+            Channel(
+              id: 102,
+              name: 'Route Sports',
+              streamUrl: 'http://example.com/live/102.m3u8',
+              categoryId: 'live',
+            ),
+          ],
+        ),
+      );
+      addTearDown(appState.dispose);
+      await appState.connectXtream(
+        const UserCredentials(
+          server: 'http://example.com',
+          username: 'user',
+          password: 'pass',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _TestApp(
+          deviceType: DeviceType.tv,
+          appState: appState,
+          useProductionPlayer: true,
+          playbackOrchestratorBuilder: () {
+            builderCallCount++;
+            return _testPlaybackOrchestrator(adapter);
+          },
+        ),
+      );
+      await _pumpAppFrame(tester);
+
+      await tester.tap(find.text('Route News').last);
+      await _pumpAppFrame(tester);
+
+      expect(builderCallCount, 1);
+      expect(adapter.loadCallCount, 1);
+
+      await tester.tap(find.byIcon(Icons.skip_next));
+      await _pumpAppFrame(tester);
+
+      expect(
+        builderCallCount,
+        1,
+        reason: 'channel switch must reuse the existing orchestrator',
+      );
+      expect(
+        adapter.disposeCallCount,
+        0,
+        reason: 'the just-opened channel must not be torn down mid-switch',
+      );
+      expect(adapter.loadCallCount, 2);
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
   testWidgets('lifecycle resume keeps an active player immersive', (
     tester,
   ) async {
@@ -1763,6 +1839,9 @@ class _NavigationPlayerAdapter implements PlayerAdapter {
   final StreamController<PlaybackError> _errorController =
       StreamController<PlaybackError>.broadcast();
 
+  int loadCallCount = 0;
+  int disposeCallCount = 0;
+
   @override
   PlaybackCapabilities get capabilities => PlaybackCapabilities.desktopLibmpv;
 
@@ -1774,6 +1853,7 @@ class _NavigationPlayerAdapter implements PlayerAdapter {
 
   @override
   Future<void> load(PlaybackSource source) async {
+    loadCallCount++;
     _stateController.add(
       PlaybackState(
         backend: PlaybackBackend.desktopLibmpv,
@@ -1809,6 +1889,7 @@ class _NavigationPlayerAdapter implements PlayerAdapter {
 
   @override
   Future<void> dispose() async {
+    disposeCallCount++;
     await _stateController.close();
     await _errorController.close();
   }

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1825,5 +1825,72 @@ void main() {
         expect(adapter.disposeCallCount, 0);
       },
     );
+
+    testWidgets(
+      'switching to a channel sharing a URL but a different stream ID '
+      'still re-opens the new source',
+      (tester) async {
+        // Two channels can share a stream URL (e.g. a proxied/transcoded URL
+        // keyed by query params the client doesn't see) while differing in
+        // stream ID, headers, EPG ID, or metadata. Comparing streamUrl alone
+        // in didUpdateWidget would wrongly treat this as a no-op switch and
+        // leave the previous channel's EPG/state in place.
+        final adapter = FakePlayerAdapter(
+          capabilities: PlaybackCapabilities.desktopLibmpv,
+          textureId: 9,
+        );
+        final orchestrator = PlaybackOrchestrator(
+          platform: PlaybackPlatform.desktop,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.desktopLibmpv: adapter,
+          },
+          transcodeGateway: FakeTranscodeGateway(),
+        );
+        addTearDown(orchestrator.dispose);
+
+        const sharedUrl = 'https://example.com/shared.m3u8';
+        const channelA = PlayerArgs(
+          streamUrl: sharedUrl,
+          title: 'Channel A',
+          type: 'live',
+          streamId: 1,
+          epgChannelId: 'channel-a',
+        );
+        const channelB = PlayerArgs(
+          streamUrl: sharedUrl,
+          title: 'Channel B',
+          type: 'live',
+          streamId: 2,
+          epgChannelId: 'channel-b',
+        );
+
+        var args = channelA;
+        late StateSetter setArgs;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StatefulBuilder(
+              builder: (context, setState) {
+                setArgs = setState;
+                return PlayerScreen(
+                  key: const ValueKey('player-session'),
+                  args: args,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                );
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(adapter.loadCalls, hasLength(1));
+
+        setArgs(() => args = channelB);
+        await tester.pump();
+
+        // Same URL, but a genuinely different channel — must still re-open.
+        expect(adapter.loadCalls, hasLength(2));
+      },
+    );
   });
 }

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1754,5 +1754,76 @@ void main() {
       expect(find.text('Launcher'), findsOneWidget);
       expect(find.text('Playback error'), findsNothing);
     });
+
+    testWidgets(
+      'switching live channel via a stable key reuses the orchestrator '
+      'instead of disposing it',
+      (tester) async {
+        // Mirrors AppShell: skip-previous/skip-next replaces `args` on an
+        // already-mounted PlayerScreen (stable key, same orchestrator)
+        // instead of remounting with a fresh orchestrator per channel. If
+        // that stops happening, the Android Media3/Apple AVKit native
+        // plugins' single global player gets released out from under the
+        // channel the user just switched to.
+        final adapter = FakePlayerAdapter(
+          capabilities: PlaybackCapabilities.desktopLibmpv,
+          textureId: 7,
+        );
+        final orchestrator = PlaybackOrchestrator(
+          platform: PlaybackPlatform.desktop,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.desktopLibmpv: adapter,
+          },
+          transcodeGateway: FakeTranscodeGateway(),
+        );
+        addTearDown(orchestrator.dispose);
+
+        const channelA = PlayerArgs(
+          streamUrl: 'https://example.com/channel-a.m3u8',
+          title: 'Channel A',
+          type: 'live',
+          streamId: 1,
+        );
+        const channelB = PlayerArgs(
+          streamUrl: 'https://example.com/channel-b.m3u8',
+          title: 'Channel B',
+          type: 'live',
+          streamId: 2,
+        );
+
+        var args = channelA;
+        late StateSetter setArgs;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StatefulBuilder(
+              builder: (context, setState) {
+                setArgs = setState;
+                return PlayerScreen(
+                  key: const ValueKey('player-session'),
+                  args: args,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                );
+              },
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(adapter.loadCalls, hasLength(1));
+        expect(adapter.loadCalls.single.uri, channelA.streamUrl);
+        expect(adapter.disposeCallCount, 0);
+
+        setArgs(() => args = channelB);
+        await tester.pump();
+
+        // The switch happened in place: same adapter kept loading, never
+        // torn down mid-flight.
+        expect(adapter.loadCalls, hasLength(2));
+        expect(adapter.loadCalls.last.uri, channelB.streamUrl);
+        expect(adapter.disposeCallCount, 0);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- Skip-previous/skip-next replaced `args` on the player by building a brand-new `PlaybackOrchestrator` per channel and remounting `PlayerScreen` with a key tied to the stream URL.
- The Android Media3 and Apple AVKit native plugins each hold a single global player behind their `MethodChannel`, so the *old* channel's deferred teardown (`orchestrator.stop()` then `dispose()`, scheduled a frame after the switch) ended up running against whatever the native side currently had loaded — the channel the user had just switched to. Its event sink got nulled in the process, so `PlayerScreen` never received another state update and hit the 20s loading timeout ("Stream loading timed out...").
- `AppShell` now reuses the existing orchestrator/session whenever a player is already open, and `PlayerScreen` gets a stable per-session key so its `State` survives the switch via `didUpdateWidget` instead of being torn down. `didUpdateWidget` resets per-channel state (status, tracks, EPG, error/failure flags, Trakt scrobble) and re-opens the new source through the already-live stream subscriptions rather than doubling them up.
- Also fixes a related race where an in-flight EPG fetch for the previous channel could overwrite the new channel's EPG overlay, and adds a generation guard in `PlaybackOrchestrator.open()` so a stale in-flight load can't clobber state set by a newer one.

## Test plan

- [x] `flutter analyze lib test` — clean
- [x] `flutter test` — all passing (545), including two new regression tests:
  - `PlayerScreen` test asserting a channel switch reuses the same adapter (no dispose)
  - `AppShell`-level test asserting the orchestrator builder is invoked once across a real skip-next, with the adapter never disposed mid-switch
- [x] Confirmed the new `AppShell` test fails against the pre-fix code and passes with the fix
- [x] `flutter build linux --release` compiles cleanly (note: the Linux desktop backend is handle-scoped per player instance, so it was never affected by this race — this only confirms the refactor builds there)