### PR TITLE
fix(epg): navigate bounded catchup date ranges

### DIFF
--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -87,7 +87,12 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
 
   void _initWindow() {
     _windowStart = _selectedDate;
-    _windowEnd = _windowStart.add(Duration(hours: widget.windowHours));
+    _windowEnd = DateTime(
+      _selectedDate.year,
+      _selectedDate.month,
+      _selectedDate.day,
+      widget.windowHours,
+    );
     _totalW = _windowEnd.difference(_windowStart).inMinutes * _kPxPerMin;
   }
 
@@ -116,6 +121,9 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
   DateTime _dateOnly(DateTime value) =>
       DateTime(value.year, value.month, value.day);
 
+  DateTime _offsetDate(DateTime value, int days) =>
+      DateTime(value.year, value.month, value.day + days);
+
   int get _maxCatchupDays => widget.channels
       .where((channel) => channel.catchupSupported)
       .map((channel) => channel.catchupDays ?? 0)
@@ -123,13 +131,14 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
 
   void _selectDate(DateTime date) {
     final today = _dateOnly(widget.clock());
-    final earliest = today.subtract(Duration(days: _maxCatchupDays));
-    final latest = today.add(Duration(days: widget.futureDays));
-    final selected = date.isBefore(earliest)
+    final earliest = _offsetDate(today, -_maxCatchupDays);
+    final latest = _offsetDate(today, widget.futureDays);
+    final requested = _dateOnly(date);
+    final selected = requested.isBefore(earliest)
         ? earliest
-        : date.isAfter(latest)
+        : requested.isAfter(latest)
         ? latest
-        : date;
+        : requested;
     if (selected == _selectedDate) return;
     setState(() {
       _selectedDate = selected;
@@ -177,11 +186,11 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
       }
       _rowHCtrls = _makeRowCtrls(widget.channels.length);
     }
-    final earliest = _dateOnly(
-      widget.clock(),
-    ).subtract(Duration(days: _maxCatchupDays));
-    if (_selectedDate.isBefore(earliest)) {
-      _selectedDate = earliest;
+    final today = _dateOnly(widget.clock());
+    final earliest = _offsetDate(today, -_maxCatchupDays);
+    final latest = _offsetDate(today, widget.futureDays);
+    if (_selectedDate.isBefore(earliest) || _selectedDate.isAfter(latest)) {
+      _selectedDate = _selectedDate.isBefore(earliest) ? earliest : latest;
       _initWindow();
     }
   }
@@ -209,16 +218,14 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
         _DayControls(
           selectedDate: _selectedDate,
           canGoPrevious: _selectedDate.isAfter(
-            _dateOnly(now).subtract(Duration(days: _maxCatchupDays)),
+            _offsetDate(now, -_maxCatchupDays),
           ),
           canGoNext: _selectedDate.isBefore(
-            _dateOnly(now).add(Duration(days: widget.futureDays)),
+            _offsetDate(now, widget.futureDays),
           ),
-          onPrevious: () => _selectDate(
-            _selectedDate.subtract(const Duration(days: 1)),
-          ),
+          onPrevious: () => _selectDate(_offsetDate(_selectedDate, -1)),
           onNow: () => _selectDate(_dateOnly(widget.clock())),
-          onNext: () => _selectDate(_selectedDate.add(const Duration(days: 1))),
+          onNext: () => _selectDate(_offsetDate(_selectedDate, 1)),
         ),
         Expanded(
           child: Row(
@@ -455,6 +462,7 @@ class _DayControls extends StatelessWidget {
             key: const ValueKey('timeline-previous-day'),
             onTap: canGoPrevious ? onPrevious : null,
             autofocus: canGoPrevious,
+            enabled: canGoPrevious,
             borderRadius: BorderRadius.circular(8),
             child: Padding(
               padding: const EdgeInsets.all(5),
@@ -501,6 +509,7 @@ class _DayControls extends StatelessWidget {
           DpadInkWell(
             key: const ValueKey('timeline-next-day'),
             onTap: canGoNext ? onNext : null,
+            enabled: canGoNext,
             borderRadius: BorderRadius.circular(8),
             child: Padding(
               padding: const EdgeInsets.all(5),
@@ -826,5 +835,15 @@ bool _canReplay(
   if (!catchupSupported || !program.end.isBefore(now)) return false;
   if (catchupDays == null) return true;
   if (catchupDays <= 0) return false;
-  return !program.start.isBefore(now.subtract(Duration(days: catchupDays)));
+  final earliest = DateTime(
+    now.year,
+    now.month,
+    now.day - catchupDays,
+    now.hour,
+    now.minute,
+    now.second,
+    now.millisecond,
+    now.microsecond,
+  );
+  return !program.start.isBefore(earliest);
 }

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -22,8 +22,9 @@ const double _kChannelColW = 128;
 const double _kTimeHeaderH = 28;
 const double _kRowH = 60;
 const double _kPxPerMin = 5; // 300 px per hour
+const int _kCatchupFallbackDays = 7;
 
-/// Horizontal TV-guide style EPG — channels on the Y-axis, time on the X-axis.
+/// Horizontal TV-guide style EPG with channels on Y and time on X.
 ///
 /// Programs appear as proportionally-sized blocks that can be scrolled left/right
 /// to move through the time window. The channel name column and time header stay
@@ -125,8 +126,12 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
       DateTime(value.year, value.month, value.day + days);
 
   int get _maxCatchupDays => widget.channels
-      .where((channel) => channel.catchupSupported)
-      .map((channel) => channel.catchupDays ?? 0)
+      .map(
+        (channel) => _effectiveCatchupDays(
+          channel.catchupSupported,
+          channel.catchupDays,
+        ),
+      )
       .fold(0, math.max);
 
   void _selectDate(DateTime date) {
@@ -325,6 +330,11 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
                             itemExtent: _kRowH,
                             itemBuilder: (_, i) {
                               final channel = widget.channels[i];
+                              final catchupRetentionDays =
+                                  _effectiveCatchupDays(
+                                    channel.catchupSupported,
+                                    channel.catchupDays,
+                                  );
                               widget.onEnsureEpg?.call(
                                 [channel],
                                 startDate: _selectedDate,
@@ -356,13 +366,11 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
                                     pixelsPerMinute: _kPxPerMin,
                                     totalWidth: _totalW,
                                     rowHeight: _kRowH,
-                                    catchupSupported: channel.catchupSupported,
-                                    catchupDays: channel.catchupDays,
+                                    catchupRetentionDays: catchupRetentionDays,
                                     now: now,
                                     onTap: (program) {
                                       final canReplay = _canReplay(
-                                        channel.catchupSupported,
-                                        channel.catchupDays,
+                                        catchupRetentionDays,
                                         program,
                                         widget.clock(),
                                       );
@@ -662,8 +670,7 @@ class _ProgramsRow extends StatelessWidget {
     required this.totalWidth,
     required this.rowHeight,
     required this.onTap,
-    required this.catchupSupported,
-    required this.catchupDays,
+    required this.catchupRetentionDays,
     required this.now,
   });
 
@@ -674,12 +681,11 @@ class _ProgramsRow extends StatelessWidget {
   final double totalWidth;
   final double rowHeight;
   final void Function(EpgProgram program) onTap;
-  final bool catchupSupported;
-  final int? catchupDays;
+  final int catchupRetentionDays;
   final DateTime now;
 
   bool showCatchupIcon(EpgProgram program) =>
-      _canReplay(catchupSupported, catchupDays, program, now);
+      _canReplay(catchupRetentionDays, program, now);
 
   @override
   Widget build(BuildContext context) {
@@ -826,19 +832,21 @@ class _ProgramsRow extends StatelessWidget {
   }
 }
 
+int _effectiveCatchupDays(bool catchupSupported, int? catchupDays) {
+  if (!catchupSupported) return 0;
+  return catchupDays ?? _kCatchupFallbackDays;
+}
+
 bool _canReplay(
-  bool catchupSupported,
-  int? catchupDays,
+  int catchupRetentionDays,
   EpgProgram program,
   DateTime now,
 ) {
-  if (!catchupSupported || !program.end.isBefore(now)) return false;
-  if (catchupDays == null) return true;
-  if (catchupDays <= 0) return false;
+  if (catchupRetentionDays <= 0 || !program.end.isBefore(now)) return false;
   final earliest = DateTime(
     now.year,
     now.month,
-    now.day - catchupDays,
+    now.day - catchupRetentionDays,
     now.hour,
     now.minute,
     now.second,

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -454,6 +454,7 @@ class _DayControls extends StatelessWidget {
           DpadInkWell(
             key: const ValueKey('timeline-previous-day'),
             onTap: canGoPrevious ? onPrevious : null,
+            autofocus: canGoPrevious,
             borderRadius: BorderRadius.circular(8),
             child: Padding(
               padding: const EdgeInsets.all(5),
@@ -482,6 +483,7 @@ class _DayControls extends StatelessWidget {
           DpadInkWell(
             key: const ValueKey('timeline-now'),
             onTap: onNow,
+            autofocus: !canGoPrevious,
             borderRadius: BorderRadius.circular(50),
             color: colorScheme.primaryContainer,
             child: Padding(

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/services/domain_models.dart';
@@ -10,6 +11,12 @@ import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
 typedef CatchupProgramSelect =
     void Function(Channel channel, EpgProgram program);
+typedef EnsureEpg =
+    void Function(
+      List<Channel> channels, {
+      DateTime? startDate,
+      DateTime? endDate,
+    });
 
 const double _kChannelColW = 128;
 const double _kTimeHeaderH = 28;
@@ -29,7 +36,9 @@ class TimelineEpgView extends StatefulWidget {
     required this.onChannelSelect,
     this.onCatchupProgramSelect,
     this.onEnsureEpg,
-    this.windowHours = 6,
+    this.windowHours = 24,
+    this.futureDays = 7,
+    this.clock = DateTime.now,
   });
 
   final List<Channel> channels;
@@ -39,10 +48,12 @@ class TimelineEpgView extends StatefulWidget {
 
   /// Requests EPG data for a channel be fetched (lazily, debounced) if not
   /// already fresh. Called per-row as the visible timeline builds.
-  final void Function(List<Channel>)? onEnsureEpg;
+  final EnsureEpg? onEnsureEpg;
 
-  /// How many hours the visible window spans (default 6).
+  /// How many hours the selected-day window spans (default 24).
   final int windowHours;
+  final int futureDays;
+  final Clock clock;
 
   @override
   State<TimelineEpgView> createState() => _TimelineEpgViewState();
@@ -55,6 +66,7 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
   late List<ScrollController> _rowHCtrls;
   bool _vSyncing = false;
   bool _hSyncing = false;
+  late DateTime _selectedDate;
   late DateTime _windowStart;
   late DateTime _windowEnd;
   late double _totalW;
@@ -62,6 +74,7 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
   @override
   void initState() {
     super.initState();
+    _selectedDate = _dateOnly(widget.clock());
     _initWindow();
     _leftVCtrl = ScrollController();
     _rightVCtrl = ScrollController();
@@ -73,14 +86,8 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
   }
 
   void _initWindow() {
-    final now = DateTime.now();
-    _windowStart = DateTime(
-      now.year,
-      now.month,
-      now.day,
-      now.hour,
-    ).subtract(const Duration(hours: 1));
-    _windowEnd = _windowStart.add(Duration(hours: widget.windowHours + 2));
+    _windowStart = _selectedDate;
+    _windowEnd = _windowStart.add(Duration(hours: widget.windowHours));
     _totalW = _windowEnd.difference(_windowStart).inMinutes * _kPxPerMin;
   }
 
@@ -89,14 +96,46 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
 
   void _scrollToNow(_) {
     if (!mounted) return;
-    final nowOffset =
-        DateTime.now().difference(_windowStart).inMinutes * _kPxPerMin;
+    final now = widget.clock();
+    final anchor = DateTime(
+      _selectedDate.year,
+      _selectedDate.month,
+      _selectedDate.day,
+      now.hour,
+      now.minute,
+    );
+    final nowOffset = anchor.difference(_windowStart).inMinutes * _kPxPerMin;
     final target = math.max(0, nowOffset - 80.0);
     for (final c in [_headerHCtrl, ..._rowHCtrls]) {
       if (c.hasClients) {
         c.jumpTo(target.clamp(0.0, c.position.maxScrollExtent).toDouble());
       }
     }
+  }
+
+  DateTime _dateOnly(DateTime value) =>
+      DateTime(value.year, value.month, value.day);
+
+  int get _maxCatchupDays => widget.channels
+      .where((channel) => channel.catchupSupported)
+      .map((channel) => channel.catchupDays ?? 0)
+      .fold(0, math.max);
+
+  void _selectDate(DateTime date) {
+    final today = _dateOnly(widget.clock());
+    final earliest = today.subtract(Duration(days: _maxCatchupDays));
+    final latest = today.add(Duration(days: widget.futureDays));
+    final selected = date.isBefore(earliest)
+        ? earliest
+        : date.isAfter(latest)
+        ? latest
+        : date;
+    if (selected == _selectedDate) return;
+    setState(() {
+      _selectedDate = selected;
+      _initWindow();
+    });
+    WidgetsBinding.instance.addPostFrameCallback(_scrollToNow);
   }
 
   void _onLeftV() {
@@ -138,6 +177,13 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
       }
       _rowHCtrls = _makeRowCtrls(widget.channels.length);
     }
+    final earliest = _dateOnly(
+      widget.clock(),
+    ).subtract(Duration(days: _maxCatchupDays));
+    if (_selectedDate.isBefore(earliest)) {
+      _selectedDate = earliest;
+      _initWindow();
+    }
   }
 
   @override
@@ -156,170 +202,211 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final now = widget.clock();
 
-    return Row(
+    return Column(
       children: [
-        // ── Fixed left channel column ──────────────────────────────────────
-        SizedBox(
-          width: _kChannelColW,
-          child: Column(
-            children: [
-              // Corner cell
-              Container(
-                height: _kTimeHeaderH,
-                color: colorScheme.surfaceContainerHighest,
-                padding: const EdgeInsets.symmetric(horizontal: 10),
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  'CHANNELS',
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    color: colorScheme.onSurfaceVariant,
-                    letterSpacing: 1.2,
-                  ),
-                ),
-              ),
-              // Channel name/logo list (synced vertically with program rows)
-              Expanded(
-                child: ListView.builder(
-                  controller: _leftVCtrl,
-                  itemCount: widget.channels.length,
-                  itemExtent: _kRowH,
-                  itemBuilder: (_, i) =>
-                      _ChannelCell(channel: widget.channels[i]),
-                ),
-              ),
-            ],
+        _DayControls(
+          selectedDate: _selectedDate,
+          canGoPrevious: _selectedDate.isAfter(
+            _dateOnly(now).subtract(Duration(days: _maxCatchupDays)),
           ),
+          canGoNext: _selectedDate.isBefore(
+            _dateOnly(now).add(Duration(days: widget.futureDays)),
+          ),
+          onPrevious: () => _selectDate(
+            _selectedDate.subtract(const Duration(days: 1)),
+          ),
+          onNow: () => _selectDate(_dateOnly(widget.clock())),
+          onNext: () => _selectDate(_selectedDate.add(const Duration(days: 1))),
         ),
-
-        // Thin vertical divider
-        Container(width: 1, color: colorScheme.outlineVariant),
-
-        // ── Right: time header + scrollable program grid ───────────────────
         Expanded(
-          child: Column(
+          child: Row(
             children: [
-              // Time axis header
+              // ── Fixed left channel column ──────────────────────────────────────
               SizedBox(
-                height: _kTimeHeaderH,
-                child: AnimatedBuilder(
-                  animation: _headerHCtrl,
-                  builder: (context, _) {
-                    final hOffset = _headerHCtrl.hasClients
-                        ? _headerHCtrl.offset
-                        : 0.0;
-                    final nowX =
-                        DateTime.now().difference(_windowStart).inMinutes *
-                            _kPxPerMin -
-                        hOffset;
-
-                    return Stack(
-                      children: [
-                        SingleChildScrollView(
-                          controller: _headerHCtrl,
-                          scrollDirection: Axis.horizontal,
-                          physics: const NeverScrollableScrollPhysics(),
-                          child: _TimeHeader(
-                            windowStart: _windowStart,
-                            windowEnd: _windowEnd,
-                            pixelsPerMinute: _kPxPerMin,
-                            height: _kTimeHeaderH,
-                          ),
+                width: _kChannelColW,
+                child: Column(
+                  children: [
+                    // Corner cell
+                    Container(
+                      height: _kTimeHeaderH,
+                      color: colorScheme.surfaceContainerHighest,
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        AppLocalizations.of(context).epgChannels,
+                        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                          letterSpacing: 1.2,
                         ),
-                        if (nowX >= 0)
-                          Positioned(
-                            left: nowX,
-                            top: 4,
-                            bottom: 0,
-                            width: 2,
-                            child: Container(
-                              color: colorScheme.primary.withValues(alpha: 0.8),
-                            ),
-                          ),
-                      ],
-                    );
-                  },
+                      ),
+                    ),
+                    // Channel name/logo list (synced vertically with program rows)
+                    Expanded(
+                      child: ListView.builder(
+                        controller: _leftVCtrl,
+                        itemCount: widget.channels.length,
+                        itemExtent: _kRowH,
+                        itemBuilder: (_, i) =>
+                            _ChannelCell(channel: widget.channels[i]),
+                      ),
+                    ),
+                  ],
                 ),
               ),
 
-              // Program rows
+              // Thin vertical divider
+              Container(width: 1, color: colorScheme.outlineVariant),
+
+              // ── Right: time header + scrollable program grid ───────────────────
               Expanded(
-                child: Stack(
+                child: Column(
                   children: [
-                    ListView.builder(
-                      controller: _rightVCtrl,
-                      itemCount: widget.channels.length,
-                      itemExtent: _kRowH,
-                      itemBuilder: (_, i) {
-                        final channel = widget.channels[i];
-                        widget.onEnsureEpg?.call([channel]);
-                        final programs = widget.epgService.programsForChannel(
-                          channel,
-                        );
-                        return NotificationListener<ScrollUpdateNotification>(
-                          onNotification: (n) {
-                            _syncH(n.metrics.pixels);
-                            return false;
-                          },
-                          child: SingleChildScrollView(
-                            controller: i < _rowHCtrls.length
-                                ? _rowHCtrls[i]
-                                : null,
-                            scrollDirection: Axis.horizontal,
-                            child: _ProgramsRow(
-                              programs: programs,
-                              windowStart: _windowStart,
-                              windowEnd: _windowEnd,
-                              pixelsPerMinute: _kPxPerMin,
-                              totalWidth: _totalW,
-                              rowHeight: _kRowH,
-                              catchupSupported: channel.catchupSupported,
-                              onTap: (program) {
-                                final canReplay =
-                                    channel.catchupSupported &&
-                                    program.end.isBefore(DateTime.now());
-                                if (canReplay &&
-                                    widget.onCatchupProgramSelect != null) {
-                                  widget.onCatchupProgramSelect!(
-                                    channel,
-                                    program,
-                                  );
-                                  return;
-                                }
-                                widget.onChannelSelect(channel);
-                              },
-                            ),
-                          ),
-                        );
-                      },
+                    // Time axis header
+                    SizedBox(
+                      height: _kTimeHeaderH,
+                      child: AnimatedBuilder(
+                        animation: _headerHCtrl,
+                        builder: (context, _) {
+                          final hOffset = _headerHCtrl.hasClients
+                              ? _headerHCtrl.offset
+                              : 0.0;
+                          final nowX =
+                              now.difference(_windowStart).inMinutes *
+                                  _kPxPerMin -
+                              hOffset;
+
+                          return Stack(
+                            children: [
+                              SingleChildScrollView(
+                                controller: _headerHCtrl,
+                                scrollDirection: Axis.horizontal,
+                                physics: const NeverScrollableScrollPhysics(),
+                                child: _TimeHeader(
+                                  windowStart: _windowStart,
+                                  windowEnd: _windowEnd,
+                                  pixelsPerMinute: _kPxPerMin,
+                                  height: _kTimeHeaderH,
+                                ),
+                              ),
+                              if (nowX >= 0 && nowX <= _totalW)
+                                Positioned(
+                                  left: nowX,
+                                  top: 4,
+                                  bottom: 0,
+                                  width: 2,
+                                  child: Container(
+                                    color: colorScheme.primary.withValues(
+                                      alpha: 0.8,
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          );
+                        },
+                      ),
                     ),
 
-                    // "Now" vertical line over the program grid
-                    AnimatedBuilder(
-                      animation: _headerHCtrl,
-                      builder: (context, _) {
-                        if (!_headerHCtrl.hasClients) {
-                          return const SizedBox.shrink();
-                        }
-                        final nowX =
-                            DateTime.now().difference(_windowStart).inMinutes *
-                                _kPxPerMin -
-                            _headerHCtrl.offset;
-                        if (nowX < 0) return const SizedBox.shrink();
-                        return Positioned(
-                          left: nowX,
-                          top: 0,
-                          bottom: 0,
-                          width: 2,
-                          child: IgnorePointer(
-                            child: Container(
-                              color: colorScheme.primary.withValues(
-                                alpha: 0.35,
-                              ),
-                            ),
+                    // Program rows
+                    Expanded(
+                      child: Stack(
+                        children: [
+                          ListView.builder(
+                            controller: _rightVCtrl,
+                            itemCount: widget.channels.length,
+                            itemExtent: _kRowH,
+                            itemBuilder: (_, i) {
+                              final channel = widget.channels[i];
+                              widget.onEnsureEpg?.call(
+                                [channel],
+                                startDate: _selectedDate,
+                                endDate: _selectedDate,
+                              );
+                              final programs = widget.epgService
+                                  .programsForChannel(
+                                    channel,
+                                  );
+                              return NotificationListener<
+                                ScrollUpdateNotification
+                              >(
+                                onNotification: (n) {
+                                  _syncH(n.metrics.pixels);
+                                  return false;
+                                },
+                                child: SingleChildScrollView(
+                                  key: ValueKey(
+                                    'timeline-row-scroll-${channel.id}',
+                                  ),
+                                  controller: i < _rowHCtrls.length
+                                      ? _rowHCtrls[i]
+                                      : null,
+                                  scrollDirection: Axis.horizontal,
+                                  child: _ProgramsRow(
+                                    programs: programs,
+                                    windowStart: _windowStart,
+                                    windowEnd: _windowEnd,
+                                    pixelsPerMinute: _kPxPerMin,
+                                    totalWidth: _totalW,
+                                    rowHeight: _kRowH,
+                                    catchupSupported: channel.catchupSupported,
+                                    catchupDays: channel.catchupDays,
+                                    now: now,
+                                    onTap: (program) {
+                                      final canReplay = _canReplay(
+                                        channel.catchupSupported,
+                                        channel.catchupDays,
+                                        program,
+                                        widget.clock(),
+                                      );
+                                      if (canReplay &&
+                                          widget.onCatchupProgramSelect !=
+                                              null) {
+                                        widget.onCatchupProgramSelect!(
+                                          channel,
+                                          program,
+                                        );
+                                        return;
+                                      }
+                                      widget.onChannelSelect(channel);
+                                    },
+                                  ),
+                                ),
+                              );
+                            },
                           ),
-                        );
-                      },
+
+                          // "Now" vertical line over the program grid
+                          AnimatedBuilder(
+                            animation: _headerHCtrl,
+                            builder: (context, _) {
+                              if (!_headerHCtrl.hasClients) {
+                                return const SizedBox.shrink();
+                              }
+                              final nowX =
+                                  now.difference(_windowStart).inMinutes *
+                                      _kPxPerMin -
+                                  _headerHCtrl.offset;
+                              if (nowX < 0 || nowX > _totalW) {
+                                return const SizedBox.shrink();
+                              }
+                              return Positioned(
+                                left: nowX,
+                                top: 0,
+                                bottom: 0,
+                                width: 2,
+                                child: IgnorePointer(
+                                  child: Container(
+                                    color: colorScheme.primary.withValues(
+                                      alpha: 0.35,
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ],
+                      ),
                     ),
                   ],
                 ),
@@ -335,6 +422,101 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
 // ─────────────────────────────────────────────────────────────────────────────
 // Private sub-widgets
 // ─────────────────────────────────────────────────────────────────────────────
+
+class _DayControls extends StatelessWidget {
+  const _DayControls({
+    required this.selectedDate,
+    required this.canGoPrevious,
+    required this.canGoNext,
+    required this.onPrevious,
+    required this.onNow,
+    required this.onNext,
+  });
+
+  final DateTime selectedDate;
+  final bool canGoPrevious;
+  final bool canGoNext;
+  final VoidCallback onPrevious;
+  final VoidCallback onNow;
+  final VoidCallback onNext;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context);
+    return Container(
+      height: 42,
+      color: colorScheme.surfaceContainerHigh,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          DpadInkWell(
+            key: const ValueKey('timeline-previous-day'),
+            onTap: canGoPrevious ? onPrevious : null,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.all(5),
+              child: Icon(
+                Icons.chevron_left,
+                size: 20,
+                color: canGoPrevious
+                    ? colorScheme.onSurface
+                    : colorScheme.onSurface.withValues(alpha: 0.35),
+                semanticLabel: l10n.epgPreviousDay,
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          SizedBox(
+            width: 116,
+            child: Text(
+              DateFormat.yMMMd(
+                Localizations.localeOf(context).toLanguageTag(),
+              ).format(selectedDate),
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.labelMedium,
+            ),
+          ),
+          const SizedBox(width: 6),
+          DpadInkWell(
+            key: const ValueKey('timeline-now'),
+            onTap: onNow,
+            borderRadius: BorderRadius.circular(50),
+            color: colorScheme.primaryContainer,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+              child: Text(
+                l10n.epgNow,
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: colorScheme.onPrimaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          DpadInkWell(
+            key: const ValueKey('timeline-next-day'),
+            onTap: canGoNext ? onNext : null,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.all(5),
+              child: Icon(
+                Icons.chevron_right,
+                size: 20,
+                color: canGoNext
+                    ? colorScheme.onSurface
+                    : colorScheme.onSurface.withValues(alpha: 0.35),
+                semanticLabel: l10n.epgNextDay,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
 
 class _ChannelCell extends StatelessWidget {
   const _ChannelCell({required this.channel});
@@ -470,6 +652,8 @@ class _ProgramsRow extends StatelessWidget {
     required this.rowHeight,
     required this.onTap,
     required this.catchupSupported,
+    required this.catchupDays,
+    required this.now,
   });
 
   final List<EpgProgram> programs;
@@ -480,9 +664,11 @@ class _ProgramsRow extends StatelessWidget {
   final double rowHeight;
   final void Function(EpgProgram program) onTap;
   final bool catchupSupported;
+  final int? catchupDays;
+  final DateTime now;
 
-  bool showCatchupIcon(EpgProgram program, DateTime now) =>
-      catchupSupported && program.end.isBefore(now);
+  bool showCatchupIcon(EpgProgram program) =>
+      _canReplay(catchupSupported, catchupDays, program, now);
 
   @override
   Widget build(BuildContext context) {
@@ -493,7 +679,6 @@ class _ProgramsRow extends StatelessWidget {
         .where((p) => p.end.isAfter(windowStart) && p.start.isBefore(windowEnd))
         .toList();
 
-    final now = DateTime.now();
     final blocks = <Widget>[];
     for (final p in visible) {
       final isCurrent = !now.isBefore(p.start) && now.isBefore(p.end);
@@ -540,7 +725,7 @@ class _ProgramsRow extends StatelessWidget {
                 children: [
                   Padding(
                     padding: EdgeInsets.only(
-                      right: showCatchupIcon(p, now) ? 22 : 0,
+                      right: showCatchupIcon(p) ? 22 : 0,
                     ),
                     child: Text(
                       p.title,
@@ -554,7 +739,7 @@ class _ProgramsRow extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                  if (showCatchupIcon(p, now))
+                  if (showCatchupIcon(p))
                     Positioned(
                       right: 0,
                       top: 0,
@@ -595,7 +780,7 @@ class _ProgramsRow extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.only(left: 12),
             child: Text(
-              'No EPG data',
+              l10n.epgNoData,
               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                 color: colorScheme.onSurfaceVariant.withValues(alpha: 0.45),
                 fontStyle: FontStyle.italic,
@@ -628,4 +813,16 @@ class _ProgramsRow extends StatelessWidget {
       ),
     );
   }
+}
+
+bool _canReplay(
+  bool catchupSupported,
+  int? catchupDays,
+  EpgProgram program,
+  DateTime now,
+) {
+  if (!catchupSupported || !program.end.isBefore(now)) return false;
+  if (catchupDays == null) return true;
+  if (catchupDays <= 0) return false;
+  return !program.start.isBefore(now.subtract(Duration(days: catchupDays)));
 }

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -143,9 +143,7 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen> {
   void _loadEpgForChannels(List<Channel> channels, EpgService epgService) {
     for (final channel in channels) {
       final result = epgService.lookupForChannel(channel);
-      if (result != null) {
-        _epgMap[channel.id] = result;
-      }
+      _epgMap[channel.id] = result;
     }
   }
 

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -48,7 +48,7 @@ class LiveTvScreen extends ConsumerStatefulWidget {
   /// Requests EPG data for the given channels be fetched (lazily, debounced)
   /// if not already fresh. Called per-item as the visible list/grid builds,
   /// so only channels actually scrolled into view get fetched.
-  final void Function(List<Channel>)? onEnsureEpg;
+  final EnsureEpg? onEnsureEpg;
 
   @override
   ConsumerState<LiveTvScreen> createState() => _LiveTvScreenState();

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -53,6 +53,11 @@
     }
   },
   "catchupProgramReplayable": "Catchup-Wiedergabe verfügbar",
+  "epgPreviousDay": "Vorheriger Tag",
+  "epgNow": "Jetzt",
+  "epgNextDay": "Nächster Tag",
+  "epgChannels": "SENDER",
+  "epgNoData": "Keine EPG-Daten",
   "playerGoBack": "Zurück",
   "playerResumeWatching": "Weiterschauen",
   "playerContinue": "Fortsetzen",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -53,6 +53,11 @@
     }
   },
   "catchupProgramReplayable": "Catchup replay available",
+  "epgPreviousDay": "Previous day",
+  "epgNow": "Now",
+  "epgNextDay": "Next day",
+  "epgChannels": "CHANNELS",
+  "epgNoData": "No EPG data",
   "playerGoBack": "Go back",
   "playerResumeWatching": "Resume Watching",
   "playerContinue": "Continue",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -53,6 +53,11 @@
     }
   },
   "catchupProgramReplayable": "Repetición por catchup disponible",
+  "epgPreviousDay": "Día anterior",
+  "epgNow": "Ahora",
+  "epgNextDay": "Día siguiente",
+  "epgChannels": "CANALES",
+  "epgNoData": "No hay datos de EPG",
   "playerGoBack": "Volver",
   "playerResumeWatching": "Continuar viendo",
   "playerContinue": "Continuar",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -53,6 +53,11 @@
     }
   },
   "catchupProgramReplayable": "Rediffusion catchup disponible",
+  "epgPreviousDay": "Jour précédent",
+  "epgNow": "Maintenant",
+  "epgNextDay": "Jour suivant",
+  "epgChannels": "CHAÎNES",
+  "epgNoData": "Aucune donnée EPG",
   "playerGoBack": "Retour",
   "playerResumeWatching": "Reprendre la lecture",
   "playerContinue": "Continuer",

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -296,6 +296,36 @@ abstract class AppLocalizations {
   /// **'Catchup replay available'**
   String get catchupProgramReplayable;
 
+  /// No description provided for @epgPreviousDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Previous day'**
+  String get epgPreviousDay;
+
+  /// No description provided for @epgNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Now'**
+  String get epgNow;
+
+  /// No description provided for @epgNextDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Next day'**
+  String get epgNextDay;
+
+  /// No description provided for @epgChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'CHANNELS'**
+  String get epgChannels;
+
+  /// No description provided for @epgNoData.
+  ///
+  /// In en, this message translates to:
+  /// **'No EPG data'**
+  String get epgNoData;
+
   /// No description provided for @playerGoBack.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -112,6 +112,21 @@ class AppLocalizationsDe extends AppLocalizations {
   String get catchupProgramReplayable => 'Catchup-Wiedergabe verfügbar';
 
   @override
+  String get epgPreviousDay => 'Vorheriger Tag';
+
+  @override
+  String get epgNow => 'Jetzt';
+
+  @override
+  String get epgNextDay => 'Nächster Tag';
+
+  @override
+  String get epgChannels => 'SENDER';
+
+  @override
+  String get epgNoData => 'Keine EPG-Daten';
+
+  @override
   String get playerGoBack => 'Zurück';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -111,6 +111,21 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catchupProgramReplayable => 'Catchup replay available';
 
   @override
+  String get epgPreviousDay => 'Previous day';
+
+  @override
+  String get epgNow => 'Now';
+
+  @override
+  String get epgNextDay => 'Next day';
+
+  @override
+  String get epgChannels => 'CHANNELS';
+
+  @override
+  String get epgNoData => 'No EPG data';
+
+  @override
   String get playerGoBack => 'Go back';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -111,6 +111,21 @@ class AppLocalizationsEs extends AppLocalizations {
   String get catchupProgramReplayable => 'Repetición por catchup disponible';
 
   @override
+  String get epgPreviousDay => 'Día anterior';
+
+  @override
+  String get epgNow => 'Ahora';
+
+  @override
+  String get epgNextDay => 'Día siguiente';
+
+  @override
+  String get epgChannels => 'CANALES';
+
+  @override
+  String get epgNoData => 'No hay datos de EPG';
+
+  @override
   String get playerGoBack => 'Volver';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -111,6 +111,21 @@ class AppLocalizationsFr extends AppLocalizations {
   String get catchupProgramReplayable => 'Rediffusion catchup disponible';
 
   @override
+  String get epgPreviousDay => 'Jour précédent';
+
+  @override
+  String get epgNow => 'Maintenant';
+
+  @override
+  String get epgNextDay => 'Jour suivant';
+
+  @override
+  String get epgChannels => 'CHAÎNES';
+
+  @override
+  String get epgNoData => 'Aucune donnée EPG';
+
+  @override
   String get playerGoBack => 'Retour';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -111,6 +111,21 @@ class AppLocalizationsZh extends AppLocalizations {
   String get catchupProgramReplayable => '可回看重播';
 
   @override
+  String get epgPreviousDay => '前一天';
+
+  @override
+  String get epgNow => '现在';
+
+  @override
+  String get epgNextDay => '后一天';
+
+  @override
+  String get epgChannels => '频道';
+
+  @override
+  String get epgNoData => '暂无 EPG 数据';
+
+  @override
   String get playerGoBack => '返回';
 
   @override

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -53,6 +53,11 @@
     }
   },
   "catchupProgramReplayable": "可回看重播",
+  "epgPreviousDay": "前一天",
+  "epgNow": "现在",
+  "epgNextDay": "后一天",
+  "epgChannels": "频道",
+  "epgNoData": "暂无 EPG 数据",
   "playerGoBack": "返回",
   "playerResumeWatching": "继续观看",
   "playerContinue": "继续",

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -241,7 +241,7 @@ class AppStateController extends ChangeNotifier {
   Future<List<Progress>>? _recentlyWatchedRefresh;
   String? _recentlyWatchedRefreshViewerId;
   final Set<int> _pendingEpgChannelIds = <int>{};
-  final Map<int, String> _fetchedEpgRangeByChannel = <int, String>{};
+  final Map<String, DateTime> _fetchedEpgRanges = <String, DateTime>{};
   Timer? _epgFetchDebounce;
   DateTime? _pendingEpgStartDate;
   DateTime? _pendingEpgEndDate;
@@ -1629,7 +1629,7 @@ class AppStateController extends ChangeNotifier {
     for (final channel in channels) {
       final isFresh = epgService.hasFreshDataForChannel(channel);
       if (rangeKey.isEmpty && isFresh) continue;
-      if (_fetchedEpgRangeByChannel[channel.id] == rangeKey && isFresh) {
+      if (rangeKey.isNotEmpty && _hasFreshEpgRange(channel.id, rangeKey)) {
         continue;
       }
       if (_pendingEpgChannelIds.add(channel.id)) added = true;
@@ -1664,22 +1664,27 @@ class AppStateController extends ChangeNotifier {
           rangeKey != _activeEpgRangeKey) {
         return;
       }
-      for (final channel in channels) {
-        _fetchedEpgRangeByChannel[channel.id] = rangeKey;
+      if (rangeKey.isNotEmpty) {
+        _markEpgRangeFetched(channels, rangeKey);
       }
-      epgService
-        ..mergePrograms(programs)
-        ..markFetched(channelIds);
+      epgService.mergePrograms(
+        programs,
+        channelIds: channelIds,
+        replaceExisting: rangeKey.isEmpty,
+        markFresh: rangeKey.isEmpty,
+      );
+      if (rangeKey.isEmpty) epgService.markFetched(channelIds);
       if (kDebugMode) {
         debugPrint(
           '[EPG] lazy fetch → ${programs.length} programs for ${channels.length} channels',
         );
       }
     } on Object catch (e) {
-      // Mark as fetched even on failure so a persistently erroring channel
-      // doesn't get re-queued (and reschedule the debounce timer) on every
-      // rebuild — it'll be retried once cacheTtl expires.
-      epgService.markFetched(channelIds);
+      if (rangeKey.isEmpty) {
+        epgService.markFetched(channelIds);
+      } else {
+        _markEpgRangeFetched(channels, rangeKey);
+      }
       if (kDebugMode) debugPrint('[EPG] lazy fetch failed: $e');
     }
   }
@@ -1712,6 +1717,22 @@ class AppStateController extends ChangeNotifier {
     String dateKey(DateTime value) =>
         '${value.year}-${value.month.toString().padLeft(2, '0')}-${value.day.toString().padLeft(2, '0')}';
     return '${dateKey(startDate)}:${dateKey(endDate ?? startDate)}';
+  }
+
+  bool _hasFreshEpgRange(int channelId, String rangeKey) {
+    final key = '$channelId:$rangeKey';
+    final fetchedAt = _fetchedEpgRanges[key];
+    if (fetchedAt == null) return false;
+    if (DateTime.now().difference(fetchedAt) < epgService.cacheTtl) return true;
+    _fetchedEpgRanges.remove(key);
+    return false;
+  }
+
+  void _markEpgRangeFetched(List<Channel> channels, String rangeKey) {
+    final now = DateTime.now();
+    for (final channel in channels) {
+      _fetchedEpgRanges['${channel.id}:$rangeKey'] = now;
+    }
   }
 
   Future<void> _loadSavedM3uSource() async {

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -312,6 +312,7 @@ class AppStateController extends ChangeNotifier {
         savedSource == AppSourceType.none) {
       final restored = await authNotifier.loadSavedCredentials();
       if (restored) {
+        _resetEpgSession();
         final credentials = authNotifier.credentials!;
         final notificationGeneration = _notificationSessionGeneration.advance();
         if (await _hydrateCachedXtreamContent()) {
@@ -378,6 +379,7 @@ class AppStateController extends ChangeNotifier {
     // until some future connect attempt happens to fully succeed.
     _pushRegistrationSuspended = false;
 
+    _resetEpgSession();
     final loaded = await _replaceWithXtreamContent(clearCache: true);
     _isLoadingContent = false;
     notifyListeners();
@@ -398,6 +400,7 @@ class AppStateController extends ChangeNotifier {
 
     try {
       final playlist = m3uParser.parse(playlistText);
+      _resetEpgSession();
       _notificationSessionGeneration.advance();
       _pushRegistrationSuspended = true;
       _pushLifecycleGeneration.advance();
@@ -1058,6 +1061,7 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<void> disconnect() async {
+    _resetEpgSession();
     _notificationSessionGeneration.advance();
     _pushRegistrationSuspended = true;
     _pushLifecycleGeneration.advance();
@@ -1113,6 +1117,7 @@ class AppStateController extends ChangeNotifier {
       await boot();
       return;
     }
+    _resetEpgSession(clearGuide: false);
     await _replaceWithXtreamContent(clearCache: true);
     _isLoadingContent = false;
     notifyListeners();
@@ -1680,6 +1685,10 @@ class AppStateController extends ChangeNotifier {
         );
       }
     } on Object catch (e) {
+      if (generation != _epgRequestGeneration ||
+          rangeKey != _activeEpgRangeKey) {
+        return;
+      }
       if (rangeKey.isEmpty) {
         epgService.markFetched(channelIds);
       } else {
@@ -1733,6 +1742,18 @@ class AppStateController extends ChangeNotifier {
     for (final channel in channels) {
       _fetchedEpgRanges['${channel.id}:$rangeKey'] = now;
     }
+  }
+
+  void _resetEpgSession({bool clearGuide = true}) {
+    _epgRequestGeneration += 1;
+    _epgFetchDebounce?.cancel();
+    _epgFetchDebounce = null;
+    _pendingEpgChannelIds.clear();
+    _fetchedEpgRanges.clear();
+    _pendingEpgStartDate = null;
+    _pendingEpgEndDate = null;
+    _activeEpgRangeKey = '';
+    if (clearGuide) epgService.clear();
   }
 
   Future<void> _loadSavedM3uSource() async {
@@ -1800,6 +1821,7 @@ class AppStateController extends ChangeNotifier {
 
   @override
   void dispose() {
+    _epgRequestGeneration += 1;
     _epgFetchDebounce?.cancel();
     _pushTokenSubscription?.cancel().ignore();
     unawaited(_tvNotificationController.close());

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -241,7 +241,12 @@ class AppStateController extends ChangeNotifier {
   Future<List<Progress>>? _recentlyWatchedRefresh;
   String? _recentlyWatchedRefreshViewerId;
   final Set<int> _pendingEpgChannelIds = <int>{};
+  final Map<int, String> _fetchedEpgRangeByChannel = <int, String>{};
   Timer? _epgFetchDebounce;
+  DateTime? _pendingEpgStartDate;
+  DateTime? _pendingEpgEndDate;
+  String _activeEpgRangeKey = '';
+  int _epgRequestGeneration = 0;
   static const _epgPrimeCount = 60;
   static const _epgFetchDebounceDelay = Duration(milliseconds: 250);
 
@@ -1605,11 +1610,28 @@ class AppStateController extends ChangeNotifier {
   /// without fresh cached data are requested. Call this from a screen's
   /// `itemBuilder` (list/grid) so only currently visible channels get fetched
   /// as the user scrolls, instead of fetching the whole channel list upfront.
-  void ensureEpgForChannels(List<Channel> channels) {
+  void ensureEpgForChannels(
+    List<Channel> channels, {
+    DateTime? startDate,
+    DateTime? endDate,
+  }) {
     if (_sourceType != AppSourceType.xtream) return;
+    final rangeKey = _epgRangeKey(startDate, endDate);
+    if (rangeKey != _activeEpgRangeKey) {
+      _activeEpgRangeKey = rangeKey;
+      _pendingEpgStartDate = startDate;
+      _pendingEpgEndDate = endDate;
+      _pendingEpgChannelIds.clear();
+      _epgFetchDebounce?.cancel();
+      _epgRequestGeneration += 1;
+    }
     var added = false;
     for (final channel in channels) {
-      if (epgService.hasFreshDataForChannel(channel)) continue;
+      final isFresh = epgService.hasFreshDataForChannel(channel);
+      if (rangeKey.isEmpty && isFresh) continue;
+      if (_fetchedEpgRangeByChannel[channel.id] == rangeKey && isFresh) {
+        continue;
+      }
       if (_pendingEpgChannelIds.add(channel.id)) added = true;
     }
     if (!added) return;
@@ -1621,6 +1643,10 @@ class AppStateController extends ChangeNotifier {
     if (_pendingEpgChannelIds.isEmpty) return;
     final ids = _pendingEpgChannelIds.toSet();
     _pendingEpgChannelIds.clear();
+    final startDate = _pendingEpgStartDate;
+    final endDate = _pendingEpgEndDate;
+    final rangeKey = _activeEpgRangeKey;
+    final generation = _epgRequestGeneration;
     final channels = _channels
         .where((channel) => ids.contains(channel.id))
         .toList(growable: false);
@@ -1629,7 +1655,18 @@ class AppStateController extends ChangeNotifier {
       (channel) => channel.epgChannelId ?? channel.tvgName ?? channel.name,
     );
     try {
-      final programs = await xtreamService.getEpgBatch(channels);
+      final programs = await xtreamService.getEpgBatch(
+        channels,
+        startDate: startDate,
+        endDate: endDate,
+      );
+      if (generation != _epgRequestGeneration ||
+          rangeKey != _activeEpgRangeKey) {
+        return;
+      }
+      for (final channel in channels) {
+        _fetchedEpgRangeByChannel[channel.id] = rangeKey;
+      }
       epgService
         ..mergePrograms(programs)
         ..markFetched(channelIds);
@@ -1648,8 +1685,10 @@ class AppStateController extends ChangeNotifier {
   }
 
   Future<void> _loadXtreamEpg(List<Channel> channels) async {
+    final generation = _epgRequestGeneration;
     try {
       final programs = await xtreamService.getEpgBatch(channels);
+      if (generation != _epgRequestGeneration) return;
       if (kDebugMode) {
         debugPrint(
           '[EPG] getEpgBatch → ${programs.length} programs for ${channels.length} channels',
@@ -1666,6 +1705,13 @@ class AppStateController extends ChangeNotifier {
       // Don't clear existing EPG data on a batch failure. A transient network
       // error shouldn't wipe a previously loaded guide.
     }
+  }
+
+  String _epgRangeKey(DateTime? startDate, DateTime? endDate) {
+    if (startDate == null) return '';
+    String dateKey(DateTime value) =>
+        '${value.year}-${value.month.toString().padLeft(2, '0')}-${value.day.toString().padLeft(2, '0')}';
+    return '${dateKey(startDate)}:${dateKey(endDate ?? startDate)}';
   }
 
   Future<void> _loadSavedM3uSource() async {

--- a/flutter_client/lib/services/epg_service.dart
+++ b/flutter_client/lib/services/epg_service.dart
@@ -16,20 +16,28 @@ class EpgService extends ChangeNotifier {
 
   void loadPrograms(List<EpgProgram> programs) {
     _programsByChannel.clear();
-    _storePrograms(programs);
+    _storePrograms(programs, markFresh: true);
     _loadedAt = _clock();
     notifyListeners();
   }
 
-  void mergePrograms(List<EpgProgram> programs) {
-    final channelIds = programs
-        .map((program) => program.channelId)
-        .where((channelId) => channelId.isNotEmpty)
-        .toSet();
-    for (final channelId in channelIds) {
-      _programsByChannel.remove(channelId);
+  void mergePrograms(
+    List<EpgProgram> programs, {
+    Iterable<String>? channelIds,
+    bool replaceExisting = true,
+    bool markFresh = true,
+  }) {
+    if (replaceExisting) {
+      final replacedChannelIds =
+          channelIds ??
+          programs
+              .map((program) => program.channelId)
+              .where((channelId) => channelId.isNotEmpty);
+      for (final channelId in replacedChannelIds) {
+        _programsByChannel.remove(channelId);
+      }
     }
-    _storePrograms(programs);
+    _storePrograms(programs, markFresh: markFresh);
     _loadedAt = _clock();
     notifyListeners();
   }
@@ -61,16 +69,31 @@ class EpgService extends ChangeNotifier {
     return false;
   }
 
-  void _storePrograms(List<EpgProgram> programs) {
+  void _storePrograms(
+    List<EpgProgram> programs, {
+    required bool markFresh,
+  }) {
     for (final program in programs) {
-      _programsByChannel
-          .putIfAbsent(program.channelId, () => <EpgProgram>[])
-          .add(program);
+      final channelPrograms = _programsByChannel.putIfAbsent(
+        program.channelId,
+        () => <EpgProgram>[],
+      );
+      final existingIndex = channelPrograms.indexWhere(
+        (existing) =>
+            existing.start == program.start && existing.end == program.end,
+      );
+      if (existingIndex == -1) {
+        channelPrograms.add(program);
+      } else {
+        channelPrograms[existingIndex] = program;
+      }
     }
     for (final entry in _programsByChannel.entries) {
       entry.value.sort((a, b) => a.start.compareTo(b.start));
     }
-    markFetched(programs.map((program) => program.channelId));
+    if (markFresh) {
+      markFetched(programs.map((program) => program.channelId));
+    }
   }
 
   void loadBatch(Map<String, List<EpgProgram>> batch) {

--- a/flutter_client/lib/services/epg_service.dart
+++ b/flutter_client/lib/services/epg_service.dart
@@ -149,5 +149,6 @@ class EpgService extends ChangeNotifier {
     _programsByChannel.clear();
     _fetchedAtByChannel.clear();
     _loadedAt = null;
+    notifyListeners();
   }
 }

--- a/flutter_client/lib/services/xtream_service.dart
+++ b/flutter_client/lib/services/xtream_service.dart
@@ -878,29 +878,62 @@ class XtreamService {
   Future<List<EpgProgram>> getEpgBatch(
     List<Channel> channels, {
     int limit = 8,
+    DateTime? startDate,
+    DateTime? endDate,
   }) async {
     if (channels.isEmpty) return const <EpgProgram>[];
+    final dates = <DateTime?>[null];
+    if (startDate != null) {
+      final firstDate = DateTime.utc(
+        startDate.year,
+        startDate.month,
+        startDate.day,
+      );
+      final lastDate = endDate == null
+          ? firstDate
+          : DateTime.utc(endDate.year, endDate.month, endDate.day);
+      if (lastDate.isBefore(firstDate)) {
+        throw ArgumentError.value(
+          endDate,
+          'endDate',
+          'Must not precede startDate',
+        );
+      }
+      dates
+        ..clear()
+        ..addAll([
+          for (
+            var date = firstDate;
+            !date.isAfter(lastDate);
+            date = date.add(const Duration(days: 1))
+          )
+            date,
+        ]);
+    }
     final programs = <EpgProgram>[];
     for (var start = 0; start < channels.length; start += _epgBatchSize) {
       final chunk = channels
           .skip(start)
           .take(_epgBatchSize)
           .toList(growable: false);
-      final response = await _request(
-        'get_epg_batch',
-        params: {
-          'stream_ids': chunk.map((channel) => '${channel.id}').join(','),
-          'limit': '$limit',
-        },
-      );
       final channelIdsByStream = <String, String>{
         for (final channel in chunk)
           '${channel.id}':
               channel.epgChannelId ?? channel.tvgName ?? channel.name,
       };
-      programs.addAll(
-        _parseEpgPrograms(response, channelIdsByStream: channelIdsByStream),
-      );
+      for (final date in dates) {
+        final response = await _request(
+          'get_epg_batch',
+          params: {
+            'stream_ids': chunk.map((channel) => '${channel.id}').join(','),
+            'limit': '$limit',
+            if (date != null) 'date': _formatEpgDate(date),
+          },
+        );
+        programs.addAll(
+          _parseEpgPrograms(response, channelIdsByStream: channelIdsByStream),
+        );
+      }
     }
     programs.sort((a, b) => a.start.compareTo(b.start));
     return programs;
@@ -1159,6 +1192,11 @@ String _formatTimeshiftStart(DateTime value) {
   final hour = twoDigits(value.hour);
   final minute = twoDigits(value.minute);
   return '$year-$month-$day:$hour-$minute';
+}
+
+String _formatEpgDate(DateTime value) {
+  String twoDigits(int number) => number.toString().padLeft(2, '0');
+  return '${value.year.toString().padLeft(4, '0')}-${twoDigits(value.month)}-${twoDigits(value.day)}';
 }
 
 String? _stringOrNull(Object? value) {

--- a/flutter_client/lib/shared/dpad_ink_well.dart
+++ b/flutter_client/lib/shared/dpad_ink_well.dart
@@ -22,6 +22,7 @@ class DpadInkWell extends StatefulWidget {
     this.onLongTap,
     this.effects,
     this.autofocus = false,
+    this.enabled = true,
     this.entry = false,
     this.color,
     this.borderRadius,
@@ -34,6 +35,7 @@ class DpadInkWell extends StatefulWidget {
   final VoidCallback? onLongTap;
   final List<DpadEffect>? effects;
   final bool autofocus;
+  final bool enabled;
   final bool entry;
   final Color? color;
   final BorderRadius? borderRadius;
@@ -55,11 +57,13 @@ class _DpadInkWellState extends State<DpadInkWell> {
   }
 
   void _onTap() {
+    if (!widget.enabled) return;
     _focusNode.requestFocus();
     widget.onTap?.call();
   }
 
-  bool get _isInteractive => widget.onTap != null || widget.onLongTap != null;
+  bool get _isInteractive =>
+      widget.enabled && (widget.onTap != null || widget.onLongTap != null);
 
   void _setHovered(bool hovered) {
     if (!_isInteractive || _hovered == hovered) return;
@@ -90,6 +94,7 @@ class _DpadInkWellState extends State<DpadInkWell> {
         focusNode: _focusNode,
         onSelect: widget.onTap == null ? null : _onTap,
         onLongSelect: widget.onLongTap,
+        enabled: widget.enabled,
         // InkWell handles touch taps; DpadFocusable.onSelect handles D-pad key
         // events. The default tapToSelect: true wraps the child in a
         // GestureDetector whose onTapDown calls requestFocus() before the
@@ -114,8 +119,8 @@ class _DpadInkWellState extends State<DpadInkWell> {
           borderRadius: widget.borderRadius,
           clipBehavior: widget.clipBehavior,
           child: InkWell(
-            onTap: widget.onTap == null ? null : _onTap,
-            onLongPress: widget.onLongTap,
+            onTap: widget.enabled && widget.onTap != null ? _onTap : null,
+            onLongPress: widget.enabled ? widget.onLongTap : null,
             borderRadius: widget.borderRadius,
             child: widget.child,
           ),

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -13,6 +13,7 @@ import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/cache_service.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
 import 'package:m3u_tv/services/persistent_store.dart';
 import 'package:m3u_tv/services/resume_service.dart';
@@ -614,6 +615,201 @@ void main() {
         'Newer day',
       );
     });
+
+    test(
+      'dated browsing preserves current guide when returning to the list',
+      () async {
+        final now = DateTime.utc(2026, 7, 31, 12);
+        final fixture = _FakeXtreamTransport.success();
+        var currentGuideRequests = 0;
+        Future<Object?> transport(XtreamRequest request) async {
+          if (request.action != 'get_epg_batch') return fixture.call(request);
+          if (request.params['date'] == null) {
+            currentGuideRequests += 1;
+            return _epgResponse('Current guide', now);
+          }
+          return _epgResponse(
+            'Yesterday guide',
+            now.subtract(const Duration(days: 1)),
+          );
+        }
+
+        final controller = _controller(
+          storage: InMemorySecureStorage(),
+          transport: transport,
+          epgService: EpgService(clock: () => now),
+        );
+        addTearDown(controller.dispose);
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'https://fixture.example',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+        expect(
+          controller.epgService
+              .lookupForChannel(controller.channels.single)
+              ?.current
+              .title,
+          'Current guide',
+        );
+
+        controller.ensureEpgForChannels(
+          controller.channels,
+          startDate: now.subtract(const Duration(days: 1)),
+          endDate: now.subtract(const Duration(days: 1)),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+        controller.ensureEpgForChannels(controller.channels);
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+
+        expect(currentGuideRequests, 1);
+        expect(
+          controller.epgService
+              .lookupForChannel(controller.channels.single)
+              ?.current
+              .title,
+          'Current guide',
+        );
+      },
+    );
+
+    test('failed EPG range is backed off independently', () async {
+      final fixture = _FakeXtreamTransport.success();
+      var rangedRequests = 0;
+      var currentGuideRequests = 0;
+      Future<Object?> transport(XtreamRequest request) async {
+        if (request.action != 'get_epg_batch') {
+          return fixture.call(request);
+        }
+        if (request.params['date'] == null) {
+          currentGuideRequests += 1;
+          return <String, Object?>{};
+        }
+        rangedRequests += 1;
+        throw StateError('dated EPG unavailable');
+      }
+
+      final controller = _controller(
+        storage: InMemorySecureStorage(),
+        transport: transport,
+      );
+      addTearDown(controller.dispose);
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'fixture-user',
+            password: 'fixture-password',
+          ),
+        ),
+        isTrue,
+      );
+
+      final date = DateTime.utc(2026, 7, 30);
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(rangedRequests, 1);
+      controller.ensureEpgForChannels(controller.channels);
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(currentGuideRequests, 2);
+      expect(
+        controller.epgService.hasFreshDataForChannel(
+          controller.channels.single,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'adjacent EPG ranges deduplicate only the overlapping program',
+      () async {
+        final fixture = _FakeXtreamTransport.success();
+        final overlapStart = DateTime.utc(2026, 7, 31);
+        Map<String, Object?> response(List<DateTime> starts) => {
+          '101': [
+            for (final start in starts)
+              <String, Object?>{
+                'stream_id': 101,
+                'title': 'Daily News',
+                'description': 'Fixture',
+                'start': start.toIso8601String(),
+                'end': start.add(const Duration(hours: 1)).toIso8601String(),
+              },
+          ],
+        };
+        Future<Object?> transport(XtreamRequest request) async {
+          if (request.action != 'get_epg_batch') return fixture.call(request);
+          return switch (request.params['date']) {
+            '2026-07-30' => response([
+              DateTime.utc(2026, 7, 30, 10),
+              overlapStart,
+            ]),
+            '2026-07-31' => response([
+              overlapStart,
+              DateTime.utc(2026, 7, 31, 10),
+            ]),
+            _ => <String, Object?>{},
+          };
+        }
+
+        final controller = _controller(
+          storage: InMemorySecureStorage(),
+          transport: transport,
+        );
+        addTearDown(controller.dispose);
+        expect(
+          await controller.connectXtream(
+            const UserCredentials(
+              server: 'https://fixture.example',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+
+        for (final date in [
+          DateTime.utc(2026, 7, 30),
+          DateTime.utc(2026, 7, 31),
+        ]) {
+          controller.ensureEpgForChannels(
+            controller.channels,
+            startDate: date,
+            endDate: date,
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 300));
+        }
+
+        final programs = controller.epgService.programsForChannel(
+          controller.channels.single,
+        );
+        expect(programs, hasLength(3));
+        expect(
+          programs.where((program) => program.title == 'Daily News'),
+          hasLength(3),
+        );
+        expect(
+          programs.where((program) => program.start == overlapStart),
+          hasLength(1),
+        );
+      },
+    );
   });
 }
 
@@ -634,6 +830,7 @@ AppStateController _controller({
   required XtreamTransport transport,
   Map<String, Object?>? cacheMemory,
   Map<String, Object?>? localMemory,
+  EpgService? epgService,
 }) {
   final sharedLocalMemory = localMemory ?? <String, Object?>{};
   return AppStateController(
@@ -646,6 +843,7 @@ AppStateController _controller({
     favoritesService: FavoritesService(memory: sharedLocalMemory),
     resumeService: ResumeService(memory: sharedLocalMemory),
     viewerService: ViewerService(memory: sharedLocalMemory),
+    epgService: epgService,
   );
 }
 

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -810,6 +810,228 @@ void main() {
         );
       },
     );
+
+    test('ranged EPG freshness is isolated between Xtream sessions', () async {
+      final fixture = _FakeXtreamTransport.success();
+      final rangedRequestUsers = <String>[];
+      Future<Object?> transport(XtreamRequest request) async {
+        if (request.action != 'get_epg_batch') return fixture.call(request);
+        if (request.params['date'] == null) return <String, Object?>{};
+        rangedRequestUsers.add(request.credentials.username);
+        return _epgResponse(
+          '${request.credentials.username} guide',
+          DateTime.utc(2026, 7, 30, 12),
+        );
+      }
+
+      final controller = _controller(
+        storage: InMemorySecureStorage(),
+        transport: transport,
+      );
+      addTearDown(controller.dispose);
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'provider-a',
+            password: 'provider-a-password',
+          ),
+        ),
+        isTrue,
+      );
+
+      final date = DateTime.utc(2026, 7, 30);
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      expect(
+        controller.epgService
+            .programsForChannel(controller.channels.single)
+            .single
+            .title,
+        'provider-a guide',
+      );
+
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'provider-b',
+            password: 'provider-b-password',
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        controller.epgService.programsForChannel(controller.channels.single),
+        isEmpty,
+      );
+
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(rangedRequestUsers, <String>['provider-a', 'provider-b']);
+      expect(
+        controller.epgService
+            .programsForChannel(controller.channels.single)
+            .single
+            .title,
+        'provider-b guide',
+      );
+    });
+
+    test('old Xtream range completion cannot update a new session', () async {
+      final fixture = _FakeXtreamTransport.success();
+      final oldRange = Completer<Object?>();
+      final newRange = Completer<Object?>();
+      Future<Object?> transport(XtreamRequest request) async {
+        if (request.action != 'get_epg_batch') return fixture.call(request);
+        if (request.params['date'] == null) return <String, Object?>{};
+        return request.credentials.username == 'provider-a'
+            ? oldRange.future
+            : newRange.future;
+      }
+
+      final controller = _controller(
+        storage: InMemorySecureStorage(),
+        transport: transport,
+      );
+      addTearDown(controller.dispose);
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'provider-a',
+            password: 'provider-a-password',
+          ),
+        ),
+        isTrue,
+      );
+
+      final date = DateTime.utc(2026, 7, 30);
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'provider-b',
+            password: 'provider-b-password',
+          ),
+        ),
+        isTrue,
+      );
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      newRange.complete(
+        _epgResponse('Provider B guide', DateTime.utc(2026, 7, 30, 12)),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        controller.epgService
+            .programsForChannel(controller.channels.single)
+            .single
+            .title,
+        'Provider B guide',
+      );
+
+      oldRange.complete(
+        _epgResponse('Provider A guide', DateTime.utc(2026, 7, 30, 12)),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        controller.epgService
+            .programsForChannel(controller.channels.single)
+            .single
+            .title,
+        'Provider B guide',
+      );
+    });
+
+    test('old Xtream range failure cannot back off a new session', () async {
+      final fixture = _FakeXtreamTransport.success();
+      final oldRange = Completer<Object?>();
+      var newSessionRequests = 0;
+      Future<Object?> transport(XtreamRequest request) async {
+        if (request.action != 'get_epg_batch') return fixture.call(request);
+        if (request.params['date'] == null) return <String, Object?>{};
+        if (request.credentials.username == 'provider-a') {
+          return oldRange.future;
+        }
+        newSessionRequests += 1;
+        return _epgResponse('Provider B guide', DateTime.utc(2026, 7, 30, 12));
+      }
+
+      final controller = _controller(
+        storage: InMemorySecureStorage(),
+        transport: transport,
+      );
+      addTearDown(controller.dispose);
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'provider-a',
+            password: 'provider-a-password',
+          ),
+        ),
+        isTrue,
+      );
+
+      final date = DateTime.utc(2026, 7, 30);
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'provider-b',
+            password: 'provider-b-password',
+          ),
+        ),
+        isTrue,
+      );
+      oldRange.completeError(StateError('Provider A guide failed'));
+      await Future<void>.delayed(Duration.zero);
+
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: date,
+        endDate: date,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      expect(newSessionRequests, 1);
+      expect(
+        controller.epgService
+            .programsForChannel(controller.channels.single)
+            .single
+            .title,
+        'Provider B guide',
+      );
+    });
   });
 }
 

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -548,8 +548,86 @@ void main() {
         );
       },
     );
+
+    test('newer EPG range wins when an older request completes last', () async {
+      final oldRange = Completer<Object?>();
+      final newRange = Completer<Object?>();
+      final fixture = _FakeXtreamTransport.success();
+      Future<Object?> transport(XtreamRequest request) async {
+        if (request.action != 'get_epg_batch') return fixture.call(request);
+        return switch (request.params['date']) {
+          '2026-01-01' => oldRange.future,
+          '2026-01-02' => newRange.future,
+          _ => <String, Object?>{},
+        };
+      }
+
+      final controller = _controller(
+        storage: InMemorySecureStorage(),
+        transport: transport,
+      );
+      expect(
+        await controller.connectXtream(
+          const UserCredentials(
+            server: 'https://fixture.example',
+            username: 'fixture-user',
+            password: 'fixture-password',
+          ),
+        ),
+        isTrue,
+      );
+
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: DateTime.utc(2026),
+        endDate: DateTime.utc(2026),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+      controller.ensureEpgForChannels(
+        controller.channels,
+        startDate: DateTime.utc(2026, 1, 2),
+        endDate: DateTime.utc(2026, 1, 2),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      newRange.complete(_epgResponse('Newer day', DateTime.utc(2026, 1, 2)));
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        controller.epgService.programsForChannel(controller.channels.single),
+        hasLength(1),
+      );
+      expect(
+        controller.epgService
+            .programsForChannel(controller.channels.single)
+            .single
+            .title,
+        'Newer day',
+      );
+
+      oldRange.complete(_epgResponse('Older day', DateTime.utc(2026)));
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        controller.epgService
+            .programsForChannel(controller.channels.single)
+            .single
+            .title,
+        'Newer day',
+      );
+    });
   });
 }
+
+Map<String, Object?> _epgResponse(String title, DateTime start) => {
+  '101': <Map<String, Object?>>[
+    <String, Object?>{
+      'stream_id': 101,
+      'title': title,
+      'description': 'Fixture',
+      'start': start.toIso8601String(),
+      'end': start.add(const Duration(minutes: 30)).toIso8601String(),
+    },
+  ],
+};
 
 AppStateController _controller({
   required InMemorySecureStorage storage,

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -876,6 +876,54 @@ void main() {
       expect(programs.last.channelId, 'epg.205');
     });
 
+    test('EPG batch composes a dated range without breaking chunks', () async {
+      final transport = FakeXtreamTransport({'auth': xtreamAuth(auth: 1)});
+      transport.onRequest = (request) {
+        if (request.action == 'get_epg_batch') return <String, Object?>{};
+        return transport.responses[request.action ?? 'auth'];
+      };
+      final service = XtreamService(transport: transport.call);
+      await service.authenticate(
+        const UserCredentials(
+          server: 'https://xtream.example',
+          username: 'demo',
+          password: 'secret',
+        ),
+      );
+
+      await service.getEpgBatch(
+        [
+          for (var index = 1; index <= 101; index += 1)
+            Channel(
+              id: index,
+              name: 'Channel $index',
+              streamUrl: 'https://example/live/$index.m3u8',
+            ),
+        ],
+        startDate: DateTime.utc(2026),
+        endDate: DateTime.utc(2026, 1, 3),
+      );
+
+      final epgRequests = transport.requests
+          .where((request) => request.action == 'get_epg_batch')
+          .toList(growable: false);
+      expect(epgRequests, hasLength(6));
+      expect(epgRequests.map((request) => request.params['date']), [
+        '2026-01-01',
+        '2026-01-02',
+        '2026-01-03',
+        '2026-01-01',
+        '2026-01-02',
+        '2026-01-03',
+      ]);
+      expect(
+        epgRequests.map(
+          (request) => request.params['stream_ids']!.split(',').length,
+        ),
+        [100, 100, 100, 1, 1, 1],
+      );
+    });
+
     test(
       'EPG batch uses listing channel_id when response key is stream id',
       () async {

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -1,5 +1,6 @@
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/features/epg/timeline_epg_view.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
@@ -408,6 +409,64 @@ void main() {
         tester.state<ScrollableState>(scrollable).position.pixels,
         greaterThan(before),
       );
+    });
+
+    testWidgets('date controls traverse and activate with D-pad keys', (
+      tester,
+    ) async {
+      final now = DateTime(2026, 7, 31, 12);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DpadRegion(
+              child: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: const [
+                    Channel(
+                      id: 101,
+                      name: 'BBC One',
+                      streamUrl: 'https://streams.example/live/101.m3u8',
+                      catchupSupported: true,
+                      catchupDays: 7,
+                    ),
+                  ],
+                  epgService: EpgService(clock: () => now),
+                  onChannelSelect: (_) {},
+                  clock: () => now,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Jul 30, 2026'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Jul 31, 2026'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Aug 1, 2026'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Jul 31, 2026'), findsOneWidget);
     });
 
     testWidgets('replay stays bounded by each channel catchup range', (

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -281,5 +281,222 @@ void main() {
         expect(find.byIcon(Icons.replay_rounded), findsNothing);
       },
     );
+
+    testWidgets('navigates days, displays the date, and returns to now', (
+      tester,
+    ) async {
+      final now = DateTime(2026, 7, 31, 12);
+      final requestedDates = <DateTime>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 300,
+              child: TimelineEpgView(
+                channels: const [
+                  Channel(
+                    id: 101,
+                    name: 'BBC One',
+                    streamUrl: 'https://streams.example/live/101.m3u8',
+                    catchupSupported: true,
+                    catchupDays: 7,
+                  ),
+                ],
+                epgService: EpgService(clock: () => now),
+                onChannelSelect: (_) {},
+                onEnsureEpg: (channels, {startDate, endDate}) {
+                  requestedDates.add(startDate!);
+                },
+                clock: () => now,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Jul 31, 2026'), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('timeline-previous-day')));
+      await tester.pump();
+      expect(find.text('Jul 30, 2026'), findsOneWidget);
+      expect(requestedDates.last, DateTime(2026, 7, 30));
+
+      await tester.tap(find.byKey(const ValueKey('timeline-next-day')));
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('timeline-next-day')));
+      await tester.pump();
+      expect(find.text('Aug 1, 2026'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('timeline-now')));
+      await tester.pump();
+      expect(find.text('Jul 31, 2026'), findsOneWidget);
+      expect(requestedDates.last, DateTime(2026, 7, 31));
+
+      for (var day = 0; day < 8; day += 1) {
+        await tester.tap(find.byKey(const ValueKey('timeline-previous-day')));
+        await tester.pump();
+      }
+      expect(find.text('Jul 24, 2026'), findsOneWidget);
+
+      await tester.tap(find.byKey(const ValueKey('timeline-now')));
+      await tester.pump();
+      for (var day = 0; day < 8; day += 1) {
+        await tester.tap(find.byKey(const ValueKey('timeline-next-day')));
+        await tester.pump();
+      }
+      expect(find.text('Aug 7, 2026'), findsOneWidget);
+
+      for (final key in const [
+        ValueKey('timeline-previous-day'),
+        ValueKey('timeline-now'),
+        ValueKey('timeline-next-day'),
+      ]) {
+        expect(
+          find.descendant(
+            of: find.byKey(key),
+            matching: find.byType(DpadFocusable),
+          ),
+          findsOneWidget,
+        );
+      }
+    });
+
+    testWidgets('keeps horizontal pointer scrolling available', (tester) async {
+      final now = DateTime(2026, 7, 31, 12);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 300,
+              child: TimelineEpgView(
+                channels: const [
+                  Channel(
+                    id: 101,
+                    name: 'BBC One',
+                    streamUrl: 'https://streams.example/live/101.m3u8',
+                  ),
+                ],
+                epgService: EpgService(clock: () => now),
+                onChannelSelect: (_) {},
+                clock: () => now,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final row = find.byKey(const ValueKey('timeline-row-scroll-101'));
+      final scrollable = find.descendant(
+        of: row,
+        matching: find.byType(Scrollable),
+      );
+      final before = tester.state<ScrollableState>(scrollable).position.pixels;
+      await tester.drag(row, const Offset(-300, 0));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.state<ScrollableState>(scrollable).position.pixels,
+        greaterThan(before),
+      );
+    });
+
+    testWidgets('replay stays bounded by each channel catchup range', (
+      tester,
+    ) async {
+      final now = DateTime(2026, 7, 31, 12);
+      final shortProgram = EpgProgram(
+        channelId: 'short',
+        title: 'Short Archive',
+        description: 'Outside one-day archive',
+        start: DateTime(2026, 7, 28, 10),
+        end: DateTime(2026, 7, 28, 11),
+      );
+      final longProgram = EpgProgram(
+        channelId: 'long',
+        title: 'Long Archive',
+        description: 'Inside seven-day archive',
+        start: DateTime(2026, 7, 28, 10),
+        end: DateTime(2026, 7, 28, 11),
+      );
+      final epg = EpgService(clock: () => now)
+        ..loadPrograms([shortProgram, longProgram]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 300,
+              child: TimelineEpgView(
+                channels: const [
+                  Channel(
+                    id: 101,
+                    name: 'Short',
+                    streamUrl: 'https://streams.example/live/101.m3u8',
+                    epgChannelId: 'short',
+                    catchupSupported: true,
+                    catchupDays: 1,
+                  ),
+                  Channel(
+                    id: 102,
+                    name: 'Long',
+                    streamUrl: 'https://streams.example/live/102.m3u8',
+                    epgChannelId: 'long',
+                    catchupSupported: true,
+                    catchupDays: 7,
+                  ),
+                ],
+                epgService: epg,
+                onChannelSelect: (_) {},
+                clock: () => now,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      for (var day = 0; day < 3; day += 1) {
+        await tester.tap(find.byKey(const ValueKey('timeline-previous-day')));
+        await tester.pump();
+      }
+
+      final shortBlock = find.byKey(
+        ValueKey(
+          'timeline-program-short-${shortProgram.start.toIso8601String()}',
+        ),
+      );
+      final longBlock = find.byKey(
+        ValueKey(
+          'timeline-program-long-${longProgram.start.toIso8601String()}',
+        ),
+      );
+      expect(
+        find.descendant(
+          of: shortBlock,
+          matching: find.byIcon(Icons.replay_rounded),
+        ),
+        findsNothing,
+      );
+      expect(
+        find.descendant(
+          of: longBlock,
+          matching: find.byIcon(Icons.replay_rounded),
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -374,6 +374,220 @@ void main() {
     });
 
     testWidgets(
+      'null catchup metadata uses a finite seven-day retention',
+      (tester) async {
+        final now = DateTime(2026, 7, 31, 12);
+        const channel = Channel(
+          id: 101,
+          name: 'BBC One',
+          streamUrl: 'https://streams.example/live/101.m3u8',
+          epgChannelId: 'bbc.one',
+          catchupSupported: true,
+        );
+        const channels = [
+          channel,
+          Channel(
+            id: 102,
+            name: 'Short Archive',
+            streamUrl: 'https://streams.example/live/102.m3u8',
+            catchupSupported: true,
+            catchupDays: 2,
+          ),
+          Channel(
+            id: 103,
+            name: 'No Archive',
+            streamUrl: 'https://streams.example/live/103.m3u8',
+          ),
+        ];
+        final olderProgram = EpgProgram(
+          channelId: 'bbc.one',
+          title: 'Outside Fallback',
+          description: 'Started before the fallback cutoff',
+          start: DateTime(2026, 7, 24, 10),
+          end: DateTime(2026, 7, 24, 11),
+        );
+        final retainedProgram = EpgProgram(
+          channelId: 'bbc.one',
+          title: 'Inside Fallback',
+          description: 'Started after the fallback cutoff',
+          start: DateTime(2026, 7, 24, 13),
+          end: DateTime(2026, 7, 24, 14),
+        );
+        final epg = EpgService(clock: () => now)
+          ..loadPrograms([olderProgram, retainedProgram]);
+        final replayedPrograms = <EpgProgram>[];
+        final selectedChannels = <Channel>[];
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: channels,
+                  epgService: epg,
+                  onChannelSelect: selectedChannels.add,
+                  onCatchupProgramSelect: (_, program) {
+                    replayedPrograms.add(program);
+                  },
+                  clock: () => now,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        for (var day = 0; day < 7; day += 1) {
+          await tester.tap(
+            find.byKey(const ValueKey('timeline-previous-day')),
+          );
+          await tester.pump();
+        }
+        expect(find.text('Jul 24, 2026'), findsOneWidget);
+        expect(
+          _dateControlFocusable(
+            tester,
+            const ValueKey('timeline-previous-day'),
+          ).enabled,
+          isFalse,
+        );
+
+        await tester.tap(find.byKey(const ValueKey('timeline-previous-day')));
+        await tester.pump();
+        expect(find.text('Jul 24, 2026'), findsOneWidget);
+
+        final retainedBlock = find.byKey(
+          ValueKey(
+            'timeline-program-bbc.one-${retainedProgram.start.toIso8601String()}',
+          ),
+        );
+        final olderBlock = find.byKey(
+          ValueKey(
+            'timeline-program-bbc.one-${olderProgram.start.toIso8601String()}',
+          ),
+        );
+        expect(
+          find.descendant(
+            of: retainedBlock,
+            matching: find.byIcon(Icons.replay_rounded),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: olderBlock,
+            matching: find.byIcon(Icons.replay_rounded),
+          ),
+          findsNothing,
+        );
+
+        tester.widget<DpadInkWell>(retainedBlock).onTap?.call();
+        tester.widget<DpadInkWell>(olderBlock).onTap?.call();
+
+        expect(replayedPrograms, [retainedProgram]);
+        expect(selectedChannels, [channel]);
+      },
+    );
+
+    testWidgets('zero and negative catchup retention remain unavailable', (
+      tester,
+    ) async {
+      final now = DateTime(2026, 7, 31, 12);
+      const channels = [
+        Channel(
+          id: 101,
+          name: 'Zero',
+          streamUrl: 'https://streams.example/live/101.m3u8',
+          epgChannelId: 'zero',
+          catchupSupported: true,
+          catchupDays: 0,
+        ),
+        Channel(
+          id: 102,
+          name: 'Negative',
+          streamUrl: 'https://streams.example/live/102.m3u8',
+          epgChannelId: 'negative',
+          catchupSupported: true,
+          catchupDays: -1,
+        ),
+      ];
+      final programs = [
+        EpgProgram(
+          channelId: 'zero',
+          title: 'Zero Archive',
+          description: 'Unavailable with zero retention',
+          start: DateTime(2026, 7, 31, 10),
+          end: DateTime(2026, 7, 31, 11),
+        ),
+        EpgProgram(
+          channelId: 'negative',
+          title: 'Negative Archive',
+          description: 'Unavailable with negative retention',
+          start: DateTime(2026, 7, 31, 10),
+          end: DateTime(2026, 7, 31, 11),
+        ),
+      ];
+      final epg = EpgService(clock: () => now)..loadPrograms(programs);
+      final replayedPrograms = <EpgProgram>[];
+      final selectedChannels = <Channel>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: SizedBox(
+              width: 800,
+              height: 300,
+              child: TimelineEpgView(
+                channels: channels,
+                epgService: epg,
+                onChannelSelect: selectedChannels.add,
+                onCatchupProgramSelect: (_, program) {
+                  replayedPrograms.add(program);
+                },
+                clock: () => now,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        _dateControlFocusable(
+          tester,
+          const ValueKey('timeline-previous-day'),
+        ).enabled,
+        isFalse,
+      );
+      for (final program in programs) {
+        final block = find.byKey(
+          ValueKey(
+            'timeline-program-${program.channelId}-${program.start.toIso8601String()}',
+          ),
+        );
+        expect(
+          find.descendant(
+            of: block,
+            matching: find.byIcon(Icons.replay_rounded),
+          ),
+          findsNothing,
+        );
+        tester.widget<DpadInkWell>(block).onTap?.call();
+      }
+
+      expect(replayedPrograms, isEmpty);
+      expect(selectedChannels, channels);
+    });
+
+    testWidgets(
       'spring-forward navigation and window keep calendar boundaries',
       (tester) async {
         final now = DateTime(2026, 3, 30, 12);

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -9,6 +9,12 @@ import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
 void main() {
+  final observesBerlinDst =
+      DateTime(2026, 3, 29).timeZoneOffset == const Duration(hours: 1) &&
+      DateTime(2026, 3, 30).timeZoneOffset == const Duration(hours: 2) &&
+      DateTime(2026, 10, 25).timeZoneOffset == const Duration(hours: 2) &&
+      DateTime(2026, 10, 26).timeZoneOffset == const Duration(hours: 1);
+
   group('TimelineEpgView', () {
     testWidgets('catchup channels show replay availability indicator', (
       tester,
@@ -367,6 +373,121 @@ void main() {
       }
     });
 
+    testWidgets(
+      'spring-forward navigation and window keep calendar boundaries',
+      (tester) async {
+        final now = DateTime(2026, 3, 30, 12);
+        final lateProgram = EpgProgram(
+          channelId: 'bbc.one',
+          title: 'Late Sunday',
+          description: 'Inside Sunday',
+          start: DateTime(2026, 3, 29, 23, 30),
+          end: DateTime(2026, 3, 29, 23, 50),
+        );
+        final nextDayProgram = EpgProgram(
+          channelId: 'bbc.one',
+          title: 'Early Monday',
+          description: 'Outside Sunday',
+          start: DateTime(2026, 3, 30, 0, 15),
+          end: DateTime(2026, 3, 30, 0, 45),
+        );
+        final epg = EpgService(clock: () => now)
+          ..loadPrograms([lateProgram, nextDayProgram]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: const [
+                    Channel(
+                      id: 101,
+                      name: 'BBC One',
+                      streamUrl: 'https://streams.example/live/101.m3u8',
+                      epgChannelId: 'bbc.one',
+                      catchupSupported: true,
+                      catchupDays: 7,
+                    ),
+                  ],
+                  epgService: epg,
+                  onChannelSelect: (_) {},
+                  clock: () => now,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const ValueKey('timeline-previous-day')));
+        await tester.pump();
+
+        expect(find.text('Mar 29, 2026'), findsOneWidget);
+        expect(find.text('Late Sunday'), findsOneWidget);
+        expect(find.text('Early Monday'), findsNothing);
+      },
+      skip: !observesBerlinDst,
+    );
+
+    testWidgets(
+      'fall-back navigation and window keep calendar boundaries',
+      (tester) async {
+        final now = DateTime(2026, 10, 24, 12);
+        final lateProgram = EpgProgram(
+          channelId: 'bbc.one',
+          title: 'Late Sunday',
+          description: 'Inside Sunday',
+          start: DateTime(2026, 10, 25, 23, 30),
+          end: DateTime(2026, 10, 25, 23, 50),
+        );
+        final epg = EpgService(clock: () => now)..loadPrograms([lateProgram]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: const [
+                    Channel(
+                      id: 101,
+                      name: 'BBC One',
+                      streamUrl: 'https://streams.example/live/101.m3u8',
+                      epgChannelId: 'bbc.one',
+                    ),
+                  ],
+                  epgService: epg,
+                  onChannelSelect: (_) {},
+                  clock: () => now,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const ValueKey('timeline-next-day')));
+        await tester.pump();
+        expect(find.text('Oct 25, 2026'), findsOneWidget);
+        expect(find.text('Late Sunday'), findsOneWidget);
+
+        await tester.tap(find.byKey(const ValueKey('timeline-next-day')));
+        await tester.pump();
+        expect(find.text('Oct 26, 2026'), findsOneWidget);
+        expect(find.text('Late Sunday'), findsNothing);
+      },
+      skip: !observesBerlinDst,
+    );
+
     testWidgets('keeps horizontal pointer scrolling available', (tester) async {
       final now = DateTime(2026, 7, 31, 12);
       await tester.pumpWidget(
@@ -469,6 +590,160 @@ void main() {
       expect(find.text('Jul 31, 2026'), findsOneWidget);
     });
 
+    testWidgets('D-pad skips disabled previous control at catchup boundary', (
+      tester,
+    ) async {
+      final now = DateTime(2026, 7, 31, 12);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DpadRegion(
+              child: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: const [
+                    Channel(
+                      id: 101,
+                      name: 'BBC One',
+                      streamUrl: 'https://streams.example/live/101.m3u8',
+                      catchupSupported: true,
+                      catchupDays: 0,
+                    ),
+                  ],
+                  epgService: EpgService(clock: () => now),
+                  onChannelSelect: (_) {},
+                  clock: () => now,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final previous = _dateControlFocusable(
+        tester,
+        const ValueKey('timeline-previous-day'),
+      );
+      expect(previous.enabled, isFalse);
+      expect(
+        _dateControlFocusable(
+          tester,
+          const ValueKey('timeline-now'),
+        ).focusNode?.hasFocus,
+        isTrue,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(
+        _dateControlFocusable(
+          tester,
+          const ValueKey('timeline-now'),
+        ).focusNode?.hasFocus,
+        isTrue,
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Jul 31, 2026'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        _dateControlFocusable(
+          tester,
+          const ValueKey('timeline-next-day'),
+        ).focusNode?.hasFocus,
+        isTrue,
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Aug 1, 2026'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Jul 31, 2026'), findsOneWidget);
+    });
+
+    testWidgets('D-pad skips disabled next control at future boundary', (
+      tester,
+    ) async {
+      final now = DateTime(2026, 7, 31, 12);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(useMaterial3: true),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: DpadRegion(
+              child: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: const [
+                    Channel(
+                      id: 101,
+                      name: 'BBC One',
+                      streamUrl: 'https://streams.example/live/101.m3u8',
+                      catchupSupported: true,
+                      catchupDays: 7,
+                    ),
+                  ],
+                  epgService: EpgService(clock: () => now),
+                  onChannelSelect: (_) {},
+                  futureDays: 0,
+                  clock: () => now,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        _dateControlFocusable(
+          tester,
+          const ValueKey('timeline-previous-day'),
+        ).focusNode?.hasFocus,
+        isTrue,
+      );
+      expect(
+        _dateControlFocusable(
+          tester,
+          const ValueKey('timeline-next-day'),
+        ).enabled,
+        isFalse,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+      await tester.pump();
+      expect(
+        _dateControlFocusable(
+          tester,
+          const ValueKey('timeline-now'),
+        ).focusNode?.hasFocus,
+        isTrue,
+      );
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Jul 31, 2026'), findsOneWidget);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.select);
+      await tester.pump();
+      expect(find.text('Jul 30, 2026'), findsOneWidget);
+    });
+
     testWidgets('replay stays bounded by each channel catchup range', (
       tester,
     ) async {
@@ -558,4 +833,10 @@ void main() {
       );
     });
   });
+}
+
+DpadFocusable _dateControlFocusable(WidgetTester tester, ValueKey<String> key) {
+  return tester.widget<DpadFocusable>(
+    find.descendant(of: find.byKey(key), matching: find.byType(DpadFocusable)),
+  );
 }

--- a/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
+++ b/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
@@ -125,4 +125,57 @@ void main() {
       expect(recordedProgram?.title, 'Noon News');
     },
   );
+
+  testWidgets('list clears stale current and next guide data', (tester) async {
+    final now = DateTime.utc(2026, 1, 1, 12);
+    final favorites = FavoritesService(memory: <String, Object?>{});
+    final epg = EpgService(clock: () => now)
+      ..loadPrograms([
+        EpgProgram(
+          channelId: 'news.epg',
+          title: 'Stale Noon News',
+          description: 'News',
+          start: now.subtract(const Duration(minutes: 30)),
+          end: now.add(const Duration(minutes: 30)),
+        ),
+      ]);
+    const channels = [
+      Channel(
+        id: 101,
+        name: 'Route News',
+        streamUrl: 'https://example.com/news.m3u8',
+        epgChannelId: 'news.epg',
+      ),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          isBootstrappingProvider.overrideWith((_) => false),
+          isConfiguredProvider.overrideWith((_) => true),
+          isLoadingContentProvider.overrideWith((_) => false),
+          liveChannelsProvider.overrideWith((_) => channels),
+          liveCategoriesProvider.overrideWith((_) => const []),
+          epgServiceProvider.overrideWith((_) => epg),
+          dvrRecordingsProvider.overrideWith((_) => const []),
+          recordingChannelIdsProvider.overrideWith((_) => const <int>{}),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: LiveTvScreen(
+            favoritesService: favorites,
+            onChannelSelect: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Stale Noon News'), findsOneWidget);
+
+    epg.loadPrograms(const []);
+    await tester.pump();
+
+    expect(find.text('Stale Noon News'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary

- compose dated Xtream EPG batch requests without breaking the 100-channel limit
- navigate a localized timeline across bounded past and future calendar dates, including DST transitions
- isolate guide data, freshness, failure backoff, pending ranges, and in-flight completions across Xtream sessions
- preserve current guide data independently from dated ranges and deduplicate adjacent provider overlap
- disable boundary date controls as D-pad focus targets while preserving previous, next, now, touch, and mouse behavior

Closes #57

## TDD evidence

RED on blocked behavior:
- null catchup metadata: expected `Jul 24, 2026` after seven previous-day actions, found no matching widget because historical navigation exposed zero days while replay remained unbounded
- fresh provider switch: expected an empty provider B guide, got provider A EPG data
- in-flight provider switch: expected `Provider B guide`, got `Provider A guide` after the old completion
- stale failure switch: expected 1 provider B request, got 0 because provider A backoff crossed sessions
- spring forward: expected `Mar 29, 2026`, found no matching widget
- fall back: expected `Late Sunday`, found no matching widget in the selected-day window
- lower and upper D-pad boundaries: expected `enabled == false`, actual was `true`
- earlier range regressions also proved generic guide preservation, failure backoff, response ordering, and adjacent deduplication

GREEN:
- the exact null catchup regression passed after applying one finite 7-calendar-day effective retention policy
- null metadata reaches day 7 but not day 8, replays programs inside the cutoff, rejects older programs, and participates in mixed-channel maximum retention
- explicit zero, negative, positive, unsupported, DST, D-pad, pointer, provider-session, backoff, stale-response, deduplication, and current-guide behavior remains covered
- `TZ=Europe/Berlin flutter test --concurrency=1` focused service/app-state/live-TV/EPG/D-pad/pointer/navigation set: 141 passed, 5 skipped
- `TZ=Europe/Berlin flutter test --concurrency=1`: 588 passed, 5 skipped

## Local verification

- `flutter analyze lib test`: no issues
- `dart format --output=none --set-exit-if-changed lib/features/epg/timeline_epg_view.dart test/ui/features/timeline_epg_view_test.dart`: 2 files, 0 changed
- Java 17 `./android/gradlew -p android :app:testDebugUnitTest`: `BUILD SUCCESSFUL`; 211 actionable tasks, 4 executed, 207 up-to-date
- worktree and staged `git diff --check`: passed
- anchored conflict-marker, credential/private-key, and U+2013/U+2014 scans: passed

## Provider overlap evidence

- current m3u-editor `c863d4f` fetches the requested date plus the next date in `XtreamApiController.php`, so adjacent date requests repeat listings
- standard Xtream fixtures use `epg_listings` with channel/start/stop data; resolved channel plus exact start/end is the provider-safe identity, while same-title programs at different times remain distinct
