### PR TITLE
feat(player): commercial-skip (comskip/EDL) auto-skip and prompt

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -877,6 +877,7 @@ class AppShellState extends ConsumerState<AppShell>
           locale: _appState.locale,
           onLocaleChanged: (locale) => unawaited(_appState.setLocale(locale)),
           proxyPlaybackSettings: _appState.proxyPlaybackSettings,
+          comskipSettings: _appState.comskipSettings,
         ),
       ),
       _ => const PlaceholderScreen(title: 'Home'),
@@ -975,6 +976,7 @@ class AppShellState extends ConsumerState<AppShell>
                   orchestrator: orch,
                   epgService: _appState.epgService,
                   xtreamService: _appState.xtreamService,
+                  comskipSettings: _appState.comskipSettings,
                   viewerId: viewerId,
                   onNextChannel: args.type == 'live' ? _openNextChannel : null,
                   onPreviousChannel: args.type == 'live'

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -89,7 +89,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
   // Comskip (commercial-skip) state — only populated when args.metadata
   // carries an 'edl_url' (completed DVR recordings with comskip enabled).
   List<({double start, double end})> _comskipSegments = const [];
-  final Set<double> _autoSkippedSegmentEnds = {};
   ({double start, double end})? _activeComskipSegment;
   bool _showComskipSkippedBadge = false;
   Timer? _comskipBadgeTimer;
@@ -224,7 +223,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
       _epgData = null;
       _overlayVisible = true;
       _comskipSegments = const [];
-      _autoSkippedSegmentEnds.clear();
       _activeComskipSegment = null;
       _showComskipSkippedBadge = false;
     });
@@ -356,11 +354,17 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
     final autoSkip = widget.comskipSettings?.autoSkipEnabled ?? false;
     if (autoSkip) {
-      if (_autoSkippedSegmentEnds.contains(current.end)) return;
-      _autoSkippedSegmentEnds.add(current.end);
-      unawaited(
-        widget.orchestrator.seek(Duration(seconds: current.end.round())),
-      );
+      final seekTarget = Duration(seconds: current.end.round());
+      // Optimistically bump the local position past the segment's end so the
+      // very next tick no longer matches it — the manually-incremented
+      // _currentPosition otherwise lags the orchestrator's true position
+      // until onState confirms the seek asynchronously, which would
+      // re-match and re-fire on the next tick. This is the whole guard
+      // against a seek storm; there's deliberately no persistent
+      // already-skipped tracking, since that would (and did) suppress a
+      // legitimate re-skip on scrub-back, replay, or restart-from-0.
+      _currentPosition = seekTarget;
+      unawaited(widget.orchestrator.seek(seekTarget));
       _flashComskipSkippedBadge();
     } else if (_activeComskipSegment?.end != current.end) {
       setState(() => _activeComskipSegment = current);

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -89,7 +89,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   // Comskip (commercial-skip) state — only populated when args.metadata
   // carries an 'edl_url' (completed DVR recordings with comskip enabled).
   List<({double start, double end})> _comskipSegments = const [];
-  double? _lastAutoSkippedSegmentEnd;
+  final Set<double> _autoSkippedSegmentEnds = {};
   ({double start, double end})? _activeComskipSegment;
   bool _showComskipSkippedBadge = false;
   Timer? _comskipBadgeTimer;
@@ -224,7 +224,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
       _epgData = null;
       _overlayVisible = true;
       _comskipSegments = const [];
-      _lastAutoSkippedSegmentEnd = null;
+      _autoSkippedSegmentEnds.clear();
       _activeComskipSegment = null;
       _showComskipSkippedBadge = false;
     });
@@ -333,10 +333,10 @@ class _PlayerScreenState extends State<PlayerScreen> {
       return;
     }
 
-    final autoSkip = widget.comskipSettings?.autoSkipEnabled ?? true;
+    final autoSkip = widget.comskipSettings?.autoSkipEnabled ?? false;
     if (autoSkip) {
-      if (_lastAutoSkippedSegmentEnd == current.end) return;
-      _lastAutoSkippedSegmentEnd = current.end;
+      if (_autoSkippedSegmentEnds.contains(current.end)) return;
+      _autoSkippedSegmentEnds.add(current.end);
       unawaited(
         widget.orchestrator.seek(Duration(seconds: current.end.round())),
       );

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -92,6 +92,15 @@ class _PlayerScreenState extends State<PlayerScreen> {
   ({double start, double end})? _activeComskipSegment;
   bool _showComskipSkippedBadge = false;
   Timer? _comskipBadgeTimer;
+  // Set while an auto-skip seek is in flight so orchestrator position
+  // reports that lag/oscillate behind the optimistic bump can't clobber
+  // _currentPosition backward into the segment. Cleared the moment the
+  // orchestrator genuinely reports a position at or past the target.
+  Duration? _pendingComskipSeekTarget;
+  // Safety net: if the orchestrator never confirms the seek (player stuck,
+  // decode failure, etc.), auto-clear after a few seconds so we don't hold
+  // _currentPosition hostage indefinitely and silently break future skips.
+  Timer? _pendingComskipSeekTimer;
 
   bool _overlayVisible = true;
 
@@ -354,16 +363,33 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
     final autoSkip = widget.comskipSettings?.autoSkipEnabled ?? false;
     if (autoSkip) {
-      final seekTarget = Duration(seconds: current.end.round());
+      // ceil() past the segment's actual end so sub-second EDL precision
+      // (e.g. end=2284.08) doesn't leave us inside the half-open interval
+      // after rounding to whole seconds. The same value is used for the
+      // optimistic bump and the real seek so they stay in lockstep.
+      final seekTargetMs = (current.end * 1000).ceil();
+      final seekTarget = Duration(milliseconds: seekTargetMs);
       // Optimistically bump the local position past the segment's end so the
       // very next tick no longer matches it — the manually-incremented
       // _currentPosition otherwise lags the orchestrator's true position
       // until onState confirms the seek asynchronously, which would
-      // re-match and re-fire on the next tick. This is the whole guard
-      // against a seek storm; there's deliberately no persistent
-      // already-skipped tracking, since that would (and did) suppress a
-      // legitimate re-skip on scrub-back, replay, or restart-from-0.
+      // re-match and re-fire on the next tick. _pendingComskipSeekTarget
+      // then prevents `_handleState` from clobbering the bump backward
+      // (the orchestrator's mid-seek position reports can lag/oscillate
+      // behind the optimistic value, which previously caused a re-fire
+      // loop). There's deliberately no persistent already-skipped tracking,
+      // since that would (and did) suppress a legitimate re-skip on
+      // scrub-back, replay, or restart-from-0.
       _currentPosition = seekTarget;
+      _pendingComskipSeekTarget = seekTarget;
+      _pendingComskipSeekTimer?.cancel();
+      _pendingComskipSeekTimer = Timer(const Duration(seconds: 5), () {
+        if (_disposed || !mounted) return;
+        // Real seek never confirmed — give up holding position hostage so
+        // future auto-skips aren't silently broken.
+        _pendingComskipSeekTarget = null;
+        _pendingComskipSeekTimer = null;
+      });
       unawaited(widget.orchestrator.seek(seekTarget));
       _flashComskipSkippedBadge();
     } else if (_activeComskipSegment?.end != current.end) {
@@ -434,6 +460,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _positionTimer?.cancel();
     _epgTimer?.cancel();
     _comskipBadgeTimer?.cancel();
+    _pendingComskipSeekTimer?.cancel();
     _screenFocusNode.dispose();
     _controlsFocusNode.dispose();
     _errorButtonFocusNode.dispose();
@@ -516,9 +543,20 @@ class _PlayerScreenState extends State<PlayerScreen> {
     // play/pause transition, not to every tick.
     final wasPlaying = _isPlaying;
 
+    // While a comskip auto-skip seek is in flight, ignore orchestrator
+    // position reports that would regress _currentPosition backward into
+    // the segment (orchestrator onState can lag/oscillate during the real
+    // seek's buffering). Accept state.position only once it's at or past
+    // the pending target — that proves the real seek genuinely caught up.
+    final pendingTarget = _pendingComskipSeekTarget;
+    final acceptedPosition = pendingTarget != null &&
+            state.position < pendingTarget
+        ? _currentPosition
+        : state.position;
+
     setState(() {
       _status = state.status;
-      _currentPosition = state.position;
+      _currentPosition = acceptedPosition;
       if (state.duration != null && state.duration! > Duration.zero) {
         _duration = state.duration!;
       }
@@ -561,6 +599,15 @@ class _PlayerScreenState extends State<PlayerScreen> {
         _goBack();
       }
     });
+
+    // If the orchestrator genuinely caught up to (or past) the pending
+    // seek target, the real seek has landed — release the guard so the
+    // next segment / next scrub-back can fire normally.
+    if (pendingTarget != null && state.position >= pendingTarget) {
+      _pendingComskipSeekTarget = null;
+      _pendingComskipSeekTimer?.cancel();
+      _pendingComskipSeekTimer = null;
+    }
     _checkComskip();
 
     // Only re-evaluate the hide timer on an actual play/pause transition:

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -363,38 +363,48 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
     final autoSkip = widget.comskipSettings?.autoSkipEnabled ?? false;
     if (autoSkip) {
-      // ceil() past the segment's actual end so sub-second EDL precision
-      // (e.g. end=2284.08) doesn't leave us inside the half-open interval
-      // after rounding to whole seconds. The same value is used for the
-      // optimistic bump and the real seek so they stay in lockstep.
-      final seekTargetMs = (current.end * 1000).ceil();
-      final seekTarget = Duration(milliseconds: seekTargetMs);
-      // Optimistically bump the local position past the segment's end so the
-      // very next tick no longer matches it — the manually-incremented
-      // _currentPosition otherwise lags the orchestrator's true position
-      // until onState confirms the seek asynchronously, which would
-      // re-match and re-fire on the next tick. _pendingComskipSeekTarget
-      // then prevents `_handleState` from clobbering the bump backward
-      // (the orchestrator's mid-seek position reports can lag/oscillate
-      // behind the optimistic value, which previously caused a re-fire
-      // loop). There's deliberately no persistent already-skipped tracking,
-      // since that would (and did) suppress a legitimate re-skip on
-      // scrub-back, replay, or restart-from-0.
-      _currentPosition = seekTarget;
-      _pendingComskipSeekTarget = seekTarget;
-      _pendingComskipSeekTimer?.cancel();
-      _pendingComskipSeekTimer = Timer(const Duration(seconds: 5), () {
-        if (_disposed || !mounted) return;
-        // Real seek never confirmed — give up holding position hostage so
-        // future auto-skips aren't silently broken.
-        _pendingComskipSeekTarget = null;
-        _pendingComskipSeekTimer = null;
-      });
-      unawaited(widget.orchestrator.seek(seekTarget));
+      _fireComskipSeek(current);
       _flashComskipSkippedBadge();
     } else if (_activeComskipSegment?.end != current.end) {
       setState(() => _activeComskipSegment = current);
     }
+  }
+
+  /// Seeks past the end of a commercial segment using sub-second EDL
+  /// precision, with the optimistic `_currentPosition` bump and
+  /// `_pendingComskipSeekTarget` guard required to keep the seek-storm
+  /// regression from coming back. Shared by the auto-skip branch above
+  /// and the prompt-mode confirm button so the two paths can't drift
+  /// out of sync again (which previously left the prompt flickering).
+  void _fireComskipSeek(({double start, double end}) segment) {
+    // ceil() past the segment's actual end so sub-second EDL precision
+    // (e.g. end=2284.08) doesn't leave us inside the half-open interval
+    // after rounding to whole seconds. The same value is used for the
+    // optimistic bump and the real seek so they stay in lockstep.
+    final seekTargetMs = (segment.end * 1000).ceil();
+    final seekTarget = Duration(milliseconds: seekTargetMs);
+    // Optimistically bump the local position past the segment's end so
+    // the very next tick no longer matches it — the manually-incremented
+    // _currentPosition otherwise lags the orchestrator's true position
+    // until onState confirms the seek asynchronously, which would
+    // re-match and re-fire on the next tick. _pendingComskipSeekTarget
+    // then prevents `_handleState` from clobbering the bump backward
+    // (the orchestrator's mid-seek position reports can lag/oscillate
+    // behind the optimistic value, which previously caused a re-fire
+    // loop). There's deliberately no persistent already-skipped
+    // tracking, since that would (and did) suppress a legitimate
+    // re-skip on scrub-back, replay, or restart-from-0.
+    _currentPosition = seekTarget;
+    _pendingComskipSeekTarget = seekTarget;
+    _pendingComskipSeekTimer?.cancel();
+    _pendingComskipSeekTimer = Timer(const Duration(seconds: 5), () {
+      if (_disposed || !mounted) return;
+      // Real seek never confirmed — give up holding position hostage so
+      // future comskip seeks aren't silently broken.
+      _pendingComskipSeekTarget = null;
+      _pendingComskipSeekTimer = null;
+    });
+    unawaited(widget.orchestrator.seek(seekTarget));
   }
 
   void _flashComskipSkippedBadge() {
@@ -412,7 +422,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   void _confirmComskipSkip() {
     final segment = _activeComskipSegment;
     if (segment == null) return;
-    unawaited(widget.orchestrator.seek(Duration(seconds: segment.end.round())));
+    _fireComskipSeek(segment);
     setState(() => _activeComskipSegment = null);
   }
 
@@ -549,8 +559,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
     // seek's buffering). Accept state.position only once it's at or past
     // the pending target — that proves the real seek genuinely caught up.
     final pendingTarget = _pendingComskipSeekTarget;
-    final acceptedPosition = pendingTarget != null &&
-            state.position < pendingTarget
+    final acceptedPosition =
+        pendingTarget != null && state.position < pendingTarget
         ? _currentPosition
         : state.position;
 
@@ -770,6 +780,17 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   void _seekTo(Duration position) {
     if (!_canSeek) return;
+    // A manual seek always supersedes any in-flight comskip seek — the
+    // user's deliberate new position should never be guarded by the
+    // auto-skip's pending target. Without this, the orchestrator's
+    // confirmation of the manual seek (which may briefly report a
+    // position before the auto-skip's target during the real seek's
+    // buffering) would be rejected as a stale regression and the
+    // player would hold _currentPosition at the auto-skip's target
+    // until the 5s safety-net timer cleared the guard.
+    _pendingComskipSeekTarget = null;
+    _pendingComskipSeekTimer?.cancel();
+    _pendingComskipSeekTimer = null;
     final clamped = position < Duration.zero
         ? Duration.zero
         : (position > _duration ? _duration : position);

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -283,7 +283,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
     try {
       final client = HttpClient();
-      final request = await client.getUrl(Uri.parse(edlUrl));
+      final request = await client.getUrl(_resolveEdlUri(Uri.parse(edlUrl)));
       final response = await request.close().timeout(
         const Duration(seconds: 8),
       );
@@ -308,6 +308,27 @@ class _PlayerScreenState extends State<PlayerScreen> {
     } on Object catch (error) {
       debugPrint('Comskip: failed to fetch EDL: $error');
     }
+  }
+
+  /// Rewrites a localhost/127.0.0.1 EDL host to the connected Xtream server's
+  /// real scheme/host/port. The m3u-editor backend occasionally returns an
+  /// edl_url pointing at its own loopback (e.g. `http://localhost/dvr/...`)
+  /// instead of the public host, which makes the client hit the user's own
+  /// machine. Only rewrites when the parsed host is loopback AND we have
+  /// configured credentials; otherwise returns the input unchanged so the
+  /// existing failure path runs untouched.
+  Uri _resolveEdlUri(Uri edlUri) {
+    final host = edlUri.host.toLowerCase();
+    if (host != 'localhost' && host != '127.0.0.1') return edlUri;
+    final server = widget.xtreamService?.credentials?.server;
+    if (server == null) return edlUri;
+    final serverUri = Uri.tryParse(server);
+    if (serverUri == null) return edlUri;
+    return edlUri.replace(
+      scheme: serverUri.scheme,
+      host: serverUri.host,
+      port: serverUri.port,
+    );
   }
 
   /// Checks whether the current playback position has entered a commercial

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -292,8 +292,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
     final edlUrl = args.metadata['edl_url'] as String?;
     if (edlUrl == null || edlUrl.isEmpty) return;
 
+    final client = HttpClient();
     try {
-      final client = HttpClient();
       final request = await client.getUrl(_resolveEdlUri(Uri.parse(edlUrl)));
       final response = await request.close().timeout(
         const Duration(seconds: 8),
@@ -318,6 +318,8 @@ class _PlayerScreenState extends State<PlayerScreen> {
       setState(() => _comskipSegments = segments);
     } on Object catch (error) {
       debugPrint('Comskip: failed to fetch EDL: $error');
+    } finally {
+      client.close();
     }
   }
 
@@ -1108,6 +1110,12 @@ class _PlayerScreenState extends State<PlayerScreen> {
                               context,
                             ).playerSkipCommercial,
                             onSkip: _confirmComskipSkip,
+                            // Only steal focus when the controls overlay is
+                            // hidden (nothing else is being actively
+                            // navigated). If the user is mid-interaction
+                            // with visible controls, let the prompt appear
+                            // without yanking focus away from them.
+                            autofocus: !_overlayVisible,
                           ),
                         ),
                       ),
@@ -1418,15 +1426,20 @@ class _ComskipSkippedBadge extends StatelessWidget {
 /// segment and auto-skip is disabled. Hides itself once the play-head
 /// exits the segment — see [_PlayerScreenState._checkComskip].
 class _ComskipSkipPrompt extends StatelessWidget {
-  const _ComskipSkipPrompt({required this.label, required this.onSkip});
+  const _ComskipSkipPrompt({
+    required this.label,
+    required this.onSkip,
+    required this.autofocus,
+  });
 
   final String label;
   final VoidCallback onSkip;
+  final bool autofocus;
 
   @override
   Widget build(BuildContext context) {
     return DpadInkWell(
-      autofocus: true,
+      autofocus: autofocus,
       onTap: onSkip,
       borderRadius: BorderRadius.circular(50),
       color: Colors.black.withValues(alpha: 0.75),

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show HttpClient, HttpStatus;
 
 import 'package:dpad/dpad.dart';
 import 'package:flutter/foundation.dart' show mapEquals;
@@ -13,10 +15,12 @@ import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/playback_orchestrator.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:m3u_tv/services/comskip_settings.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/trakt_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:media_kit_video/media_kit_video.dart' as mkv;
 
@@ -32,6 +36,7 @@ class PlayerScreen extends StatefulWidget {
     required this.orchestrator,
     required this.epgService,
     this.xtreamService,
+    this.comskipSettings,
     this.progressReporter,
     this.traktService,
     this.viewerId = '',
@@ -46,6 +51,7 @@ class PlayerScreen extends StatefulWidget {
   final PlaybackOrchestrator orchestrator;
   final EpgService epgService;
   final XtreamService? xtreamService;
+  final ComskipSettings? comskipSettings;
   final void Function(Progress progress)? progressReporter;
   final TraktService? traktService;
   final String viewerId;
@@ -79,6 +85,14 @@ class _PlayerScreenState extends State<PlayerScreen> {
   bool _isSubtitleTrackSelectionKnown = false;
 
   EpgCurrentNext? _epgData;
+
+  // Comskip (commercial-skip) state — only populated when args.metadata
+  // carries an 'edl_url' (completed DVR recordings with comskip enabled).
+  List<({double start, double end})> _comskipSegments = const [];
+  double? _lastAutoSkippedSegmentEnd;
+  ({double start, double end})? _activeComskipSegment;
+  bool _showComskipSkippedBadge = false;
+  Timer? _comskipBadgeTimer;
 
   bool _overlayVisible = true;
 
@@ -170,6 +184,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _openSource(widget.args);
     _startLoadingTimeout();
     _scheduleOverlayHide();
+    unawaited(_initComskip(widget.args));
   }
 
   // Live-TV skip-previous/skip-next replaces `args` on an already-mounted
@@ -192,6 +207,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _progressTimer?.cancel();
     _epgTimer?.cancel();
     _epgFetch = null;
+    _comskipBadgeTimer?.cancel();
 
     setState(() {
       _status = PlaybackStatus.idle;
@@ -207,11 +223,16 @@ class _PlayerScreenState extends State<PlayerScreen> {
       _selectedSubtitleTrackId = null;
       _epgData = null;
       _overlayVisible = true;
+      _comskipSegments = const [];
+      _lastAutoSkippedSegmentEnd = null;
+      _activeComskipSegment = null;
+      _showComskipSkippedBadge = false;
     });
 
     _openSource(widget.args);
     _startLoadingTimeout();
     _scheduleOverlayHide();
+    unawaited(_initComskip(widget.args));
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted && _overlayVisible) _controlsFocusNode.requestFocus();
     });
@@ -241,12 +262,107 @@ class _PlayerScreenState extends State<PlayerScreen> {
             ? _duration
             : next;
       });
+      _checkComskip();
     });
   }
 
   void _stopPositionTimer() {
     _positionTimer?.cancel();
     _positionTimer = null;
+  }
+
+  // ── Comskip (commercial-skip) ──────────────────────────────────────────
+
+  /// Fetches the comskip EDL segment list for completed DVR recordings.
+  /// Fire-and-forget: an older server, a recording with comskip disabled, or
+  /// any fetch failure just leaves [_comskipSegments] empty, so the rest of
+  /// the player behaves exactly as if this recording had no EDL at all.
+  Future<void> _initComskip(PlayerArgs args) async {
+    final edlUrl = args.metadata['edl_url'] as String?;
+    if (edlUrl == null || edlUrl.isEmpty) return;
+
+    try {
+      final client = HttpClient();
+      final request = await client.getUrl(Uri.parse(edlUrl));
+      final response = await request.close().timeout(
+        const Duration(seconds: 8),
+      );
+      if (response.statusCode != HttpStatus.ok) return;
+      final body = await utf8.decodeStream(response);
+      final decoded = jsonDecode(body);
+      if (decoded is! List) return;
+
+      final segments = decoded
+          .whereType<Map<String, Object?>>()
+          .map((segment) {
+            final start = segment['start'];
+            final end = segment['end'];
+            if (start is! num || end is! num) return null;
+            return (start: start.toDouble(), end: end.toDouble());
+          })
+          .whereType<({double start, double end})>()
+          .toList(growable: false);
+
+      if (!mounted || !identical(args, widget.args)) return;
+      setState(() => _comskipSegments = segments);
+    } on Object catch (error) {
+      debugPrint('Comskip: failed to fetch EDL: $error');
+    }
+  }
+
+  /// Checks whether the current playback position has entered a commercial
+  /// segment and reacts per the user's auto-skip/prompt preference. Called
+  /// after every position update, mirroring the web player's
+  /// timeupdate-driven `_checkComskip`.
+  void _checkComskip() {
+    if (_comskipSegments.isEmpty || _disposed || !mounted) return;
+
+    final positionSeconds = _currentPosition.inMilliseconds / 1000.0;
+    ({double start, double end})? current;
+    for (final segment in _comskipSegments) {
+      if (positionSeconds >= segment.start && positionSeconds < segment.end) {
+        current = segment;
+        break;
+      }
+    }
+
+    if (current == null) {
+      if (_activeComskipSegment != null) {
+        setState(() => _activeComskipSegment = null);
+      }
+      return;
+    }
+
+    final autoSkip = widget.comskipSettings?.autoSkipEnabled ?? true;
+    if (autoSkip) {
+      if (_lastAutoSkippedSegmentEnd == current.end) return;
+      _lastAutoSkippedSegmentEnd = current.end;
+      unawaited(
+        widget.orchestrator.seek(Duration(seconds: current.end.round())),
+      );
+      _flashComskipSkippedBadge();
+    } else if (_activeComskipSegment?.end != current.end) {
+      setState(() => _activeComskipSegment = current);
+    }
+  }
+
+  void _flashComskipSkippedBadge() {
+    _comskipBadgeTimer?.cancel();
+    setState(() => _showComskipSkippedBadge = true);
+    _comskipBadgeTimer = Timer(const Duration(seconds: 3), () {
+      if (!_disposed && mounted) {
+        setState(() => _showComskipSkippedBadge = false);
+      }
+    });
+  }
+
+  /// Confirms the prompt-mode skip control, jumping to the active segment's
+  /// end the same way auto-skip would.
+  void _confirmComskipSkip() {
+    final segment = _activeComskipSegment;
+    if (segment == null) return;
+    unawaited(widget.orchestrator.seek(Duration(seconds: segment.end.round())));
+    setState(() => _activeComskipSegment = null);
   }
 
   void _scrobble(String action) => _scrobbleFor(widget.args, action);
@@ -292,6 +408,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _progressTimer?.cancel();
     _positionTimer?.cancel();
     _epgTimer?.cancel();
+    _comskipBadgeTimer?.cancel();
     _screenFocusNode.dispose();
     _controlsFocusNode.dispose();
     _errorButtonFocusNode.dispose();
@@ -419,6 +536,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
         _goBack();
       }
     });
+    _checkComskip();
 
     // Only re-evaluate the hide timer on an actual play/pause transition:
     // pausing cancels it (keeping the overlay up), resuming restarts the
@@ -835,6 +953,34 @@ class _PlayerScreenState extends State<PlayerScreen> {
                       description: _nowPlayingDescription(),
                     ),
                   ),
+
+                // Comskip: brief auto-skip indicator (DVR recordings only)
+                if (_showComskipSkippedBadge)
+                  Positioned(
+                    top: 40,
+                    left: 40,
+                    child: _ComskipSkippedBadge(
+                      label: AppLocalizations.of(
+                        context,
+                      ).playerCommercialSkipped,
+                    ),
+                  ),
+
+                // Comskip: confirm-to-skip prompt (auto-skip disabled)
+                if (_activeComskipSegment != null)
+                  Positioned(
+                    left: 0,
+                    right: 0,
+                    bottom: 140,
+                    child: Center(
+                      child: _ComskipSkipPrompt(
+                        label: AppLocalizations.of(
+                          context,
+                        ).playerSkipCommercial,
+                        onSkip: _confirmComskipSkip,
+                      ),
+                    ),
+                  ),
               ],
             ),
           ),
@@ -1096,6 +1242,78 @@ class FallbackReasonBadge extends StatelessWidget {
           color: Colors.white,
           fontSize: 11,
           fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Brief, non-interactive indicator shown when a commercial segment was
+/// auto-skipped. Self-dismisses via [_PlayerScreenState._flashComskipSkippedBadge].
+class _ComskipSkippedBadge extends StatelessWidget {
+  const _ComskipSkippedBadge({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.75),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.fast_forward, color: Colors.white, size: 16),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Confirm-to-skip control shown while playback is inside a commercial
+/// segment and auto-skip is disabled. Hides itself once the play-head
+/// exits the segment — see [_PlayerScreenState._checkComskip].
+class _ComskipSkipPrompt extends StatelessWidget {
+  const _ComskipSkipPrompt({required this.label, required this.onSkip});
+
+  final String label;
+  final VoidCallback onSkip;
+
+  @override
+  Widget build(BuildContext context) {
+    return DpadInkWell(
+      autofocus: true,
+      onTap: onSkip,
+      borderRadius: BorderRadius.circular(50),
+      color: Colors.black.withValues(alpha: 0.75),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.fast_forward, color: Colors.white, size: 18),
+            const SizedBox(width: 8),
+            Text(
+              label,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/flutter_client/lib/features/settings/settings_screen.dart
+++ b/flutter_client/lib/features/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/services/app_version_service.dart';
 import 'package:m3u_tv/services/auth_notifier.dart';
+import 'package:m3u_tv/services/comskip_settings.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/proxy_playback_settings.dart';
 import 'package:m3u_tv/services/trakt_service.dart';
@@ -40,11 +41,13 @@ class SettingsScreen extends StatefulWidget {
     this.locale,
     this.onLocaleChanged,
     this.proxyPlaybackSettings,
+    this.comskipSettings,
   });
 
   final AuthNotifier authNotifier;
   final TraktService traktService;
   final ProxyPlaybackSettings? proxyPlaybackSettings;
+  final ComskipSettings? comskipSettings;
   final Viewer? activeViewer;
   final List<Viewer> viewers;
   final String? sourceLabel;
@@ -147,6 +150,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         locale: widget.locale,
         onLocaleChanged: widget.onLocaleChanged,
         proxyPlaybackSettings: widget.proxyPlaybackSettings,
+        comskipSettings: widget.comskipSettings,
       ),
     );
   }
@@ -332,11 +336,13 @@ class _ConnectedView extends StatefulWidget {
     this.locale,
     this.onLocaleChanged,
     this.proxyPlaybackSettings,
+    this.comskipSettings,
   });
 
   final AuthNotifier authNotifier;
   final TraktService traktService;
   final ProxyPlaybackSettings? proxyPlaybackSettings;
+  final ComskipSettings? comskipSettings;
   final Viewer? activeViewer;
   final List<Viewer> viewers;
   final String? sourceLabel;
@@ -675,6 +681,32 @@ class _ConnectedViewState extends State<_ConnectedView>
               builder: (context, _) => _ProxyPlaybackControls(
                 capability: auth!.proxy!,
                 settings: widget.proxyPlaybackSettings!,
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+        ],
+
+        // ── Commercial skipping ──────────────────────────────────────────────
+        if (widget.comskipSettings != null) ...[
+          _SettingsSection(
+            title: l.settingsComskip,
+            subtitle: l.settingsComskipSubtitle,
+            child: ListenableBuilder(
+              listenable: widget.comskipSettings!,
+              builder: (context, _) => Wrap(
+                spacing: 8,
+                children: [
+                  _IntervalChip(
+                    label: l.settingsComskipAutoSkip,
+                    isSelected: widget.comskipSettings!.autoSkipEnabled,
+                    onTap: () => unawaited(
+                      widget.comskipSettings!.setAutoSkipEnabled(
+                        enabled: !widget.comskipSettings!.autoSkipEnabled,
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
           ),

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -86,6 +86,8 @@
       }
     }
   },
+  "playerCommercialSkipped": "Werbung übersprungen",
+  "playerSkipCommercial": "Werbung überspringen",
   "searchHint": "Live-TV, Filme und Serien durchsuchen …",
   "searchSectionLiveTv": "Live-TV",
   "searchSectionMovies": "Filme",
@@ -126,6 +128,9 @@
   "settingsProxyProfileDefault": "Standard",
   "settingsProxyProfileDirect": "Direkt (ohne Transkodierung)",
   "settingsProxyNoProfiles": "Keine Transkodierungsprofile verfügbar — Streams nutzen den direkten Proxy.",
+  "settingsComskip": "Werbeerkennung",
+  "settingsComskipSubtitle": "Legt fest, wie der Player auf erkannte Werbeunterbrechungen in DVR-Aufnahmen reagiert.",
+  "settingsComskipAutoSkip": "Werbung automatisch überspringen",
   "settingsDisconnectTitle": "Trennen?",
   "settingsDisconnectBody": "Du wirst abgemeldet und musst deine Anmeldedaten erneut eingeben, um dich wieder zu verbinden.",
   "settingsDisconnectConfirm": "Trennen",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -86,6 +86,8 @@
       }
     }
   },
+  "playerCommercialSkipped": "Skipped commercial",
+  "playerSkipCommercial": "Skip commercial",
   "searchHint": "Search live TV, movies, and series...",
   "searchSectionLiveTv": "Live TV",
   "searchSectionMovies": "Movies",
@@ -151,6 +153,9 @@
   "settingsProxyProfileDefault": "Default",
   "settingsProxyProfileDirect": "Direct (no transcoding)",
   "settingsProxyNoProfiles": "No transcoding profiles available — streams use the direct proxy.",
+  "settingsComskip": "Commercial Skipping",
+  "settingsComskipSubtitle": "Controls how the player reacts to commercial breaks detected in DVR recordings.",
+  "settingsComskipAutoSkip": "Auto-skip commercials",
   "settingsDisconnectTitle": "Disconnect?",
   "settingsDisconnectBody": "You will be signed out and will need to re-enter your credentials to reconnect.",
   "settingsDisconnectConfirm": "Disconnect",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -86,6 +86,8 @@
       }
     }
   },
+  "playerCommercialSkipped": "Anuncio omitido",
+  "playerSkipCommercial": "Omitir anuncio",
   "searchHint": "Buscar Televisión en vivo, cine y series…",
   "searchSectionLiveTv": "Televisión en vivo",
   "searchSectionMovies": "Cine",
@@ -126,6 +128,9 @@
   "settingsProxyProfileDefault": "Predeterminado",
   "settingsProxyProfileDirect": "Directo (sin transcodificación)",
   "settingsProxyNoProfiles": "No hay perfiles de transcodificación disponibles; las transmisiones usan el proxy directo.",
+  "settingsComskip": "Omisión de anuncios",
+  "settingsComskipSubtitle": "Controla cómo reacciona el reproductor a los anuncios detectados en las grabaciones DVR.",
+  "settingsComskipAutoSkip": "Omitir anuncios automáticamente",
   "settingsDisconnectTitle": "¿Desconectar?",
   "settingsDisconnectBody": "Se cerrará tu sesión y deberás volver a introducir tus credenciales para reconectarte.",
   "settingsDisconnectConfirm": "Desconectar",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -86,6 +86,8 @@
       }
     }
   },
+  "playerCommercialSkipped": "Publicité ignorée",
+  "playerSkipCommercial": "Ignorer la publicité",
   "searchHint": "Rechercher Télévision en direct, films et séries…",
   "searchSectionLiveTv": "Télévision en direct",
   "searchSectionMovies": "Films",
@@ -126,6 +128,9 @@
   "settingsProxyProfileDefault": "Par défaut",
   "settingsProxyProfileDirect": "Direct (sans transcodage)",
   "settingsProxyNoProfiles": "Aucun profil de transcodage disponible — les flux utilisent le proxy direct.",
+  "settingsComskip": "Suppression des publicités",
+  "settingsComskipSubtitle": "Contrôle la réaction du lecteur aux coupures publicitaires détectées dans les enregistrements DVR.",
+  "settingsComskipAutoSkip": "Ignorer automatiquement les publicités",
   "settingsDisconnectTitle": "Se déconnecter ?",
   "settingsDisconnectBody": "Vous serez déconnecté et devrez saisir à nouveau vos identifiants pour vous reconnecter.",
   "settingsDisconnectConfirm": "Déconnecter",

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -392,6 +392,18 @@ abstract class AppLocalizations {
   /// **'S{season} · E{episode}'**
   String playerNowPlayingSeasonEpisode(int season, int episode);
 
+  /// No description provided for @playerCommercialSkipped.
+  ///
+  /// In en, this message translates to:
+  /// **'Skipped commercial'**
+  String get playerCommercialSkipped;
+
+  /// No description provided for @playerSkipCommercial.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip commercial'**
+  String get playerSkipCommercial;
+
   /// No description provided for @searchHint.
   ///
   /// In en, this message translates to:
@@ -697,6 +709,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No transcoding profiles available — streams use the direct proxy.'**
   String get settingsProxyNoProfiles;
+
+  /// No description provided for @settingsComskip.
+  ///
+  /// In en, this message translates to:
+  /// **'Commercial Skipping'**
+  String get settingsComskip;
+
+  /// No description provided for @settingsComskipSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Controls how the player reacts to commercial breaks detected in DVR recordings.'**
+  String get settingsComskipSubtitle;
+
+  /// No description provided for @settingsComskipAutoSkip.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-skip commercials'**
+  String get settingsComskipAutoSkip;
 
   /// No description provided for @settingsDisconnectTitle.
   ///

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -164,6 +164,12 @@ class AppLocalizationsDe extends AppLocalizations {
   }
 
   @override
+  String get playerCommercialSkipped => 'Werbung übersprungen';
+
+  @override
+  String get playerSkipCommercial => 'Werbung überspringen';
+
+  @override
   String get searchHint => 'Live-TV, Filme und Serien durchsuchen …';
 
   @override
@@ -325,6 +331,16 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get settingsProxyNoProfiles =>
       'Keine Transkodierungsprofile verfügbar — Streams nutzen den direkten Proxy.';
+
+  @override
+  String get settingsComskip => 'Werbeerkennung';
+
+  @override
+  String get settingsComskipSubtitle =>
+      'Legt fest, wie der Player auf erkannte Werbeunterbrechungen in DVR-Aufnahmen reagiert.';
+
+  @override
+  String get settingsComskipAutoSkip => 'Werbung automatisch überspringen';
 
   @override
   String get settingsDisconnectTitle => 'Trennen?';

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -163,6 +163,12 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String get playerCommercialSkipped => 'Skipped commercial';
+
+  @override
+  String get playerSkipCommercial => 'Skip commercial';
+
+  @override
   String get searchHint => 'Search live TV, movies, and series...';
 
   @override
@@ -324,6 +330,16 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get settingsProxyNoProfiles =>
       'No transcoding profiles available — streams use the direct proxy.';
+
+  @override
+  String get settingsComskip => 'Commercial Skipping';
+
+  @override
+  String get settingsComskipSubtitle =>
+      'Controls how the player reacts to commercial breaks detected in DVR recordings.';
+
+  @override
+  String get settingsComskipAutoSkip => 'Auto-skip commercials';
 
   @override
   String get settingsDisconnectTitle => 'Disconnect?';

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -163,6 +163,12 @@ class AppLocalizationsEs extends AppLocalizations {
   }
 
   @override
+  String get playerCommercialSkipped => 'Anuncio omitido';
+
+  @override
+  String get playerSkipCommercial => 'Omitir anuncio';
+
+  @override
   String get searchHint => 'Buscar Televisión en vivo, cine y series…';
 
   @override
@@ -325,6 +331,16 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get settingsProxyNoProfiles =>
       'No hay perfiles de transcodificación disponibles; las transmisiones usan el proxy directo.';
+
+  @override
+  String get settingsComskip => 'Omisión de anuncios';
+
+  @override
+  String get settingsComskipSubtitle =>
+      'Controla cómo reacciona el reproductor a los anuncios detectados en las grabaciones DVR.';
+
+  @override
+  String get settingsComskipAutoSkip => 'Omitir anuncios automáticamente';
 
   @override
   String get settingsDisconnectTitle => '¿Desconectar?';

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -163,6 +163,12 @@ class AppLocalizationsFr extends AppLocalizations {
   }
 
   @override
+  String get playerCommercialSkipped => 'Publicité ignorée';
+
+  @override
+  String get playerSkipCommercial => 'Ignorer la publicité';
+
+  @override
   String get searchHint => 'Rechercher Télévision en direct, films et séries…';
 
   @override
@@ -324,6 +330,17 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get settingsProxyNoProfiles =>
       'Aucun profil de transcodage disponible — les flux utilisent le proxy direct.';
+
+  @override
+  String get settingsComskip => 'Suppression des publicités';
+
+  @override
+  String get settingsComskipSubtitle =>
+      'Contrôle la réaction du lecteur aux coupures publicitaires détectées dans les enregistrements DVR.';
+
+  @override
+  String get settingsComskipAutoSkip =>
+      'Ignorer automatiquement les publicités';
 
   @override
   String get settingsDisconnectTitle => 'Se déconnecter ?';

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -163,6 +163,12 @@ class AppLocalizationsZh extends AppLocalizations {
   }
 
   @override
+  String get playerCommercialSkipped => '已跳过广告';
+
+  @override
+  String get playerSkipCommercial => '跳过广告';
+
+  @override
   String get searchHint => '搜索直播电视、电影和剧集…';
 
   @override
@@ -319,6 +325,15 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get settingsProxyNoProfiles => '没有可用的转码配置——将使用直连代理播放。';
+
+  @override
+  String get settingsComskip => '广告跳过';
+
+  @override
+  String get settingsComskipSubtitle => '控制播放器在录制内容中检测到广告时的处理方式。';
+
+  @override
+  String get settingsComskipAutoSkip => '自动跳过广告';
 
   @override
   String get settingsDisconnectTitle => '断开连接？';

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -86,6 +86,8 @@
       }
     }
   },
+  "playerCommercialSkipped": "已跳过广告",
+  "playerSkipCommercial": "跳过广告",
   "searchHint": "搜索直播电视、电影和剧集…",
   "searchSectionLiveTv": "直播电视",
   "searchSectionMovies": "电影",
@@ -126,6 +128,9 @@
   "settingsProxyProfileDefault": "默认",
   "settingsProxyProfileDirect": "直连（不转码）",
   "settingsProxyNoProfiles": "没有可用的转码配置——将使用直连代理播放。",
+  "settingsComskip": "广告跳过",
+  "settingsComskipSubtitle": "控制播放器在录制内容中检测到广告时的处理方式。",
+  "settingsComskipAutoSkip": "自动跳过广告",
   "settingsDisconnectTitle": "断开连接？",
   "settingsDisconnectBody": "您将被退出登录，需要重新输入凭据才能重新连接。",
   "settingsDisconnectConfirm": "断开连接",

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -10,6 +10,7 @@ import 'package:m3u_tv/services/aiostreams_favorites_service.dart';
 import 'package:m3u_tv/services/async_lifecycle.dart';
 import 'package:m3u_tv/services/auth_notifier.dart';
 import 'package:m3u_tv/services/cache_service.dart';
+import 'package:m3u_tv/services/comskip_settings.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/favorites_service.dart';
@@ -47,6 +48,7 @@ class AppStateController extends ChangeNotifier {
     ReverbService? reverbService,
     AIOStreamsFavoritesService? aioFavoritesService,
     ProxyPlaybackSettings? proxyPlaybackSettings,
+    ComskipSettings? comskipSettings,
     PushNotificationService? pushNotificationService,
   }) {
     final store = persistentStore ?? PersistentJsonStore();
@@ -87,6 +89,7 @@ class AppStateController extends ChangeNotifier {
           aioFavoritesService ?? AIOStreamsFavoritesService(store: store),
       proxyPlaybackSettings:
           proxyPlaybackSettings ?? ProxyPlaybackSettings(store: store),
+      comskipSettings: comskipSettings ?? ComskipSettings(store: store),
       pushNotificationService:
           pushNotificationService ?? PushNotificationService(),
     );
@@ -110,6 +113,7 @@ class AppStateController extends ChangeNotifier {
     required this._reverbService,
     required this.aioFavoritesService,
     required this.proxyPlaybackSettings,
+    required this.comskipSettings,
     required this._pushNotificationService,
   }) {
     favoritesService.onChanged = (streamId, {required favorited}) =>
@@ -143,6 +147,7 @@ class AppStateController extends ChangeNotifier {
   final ResumeService resumeService;
   final AIOStreamsFavoritesService aioFavoritesService;
   final ProxyPlaybackSettings proxyPlaybackSettings;
+  final ComskipSettings comskipSettings;
   final TvNotificationService _tvNotificationService;
   final TvNotificationStore notificationStore;
   final ReverbService _reverbService;
@@ -295,6 +300,7 @@ class AppStateController extends ChangeNotifier {
     notifyListeners();
     unawaited(traktService.init());
     unawaited(proxyPlaybackSettings.load());
+    unawaited(comskipSettings.load());
 
     final savedLocale = await secureStorage.read(_localeKey);
     if (savedLocale != null) _locale = Locale(savedLocale);

--- a/flutter_client/lib/services/comskip_settings.dart
+++ b/flutter_client/lib/services/comskip_settings.dart
@@ -1,0 +1,40 @@
+// ignore_for_file: prefer_initializing_formals
+
+import 'package:flutter/foundation.dart';
+import 'package:m3u_tv/services/persistent_store.dart';
+
+/// Per-device commercial-skip (comskip/EDL) playback preference.
+///
+/// Controls how the player reacts when a DVR recording's EDL segments show
+/// the play-head inside a detected commercial break: auto-skip straight to
+/// the segment's end, or show a confirm-to-skip prompt instead.
+class ComskipSettings extends ChangeNotifier {
+  ComskipSettings({PersistentJsonStore? store}) : _store = store;
+
+  static const _storeKey = 'm3ue_tv_comskip';
+
+  final PersistentJsonStore? _store;
+
+  bool _autoSkipEnabled = true;
+
+  bool get autoSkipEnabled => _autoSkipEnabled;
+
+  Future<void> load() async {
+    final raw = await _store?.read(_storeKey);
+    if (raw is! Map) return;
+    _autoSkipEnabled = raw['auto_skip_enabled'] != false;
+    notifyListeners();
+  }
+
+  Future<void> setAutoSkipEnabled({required bool enabled}) async {
+    _autoSkipEnabled = enabled;
+    await _persist();
+    notifyListeners();
+  }
+
+  Future<void> _persist() async {
+    await _store?.write(_storeKey, <String, Object?>{
+      'auto_skip_enabled': _autoSkipEnabled,
+    });
+  }
+}

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -992,9 +992,9 @@ bool _asBool(Object? value) {
 }
 
 String? _asNullableString(Object? value) {
-  if (value == null) return null;
-  final text = '$value';
-  return text.isEmpty ? null : text;
+  if (value is String) return value.isEmpty ? null : value;
+  if (value is num) return '$value';
+  return null;
 }
 
 Map<String, Object?> _asMap(Object? value) {

--- a/flutter_client/test/services/comskip_settings_test.dart
+++ b/flutter_client/test/services/comskip_settings_test.dart
@@ -25,39 +25,45 @@ void main() {
       expect(settings.autoSkipEnabled, isTrue);
     });
 
-    test('round-trips a disabled preference through the persistent store', () async {
-      final dir = await Directory.systemTemp.createTemp('comskip_settings');
-      addTearDown(() => dir.delete(recursive: true));
-      final file = File('${dir.path}/store.json');
+    test(
+      'round-trips a disabled preference through the persistent store',
+      () async {
+        final dir = await Directory.systemTemp.createTemp('comskip_settings');
+        addTearDown(() => dir.delete(recursive: true));
+        final file = File('${dir.path}/store.json');
 
-      final store = PersistentJsonStore(file: file);
-      final settings = ComskipSettings(store: store);
-      await settings.setAutoSkipEnabled(enabled: false);
+        final store = PersistentJsonStore(file: file);
+        final settings = ComskipSettings(store: store);
+        await settings.setAutoSkipEnabled(enabled: false);
 
-      final restored = ComskipSettings(
-        store: PersistentJsonStore(file: file),
-      );
-      await restored.load();
+        final restored = ComskipSettings(
+          store: PersistentJsonStore(file: file),
+        );
+        await restored.load();
 
-      expect(restored.autoSkipEnabled, isFalse);
-    });
+        expect(restored.autoSkipEnabled, isFalse);
+      },
+    );
 
-    test('round-trips a re-enabled preference through the persistent store', () async {
-      final dir = await Directory.systemTemp.createTemp('comskip_settings');
-      addTearDown(() => dir.delete(recursive: true));
-      final file = File('${dir.path}/store.json');
+    test(
+      'round-trips a re-enabled preference through the persistent store',
+      () async {
+        final dir = await Directory.systemTemp.createTemp('comskip_settings');
+        addTearDown(() => dir.delete(recursive: true));
+        final file = File('${dir.path}/store.json');
 
-      final store = PersistentJsonStore(file: file);
-      final settings = ComskipSettings(store: store);
-      await settings.setAutoSkipEnabled(enabled: false);
-      await settings.setAutoSkipEnabled(enabled: true);
+        final store = PersistentJsonStore(file: file);
+        final settings = ComskipSettings(store: store);
+        await settings.setAutoSkipEnabled(enabled: false);
+        await settings.setAutoSkipEnabled(enabled: true);
 
-      final restored = ComskipSettings(
-        store: PersistentJsonStore(file: file),
-      );
-      await restored.load();
+        final restored = ComskipSettings(
+          store: PersistentJsonStore(file: file),
+        );
+        await restored.load();
 
-      expect(restored.autoSkipEnabled, isTrue);
-    });
+        expect(restored.autoSkipEnabled, isTrue);
+      },
+    );
   });
 }

--- a/flutter_client/test/services/comskip_settings_test.dart
+++ b/flutter_client/test/services/comskip_settings_test.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/comskip_settings.dart';
+import 'package:m3u_tv/services/persistent_store.dart';
+
+void main() {
+  group('ComskipSettings', () {
+    test('defaults auto-skip to enabled with no persisted store', () {
+      final settings = ComskipSettings();
+
+      expect(settings.autoSkipEnabled, isTrue);
+    });
+
+    test('load() with no persisted value keeps the default enabled', () async {
+      final dir = await Directory.systemTemp.createTemp('comskip_settings');
+      addTearDown(() => dir.delete(recursive: true));
+      final file = File('${dir.path}/store.json');
+
+      final settings = ComskipSettings(
+        store: PersistentJsonStore(file: file),
+      );
+      await settings.load();
+
+      expect(settings.autoSkipEnabled, isTrue);
+    });
+
+    test('round-trips a disabled preference through the persistent store', () async {
+      final dir = await Directory.systemTemp.createTemp('comskip_settings');
+      addTearDown(() => dir.delete(recursive: true));
+      final file = File('${dir.path}/store.json');
+
+      final store = PersistentJsonStore(file: file);
+      final settings = ComskipSettings(store: store);
+      await settings.setAutoSkipEnabled(enabled: false);
+
+      final restored = ComskipSettings(
+        store: PersistentJsonStore(file: file),
+      );
+      await restored.load();
+
+      expect(restored.autoSkipEnabled, isFalse);
+    });
+
+    test('round-trips a re-enabled preference through the persistent store', () async {
+      final dir = await Directory.systemTemp.createTemp('comskip_settings');
+      addTearDown(() => dir.delete(recursive: true));
+      final file = File('${dir.path}/store.json');
+
+      final store = PersistentJsonStore(file: file);
+      final settings = ComskipSettings(store: store);
+      await settings.setAutoSkipEnabled(enabled: false);
+      await settings.setAutoSkipEnabled(enabled: true);
+
+      final restored = ComskipSettings(
+        store: PersistentJsonStore(file: file),
+      );
+      await restored.load();
+
+      expect(restored.autoSkipEnabled, isTrue);
+    });
+  });
+}

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  // The `_asNullableString` helper is private, so these tests exercise it
+  // indirectly through `DvrRecording.fromXtream`, which is its primary user.
+  // The behavior we care about: URL-like fields must end up null rather than
+  // a stringified "[]" / "{}" / "true" when the backend returns a non-string
+  // JSON value.
+  group('DvrRecording.fromXtream non-string hardening', () {
+    Map<String, Object?> jsonWith(Object? edlUrl) => <String, Object?>{
+      'uuid': 'rec-1',
+      'title': 'Hardening fixture',
+      'status': 'completed',
+      'stream_url': 'https://example.com/stream.mp4',
+      'edl_url': edlUrl,
+      'channel_icon': edlUrl,
+    };
+
+    test('empty list maps to null (was previously the literal "[]")', () {
+      final recording = DvrRecording.fromXtream(jsonWith(<Object?>[]));
+      expect(recording.edlUrl, isNull);
+      expect(recording.channelIconUrl, isNull);
+    });
+
+    test('non-empty list maps to null (was previously "[a, b]")', () {
+      final recording = DvrRecording.fromXtream(
+        jsonWith(<Object?>['https://example.com/edl']),
+      );
+      expect(recording.edlUrl, isNull);
+      expect(recording.channelIconUrl, isNull);
+    });
+
+    test('Map maps to null (was previously the literal "{...}")', () {
+      final recording = DvrRecording.fromXtream(
+        jsonWith(<String, Object?>{'host': 'evil'}),
+      );
+      expect(recording.edlUrl, isNull);
+      expect(recording.channelIconUrl, isNull);
+    });
+
+    test('bool maps to null', () {
+      final recording = DvrRecording.fromXtream(jsonWith(true));
+      expect(recording.edlUrl, isNull);
+      expect(recording.channelIconUrl, isNull);
+    });
+
+    test('null maps to null', () {
+      final recording = DvrRecording.fromXtream(jsonWith(null));
+      expect(recording.edlUrl, isNull);
+      expect(recording.channelIconUrl, isNull);
+    });
+
+    test('String round-trips unchanged', () {
+      const url = 'https://m3u.bearald.com/dvr/abc/edl';
+      final recording = DvrRecording.fromXtream(jsonWith(url));
+      expect(recording.edlUrl, url);
+      expect(recording.channelIconUrl, url);
+    });
+
+    test('empty String maps to null', () {
+      final recording = DvrRecording.fromXtream(jsonWith(''));
+      expect(recording.edlUrl, isNull);
+    });
+
+    test('int stringifies (numeric IDs still come through as raw numbers)', () {
+      final recording = DvrRecording.fromXtream(jsonWith(42));
+      expect(recording.edlUrl, '42');
+      expect(recording.channelIconUrl, '42');
+    });
+
+    test('double stringifies', () {
+      final recording = DvrRecording.fromXtream(jsonWith(3.14));
+      expect(recording.edlUrl, '3.14');
+      expect(recording.channelIconUrl, '3.14');
+    });
+  });
+}

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
@@ -16,12 +18,74 @@ import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/playback/playback_capabilities.dart';
 import 'package:m3u_tv/playback/playback_orchestrator.dart';
 import 'package:m3u_tv/playback/player_adapter.dart';
+import 'package:m3u_tv/services/comskip_settings.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
 
 import 'fake_player_adapter.dart';
 import 'fake_transcode_gateway.dart';
+
+/// Minimal `HttpClient` fake for testing the comskip EDL fetch — every
+/// request returns the same canned body/status, regardless of URL. Only
+/// [getUrl] and [close] are implemented; anything else falls through to
+/// [noSuchMethod], which is fine since `_initComskip` never touches it.
+class _FakeHttpClient implements HttpClient {
+  _FakeHttpClient(this._body);
+
+  final String _body;
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async {
+    return _FakeHttpClientRequest(_body, HttpStatus.ok);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpClientRequest implements HttpClientRequest {
+  _FakeHttpClientRequest(this._body, this._statusCode);
+
+  final String _body;
+  final int _statusCode;
+
+  @override
+  Future<HttpClientResponse> close() async =>
+      _FakeHttpClientResponse(_body, _statusCode);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpClientResponse extends Stream<List<int>>
+    implements HttpClientResponse {
+  _FakeHttpClientResponse(String body, this.statusCode)
+    : _stream = Stream.value(utf8.encode(body));
+
+  final Stream<List<int>> _stream;
+
+  @override
+  final int statusCode;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return _stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 void main() {
   group('formatTime', () {
@@ -2109,5 +2173,245 @@ void main() {
         expect(adapter.loadCalls, hasLength(2));
       },
     );
+
+    group('Comskip', () {
+      PlaybackOrchestrator buildOrchestrator(FakePlayerAdapter adapter) {
+        return PlaybackOrchestrator(
+          platform: PlaybackPlatform.desktop,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.desktopLibmpv: adapter,
+          },
+          transcodeGateway: FakeTranscodeGateway(),
+        );
+      }
+
+      const recordingArgs = PlayerArgs(
+        streamUrl: 'https://example.com/recording.mp4',
+        title: 'Comskip Fixture',
+        type: 'vod',
+        metadata: <String, Object?>{
+          'edl_url': 'https://example.com/recording/edl',
+        },
+      );
+
+      testWidgets(
+        'never fetches or shows comskip UI when edl_url is absent',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: PlayerScreen(
+                args: const PlayerArgs(
+                  streamUrl: 'https://example.com/recording.mp4',
+                  title: 'No EDL Fixture',
+                  type: 'vod',
+                ),
+                orchestrator: orchestrator,
+                epgService: EpgService(clock: () => DateTime.utc(2026)),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          adapter.emitState(
+            const PlaybackState(
+              backend: PlaybackBackend.desktopLibmpv,
+              status: PlaybackStatus.playing,
+              position: Duration(seconds: 15),
+              duration: Duration(minutes: 1),
+            ),
+          );
+          await tester.pump();
+
+          expect(adapter.seekCalls, isEmpty);
+          expect(find.text('Skipped commercial'), findsNothing);
+          expect(find.text('Skip commercial'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'auto-skip mode seeks past a segment once and does not re-trigger',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 5),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, isEmpty);
+
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            expect(find.text('Skipped commercial'), findsOneWidget);
+
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 15),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
+            // Still inside the same segment — must not seek a second time.
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'prompt mode shows the skip control inside a segment and confirms on tap',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+          final settings = ComskipSettings();
+          await settings.setAutoSkipEnabled(enabled: false);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: settings,
+                ),
+              ),
+            );
+            await tester.pump();
+
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
+            expect(adapter.seekCalls, isEmpty);
+            expect(find.text('Skip commercial'), findsOneWidget);
+
+            await tester.tap(find.text('Skip commercial'));
+            await tester.pump();
+
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            expect(find.text('Skip commercial'), findsNothing);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'prompt mode hides the skip control once playback exits the segment',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+          final settings = ComskipSettings();
+          await settings.setAutoSkipEnabled(enabled: false);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: settings,
+                ),
+              ),
+            );
+            await tester.pump();
+
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(find.text('Skip commercial'), findsOneWidget);
+
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 25),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
+            expect(find.text('Skip commercial'), findsNothing);
+            expect(adapter.seekCalls, isEmpty);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+    });
   });
 }

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -2257,6 +2257,7 @@ void main() {
                   args: recordingArgs,
                   orchestrator: orchestrator,
                   epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: ComskipSettings(),
                 ),
               ),
             );
@@ -2409,6 +2410,127 @@ void main() {
             expect(adapter.seekCalls, isEmpty);
           }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
                 {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'falls back to confirm prompt when comskipSettings is null',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  // comskipSettings intentionally omitted — null fallback
+                ),
+              ),
+            );
+            await tester.pump();
+
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
+            expect(adapter.seekCalls, isEmpty);
+            expect(find.text('Skip commercial'), findsOneWidget);
+
+            await tester.tap(find.text('Skip commercial'));
+            await tester.pump();
+
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            expect(find.text('Skip commercial'), findsNothing);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'does not re-trigger auto-skip when rewinding into an already-skipped segment',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            // Enter segment A (10–20) → auto-skip to 20.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Rewind back to 15 — still inside A — must NOT seek again.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 15),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Advance into segment B (30–40) — must auto-skip to 40.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 35),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [
+              const Duration(seconds: 20),
+              const Duration(seconds: 40),
+            ]);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+                {'start': 30.0, 'end': 40.0},
               ])));
         },
       );

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -2240,7 +2240,7 @@ void main() {
       );
 
       testWidgets(
-        'auto-skip mode seeks past a segment once and does not re-trigger',
+        'auto-skip mode seeks past a segment and re-fires on re-entry',
         (tester) async {
           final adapter = FakePlayerAdapter(
             capabilities: PlaybackCapabilities.desktopLibmpv,
@@ -2289,6 +2289,10 @@ void main() {
             expect(adapter.seekCalls, [const Duration(seconds: 20)]);
             expect(find.text('Skipped commercial'), findsOneWidget);
 
+            // Re-entry into the same segment — must RE-fire seek. The
+            // mechanism is stateless: position is the source of truth.
+            // No persistent guard set suppresses repeat skips on
+            // user-initiated re-entry (scrub-back, restart, replay).
             adapter.emitState(
               const PlaybackState(
                 backend: PlaybackBackend.desktopLibmpv,
@@ -2299,8 +2303,10 @@ void main() {
             );
             await tester.pump();
 
-            // Still inside the same segment — must not seek a second time.
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            expect(adapter.seekCalls, [
+              const Duration(seconds: 20),
+              const Duration(seconds: 20),
+            ]);
           }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
                 {'start': 10.0, 'end': 20.0},
               ])));
@@ -2467,7 +2473,7 @@ void main() {
       );
 
       testWidgets(
-        'does not re-trigger auto-skip when rewinding into an already-skipped segment',
+        're-fires auto-skip when user scrubs back into an already-skipped segment',
         (tester) async {
           final adapter = FakePlayerAdapter(
             capabilities: PlaybackCapabilities.desktopLibmpv,
@@ -2504,7 +2510,10 @@ void main() {
             await tester.pump();
             expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Rewind back to 15 — still inside A — must NOT seek again.
+            // User scrubs back to 15s — still inside segment A — must
+            // RE-fire auto-skip. The mechanism is stateless: position is
+            // the source of truth, no persistent guard set. This matches
+            // the web reference _checkComskip behavior.
             adapter.emitState(
               const PlaybackState(
                 backend: PlaybackBackend.desktopLibmpv,
@@ -2514,7 +2523,10 @@ void main() {
               ),
             );
             await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            expect(adapter.seekCalls, [
+              const Duration(seconds: 20),
+              const Duration(seconds: 20),
+            ]);
 
             // Advance into segment B (30–40) — must auto-skip to 40.
             adapter.emitState(
@@ -2528,11 +2540,152 @@ void main() {
             await tester.pump();
             expect(adapter.seekCalls, [
               const Duration(seconds: 20),
+              const Duration(seconds: 20),
               const Duration(seconds: 40),
             ]);
           }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
                 {'start': 10.0, 'end': 20.0},
                 {'start': 30.0, 'end': 40.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'does not fire auto-skip while seek is in flight (orchestrator confirms at segment end)',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            // Enter segment A (10–20) → auto-skip fires.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Orchestrator confirms seek — position now AT segment end.
+            // _checkComskip reads _currentPosition=20, no segment matched,
+            // no extra seek. This is the optimistic-bump mechanism: the
+            // next [start, end) half-open interval check naturally
+            // evaluates false at t=20.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 20),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        're-fires auto-skip on segment 1 after restart from position 0',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            // First playthrough: enter segment A (10–20) → auto-skip fires.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Orchestrator confirms seek at 20s.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 20),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
+            // User restarts from beginning — position now at 5s (outside).
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 5),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Forward playback re-enters segment A — must auto-skip AGAIN.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 15),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [
+              const Duration(seconds: 20),
+              const Duration(seconds: 20),
+            ]);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
               ])));
         },
       );

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -43,6 +43,9 @@ class _FakeHttpClient implements HttpClient {
   }
 
   @override
+  void close({bool force = false}) {}
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
@@ -2889,7 +2892,7 @@ void main() {
       );
 
       testWidgets(
-        'rewrites a localhost edl_url host to the Xtream server before fetching',
+        're-fires auto-skip when user restarts playback from the beginning',
         (tester) async {
           final adapter = FakePlayerAdapter(
             capabilities: PlaybackCapabilities.desktopLibmpv,

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -2289,10 +2289,20 @@ void main() {
             expect(adapter.seekCalls, [const Duration(seconds: 20)]);
             expect(find.text('Skipped commercial'), findsOneWidget);
 
-            // Re-entry into the same segment — must RE-fire seek. The
-            // mechanism is stateless: position is the source of truth.
-            // No persistent guard set suppresses repeat skips on
-            // user-initiated re-entry (scrub-back, restart, replay).
+            // Orchestrator confirms the seek — clears the pending guard.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 20),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
+            // Re-entry into the same segment after confirmation — must
+            // RE-fire seek. The mechanism is stateless once the guard
+            // clears: position is the source of truth.
             adapter.emitState(
               const PlaybackState(
                 backend: PlaybackBackend.desktopLibmpv,
@@ -2510,10 +2520,21 @@ void main() {
             await tester.pump();
             expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
+            // Orchestrator confirms the seek — clears the pending guard.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 20),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+
             // User scrubs back to 15s — still inside segment A — must
-            // RE-fire auto-skip. The mechanism is stateless: position is
-            // the source of truth, no persistent guard set. This matches
-            // the web reference _checkComskip behavior.
+            // RE-fire auto-skip. The mechanism is stateless once the guard
+            // clears: position is the source of truth, no persistent
+            // already-skipped tracking. Matches the web reference.
             adapter.emitState(
               const PlaybackState(
                 backend: PlaybackBackend.desktopLibmpv,
@@ -2527,6 +2548,17 @@ void main() {
               const Duration(seconds: 20),
               const Duration(seconds: 20),
             ]);
+
+            // Orchestrator confirms the second seek.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 20),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
 
             // Advance into segment B (30–40) — must auto-skip to 40.
             adapter.emitState(
@@ -2686,6 +2718,217 @@ void main() {
             ]);
           }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
                 {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'auto-skip uses ceil() past sub-second EDL end (avoids stuck loop on real recordings)',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            // Segment ends at 2284.08s — sub-second precision like a real
+            // comskip EDL. Pre-fix this caused an infinite stuck loop
+            // because round(2284.08) = 2284 → bump-to-2284 was still
+            // inside [start, 2284.08) → re-match every tick. With ceil()
+            // on the millisecond value we seek to 2284.080s, which is
+            // exactly past the half-open end and so no longer matches.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 2280),
+                duration: Duration(minutes: 60),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [
+              const Duration(milliseconds: 2284080),
+            ]);
+
+            // Position 2285 confirmed — guard clears.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 2285),
+                duration: Duration(minutes: 60),
+              ),
+            );
+            await tester.pump();
+            // No additional seek — stuck-loop is gone.
+            expect(adapter.seekCalls, [
+              const Duration(milliseconds: 2284080),
+            ]);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 2074.12, 'end': 2284.08},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'stale orchestrator position report during seek does not re-fire auto-skip',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            // Enter segment A (10–20) → seek to 20, pending guard = 20.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Orchestrator's mid-seek position report LAGS back to 15s
+            // (real seek hasn't completed yet). The pending-seek-target
+            // guard must reject this — _currentPosition stays at the
+            // bumped 20s and no second seek fires. Pre-fix this would
+            // re-fire because the clobber pulled _currentPosition back
+            // inside the segment.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 15),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Another stale report — still no re-fire.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 18),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ])));
+        },
+      );
+
+      testWidgets(
+        'pending-seek-target guard clears on confirmation and next segment still fires',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            // Enter segment A (10–20) → seek to 20, pending = 20.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 12),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Orchestrator genuinely catches up past the target —
+            // 20 >= 20, guard clears, position is accepted.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 20),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+            // Advance into segment B (30–40) — must auto-skip to 40.
+            // If the guard were stuck or the mechanism broken, this
+            // wouldn't fire.
+            adapter.emitState(
+              const PlaybackState(
+                backend: PlaybackBackend.desktopLibmpv,
+                status: PlaybackStatus.playing,
+                position: Duration(seconds: 35),
+                duration: Duration(minutes: 1),
+              ),
+            );
+            await tester.pump();
+            expect(adapter.seekCalls, [
+              const Duration(seconds: 20),
+              const Duration(seconds: 40),
+            ]);
+          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+                {'start': 30.0, 'end': 40.0},
               ])));
         },
       );

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -34,9 +34,11 @@ class _FakeHttpClient implements HttpClient {
   _FakeHttpClient(this._body);
 
   final String _body;
+  final List<Uri> requestedUrls = <Uri>[];
 
   @override
   Future<HttpClientRequest> getUrl(Uri url) async {
+    requestedUrls.add(url);
     return _FakeHttpClientRequest(_body, HttpStatus.ok);
   }
 
@@ -2532,6 +2534,149 @@ void main() {
                 {'start': 10.0, 'end': 20.0},
                 {'start': 30.0, 'end': 40.0},
               ])));
+        },
+      );
+
+      testWidgets(
+        'rewrites a localhost edl_url host to the Xtream server before fetching',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([{'start': 10.0, 'end': 20.0}]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: const PlayerArgs(
+                    streamUrl: 'https://example.com/recording.mp4',
+                    title: 'Localhost EDL Fixture',
+                    type: 'vod',
+                    metadata: <String, Object?>{
+                      'edl_url': 'http://localhost/dvr/some/path/edl',
+                    },
+                  ),
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            // Give the fire-and-forget EDL fetch a chance to settle.
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(httpClient.requestedUrls, isNotEmpty);
+            final fetched = httpClient.requestedUrls.single;
+            expect(fetched.scheme, 'https');
+            expect(fetched.host, 'xtream.example');
+            expect(fetched.path, '/dvr/some/path/edl');
+            expect(fetched.hasPort, isFalse);
+          }, createHttpClient: (_) => httpClient);
+        },
+      );
+
+      testWidgets(
+        'leaves a non-localhost edl_url host untouched',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([{'start': 10.0, 'end': 20.0}]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates:
+                    AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: const PlayerArgs(
+                    streamUrl: 'https://example.com/recording.mp4',
+                    title: 'Real Host EDL Fixture',
+                    type: 'vod',
+                    metadata: <String, Object?>{
+                      'edl_url':
+                          'https://m3u.bearald.com/dvr/real/path/edl',
+                    },
+                  ),
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(httpClient.requestedUrls, isNotEmpty);
+            final fetched = httpClient.requestedUrls.single;
+            expect(fetched.scheme, 'https');
+            expect(fetched.host, 'm3u.bearald.com');
+            expect(fetched.path, '/dvr/real/path/edl');
+          }, createHttpClient: (_) => httpClient);
         },
       );
     });

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -2249,77 +2249,82 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: ComskipSettings(),
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 5),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, isEmpty);
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 5),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, isEmpty);
 
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
-            expect(find.text('Skipped commercial'), findsOneWidget);
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              expect(find.text('Skipped commercial'), findsOneWidget);
 
-            // Orchestrator confirms the seek — clears the pending guard.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 20),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              // Orchestrator confirms the seek — clears the pending guard.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 20),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            // Re-entry into the same segment after confirmation — must
-            // RE-fire seek. The mechanism is stateless once the guard
-            // clears: position is the source of truth.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 15),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              // Re-entry into the same segment after confirmation — must
+              // RE-fire seek. The mechanism is stateless once the guard
+              // clears: position is the source of truth.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 15),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            expect(adapter.seekCalls, [
-              const Duration(seconds: 20),
-              const Duration(seconds: 20),
-            ]);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              expect(adapter.seekCalls, [
+                const Duration(seconds: 20),
+                const Duration(seconds: 20),
+              ]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2335,43 +2340,48 @@ void main() {
           final settings = ComskipSettings();
           await settings.setAutoSkipEnabled(enabled: false);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: settings,
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: settings,
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            expect(adapter.seekCalls, isEmpty);
-            expect(find.text('Skip commercial'), findsOneWidget);
+              expect(adapter.seekCalls, isEmpty);
+              expect(find.text('Skip commercial'), findsOneWidget);
 
-            await tester.tap(find.text('Skip commercial'));
-            await tester.pump();
+              await tester.tap(find.text('Skip commercial'));
+              await tester.pump();
 
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
-            expect(find.text('Skip commercial'), findsNothing);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              expect(find.text('Skip commercial'), findsNothing);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2387,48 +2397,53 @@ void main() {
           final settings = ComskipSettings();
           await settings.setAutoSkipEnabled(enabled: false);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: settings,
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: settings,
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(find.text('Skip commercial'), findsOneWidget);
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(find.text('Skip commercial'), findsOneWidget);
 
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 25),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 25),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            expect(find.text('Skip commercial'), findsNothing);
-            expect(adapter.seekCalls, isEmpty);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              expect(find.text('Skip commercial'), findsNothing);
+              expect(adapter.seekCalls, isEmpty);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2442,43 +2457,48 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  // comskipSettings intentionally omitted — null fallback
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    // comskipSettings intentionally omitted — null fallback
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            expect(adapter.seekCalls, isEmpty);
-            expect(find.text('Skip commercial'), findsOneWidget);
+              expect(adapter.seekCalls, isEmpty);
+              expect(find.text('Skip commercial'), findsOneWidget);
 
-            await tester.tap(find.text('Skip commercial'));
-            await tester.pump();
+              await tester.tap(find.text('Skip commercial'));
+              await tester.pump();
 
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
-            expect(find.text('Skip commercial'), findsNothing);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              expect(find.text('Skip commercial'), findsNothing);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2492,93 +2512,98 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: ComskipSettings(),
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            // Enter segment A (10–20) → auto-skip to 20.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              // Enter segment A (10–20) → auto-skip to 20.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Orchestrator confirms the seek — clears the pending guard.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 20),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              // Orchestrator confirms the seek — clears the pending guard.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 20),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            // User scrubs back to 15s — still inside segment A — must
-            // RE-fire auto-skip. The mechanism is stateless once the guard
-            // clears: position is the source of truth, no persistent
-            // already-skipped tracking. Matches the web reference.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 15),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [
-              const Duration(seconds: 20),
-              const Duration(seconds: 20),
-            ]);
+              // User scrubs back to 15s — still inside segment A — must
+              // RE-fire auto-skip. The mechanism is stateless once the guard
+              // clears: position is the source of truth, no persistent
+              // already-skipped tracking. Matches the web reference.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 15),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [
+                const Duration(seconds: 20),
+                const Duration(seconds: 20),
+              ]);
 
-            // Orchestrator confirms the second seek.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 20),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              // Orchestrator confirms the second seek.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 20),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
 
-            // Advance into segment B (30–40) — must auto-skip to 40.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 35),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [
-              const Duration(seconds: 20),
-              const Duration(seconds: 20),
-              const Duration(seconds: 40),
-            ]);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              // Advance into segment B (30–40) — must auto-skip to 40.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 35),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [
+                const Duration(seconds: 20),
+                const Duration(seconds: 20),
+                const Duration(seconds: 40),
+              ]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
                 {'start': 30.0, 'end': 40.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2592,57 +2617,199 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: ComskipSettings(),
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            // Enter segment A (10–20) → auto-skip fires.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              // Enter segment A (10–20) → auto-skip fires.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Orchestrator confirms seek — position now AT segment end.
-            // _checkComskip reads _currentPosition=20, no segment matched,
-            // no extra seek. This is the optimistic-bump mechanism: the
-            // next [start, end) half-open interval check naturally
-            // evaluates false at t=20.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 20),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              // Orchestrator confirms seek — position now AT segment end.
+              // _checkComskip reads _currentPosition=20, no segment matched,
+              // no extra seek. This is the optimistic-bump mechanism: the
+              // next [start, end) half-open interval check naturally
+              // evaluates false at t=20.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 20),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
       testWidgets(
-        're-fires auto-skip on segment 1 after restart from position 0',
+        'prompt-mode confirm does not flicker on stale orchestrator report after tap',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+          final settings = ComskipSettings();
+          await settings.setAutoSkipEnabled(enabled: false);
+
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: settings,
+                  ),
+                ),
+              );
+              await tester.pump();
+
+              // Enter segment A (10–20) → prompt appears.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(find.text('Skip commercial'), findsOneWidget);
+
+              // User taps the button. _confirmComskipSkip now goes through
+              // _fireComskipSeek: optimistic bump to 20 + pending target 20.
+              await tester.tap(find.text('Skip commercial'));
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              expect(find.text('Skip commercial'), findsNothing);
+
+              // Orchestrator's mid-seek stale report (still inside the
+              // segment). The pending guard must keep _currentPosition at
+              // the optimistic 20 — _checkComskip reads 20, the half-open
+              // interval [10, 20) doesn't match, and the prompt does NOT
+              // reappear. Pre-fix the prompt flickered back because the
+              // old confirm path never set the pending guard.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 15),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(find.text('Skip commercial'), findsNothing);
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ]),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'prompt-mode confirm uses ceil() precision for sub-second EDL end',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+          final settings = ComskipSettings();
+          await settings.setAutoSkipEnabled(enabled: false);
+
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: settings,
+                  ),
+                ),
+              );
+              await tester.pump();
+
+              // Segment ends at 20.08 — sub-second precision. Pre-fix the
+              // prompt path used round() and seeked to Duration(seconds: 20),
+              // i.e. 20.000s, which is still inside [10, 20.08) and would
+              // re-match on the next tick. The shared _fireComskipSeek
+              // helper now uses ceil() and seeks to 20.080s, exactly past
+              // the half-open end.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(find.text('Skip commercial'), findsOneWidget);
+
+              await tester.tap(find.text('Skip commercial'));
+              await tester.pump();
+
+              expect(adapter.seekCalls, [
+                const Duration(milliseconds: 20080),
+              ]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
+                {'start': 10.0, 'end': 20.08},
+              ]),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'manual seek clears pending auto-skip guard so user position is respected',
         (tester) async {
           final adapter = FakePlayerAdapter(
             capabilities: PlaybackCapabilities.desktopLibmpv,
@@ -2651,74 +2818,159 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: ComskipSettings(),
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            // First playthrough: enter segment A (10–20) → auto-skip fires.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              // Auto-skip fires: segment [10..20], emit 12 → seek to 20,
+              // pending=20, _currentPosition=20.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Orchestrator confirms seek at 20s.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 20),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
+              // User rewinds twice: 20 → 10 → 0. _seekTo clears the pending
+              // guard (the user's deliberate new position must never be
+              // guarded by the auto-skip's pending target). Pre-fix the
+              // guard stayed set at 20 across these manual seeks.
+              await tester.tap(find.byIcon(Icons.replay_10));
+              await tester.pump();
+              await tester.tap(find.byIcon(Icons.replay_10));
+              await tester.pump();
+              expect(adapter.seekCalls, [
+                const Duration(seconds: 20),
+                const Duration(seconds: 10),
+                Duration.zero,
+              ]);
 
-            // User restarts from beginning — position now at 5s (outside).
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 5),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
-
-            // Forward playback re-enters segment A — must auto-skip AGAIN.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 15),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [
-              const Duration(seconds: 20),
-              const Duration(seconds: 20),
-            ]);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              // Orchestrator's confirmation of the manual seek arrives at
+              // 5s (mid-seek buffering). With the fix, _currentPosition is
+              // accepted as 5 — display '0:05'. Pre-fix, 5 < pending(20)
+              // would suppress the emit and the manual seek would silently
+              // snap back to 0 from _seekTo — display '0:00'.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 5),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(find.text('0:05'), findsOneWidget);
+              expect(find.text('0:00'), findsNothing);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
-              ])));
+              ]),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
+        'rewrites a localhost edl_url host to the Xtream server before fetching',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
+                ),
+              );
+              await tester.pump();
+
+              // First playthrough: enter segment A (10–20) → auto-skip fires.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+              // Orchestrator confirms seek at 20s.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 20),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+
+              // User restarts from beginning — position now at 5s (outside).
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 5),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+
+              // Forward playback re-enters segment A — must auto-skip AGAIN.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 15),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [
+                const Duration(seconds: 20),
+                const Duration(seconds: 20),
+              ]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
+                {'start': 10.0, 'end': 20.0},
+              ]),
+            ),
+          );
         },
       );
 
@@ -2732,58 +2984,63 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: ComskipSettings(),
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            // Segment ends at 2284.08s — sub-second precision like a real
-            // comskip EDL. Pre-fix this caused an infinite stuck loop
-            // because round(2284.08) = 2284 → bump-to-2284 was still
-            // inside [start, 2284.08) → re-match every tick. With ceil()
-            // on the millisecond value we seek to 2284.080s, which is
-            // exactly past the half-open end and so no longer matches.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 2280),
-                duration: Duration(minutes: 60),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [
-              const Duration(milliseconds: 2284080),
-            ]);
+              // Segment ends at 2284.08s — sub-second precision like a real
+              // comskip EDL. Pre-fix this caused an infinite stuck loop
+              // because round(2284.08) = 2284 → bump-to-2284 was still
+              // inside [start, 2284.08) → re-match every tick. With ceil()
+              // on the millisecond value we seek to 2284.080s, which is
+              // exactly past the half-open end and so no longer matches.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 2280),
+                  duration: Duration(minutes: 60),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [
+                const Duration(milliseconds: 2284080),
+              ]);
 
-            // Position 2285 confirmed — guard clears.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 2285),
-                duration: Duration(minutes: 60),
-              ),
-            );
-            await tester.pump();
-            // No additional seek — stuck-loop is gone.
-            expect(adapter.seekCalls, [
-              const Duration(milliseconds: 2284080),
-            ]);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              // Position 2285 confirmed — guard clears.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 2285),
+                  duration: Duration(minutes: 60),
+                ),
+              );
+              await tester.pump();
+              // No additional seek — stuck-loop is gone.
+              expect(adapter.seekCalls, [
+                const Duration(milliseconds: 2284080),
+              ]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 2074.12, 'end': 2284.08},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2797,65 +3054,70 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: ComskipSettings(),
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            // Enter segment A (10–20) → seek to 20, pending guard = 20.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              // Enter segment A (10–20) → seek to 20, pending guard = 20.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Orchestrator's mid-seek position report LAGS back to 15s
-            // (real seek hasn't completed yet). The pending-seek-target
-            // guard must reject this — _currentPosition stays at the
-            // bumped 20s and no second seek fires. Pre-fix this would
-            // re-fire because the clobber pulled _currentPosition back
-            // inside the segment.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 15),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              // Orchestrator's mid-seek position report LAGS back to 15s
+              // (real seek hasn't completed yet). The pending-seek-target
+              // guard must reject this — _currentPosition stays at the
+              // bumped 20s and no second seek fires. Pre-fix this would
+              // re-fire because the clobber pulled _currentPosition back
+              // inside the segment.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 15),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Another stale report — still no re-fire.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 18),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              // Another stale report — still no re-fire.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 18),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2869,67 +3131,72 @@ void main() {
           final orchestrator = buildOrchestrator(adapter);
           addTearDown(orchestrator.dispose);
 
-          await HttpOverrides.runZoned(() async {
-            await tester.pumpWidget(
-              MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: PlayerScreen(
-                  args: recordingArgs,
-                  orchestrator: orchestrator,
-                  epgService: EpgService(clock: () => DateTime.utc(2026)),
-                  comskipSettings: ComskipSettings(),
+          await HttpOverrides.runZoned(
+            () async {
+              await tester.pumpWidget(
+                MaterialApp(
+                  localizationsDelegates:
+                      AppLocalizations.localizationsDelegates,
+                  supportedLocales: AppLocalizations.supportedLocales,
+                  home: PlayerScreen(
+                    args: recordingArgs,
+                    orchestrator: orchestrator,
+                    epgService: EpgService(clock: () => DateTime.utc(2026)),
+                    comskipSettings: ComskipSettings(),
+                  ),
                 ),
-              ),
-            );
-            await tester.pump();
+              );
+              await tester.pump();
 
-            // Enter segment A (10–20) → seek to 20, pending = 20.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 12),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              // Enter segment A (10–20) → seek to 20, pending = 20.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 12),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Orchestrator genuinely catches up past the target —
-            // 20 >= 20, guard clears, position is accepted.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 20),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [const Duration(seconds: 20)]);
+              // Orchestrator genuinely catches up past the target —
+              // 20 >= 20, guard clears, position is accepted.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 20),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [const Duration(seconds: 20)]);
 
-            // Advance into segment B (30–40) — must auto-skip to 40.
-            // If the guard were stuck or the mechanism broken, this
-            // wouldn't fire.
-            adapter.emitState(
-              const PlaybackState(
-                backend: PlaybackBackend.desktopLibmpv,
-                status: PlaybackStatus.playing,
-                position: Duration(seconds: 35),
-                duration: Duration(minutes: 1),
-              ),
-            );
-            await tester.pump();
-            expect(adapter.seekCalls, [
-              const Duration(seconds: 20),
-              const Duration(seconds: 40),
-            ]);
-          }, createHttpClient: (_) => _FakeHttpClient(jsonEncode([
+              // Advance into segment B (30–40) — must auto-skip to 40.
+              // If the guard were stuck or the mechanism broken, this
+              // wouldn't fire.
+              adapter.emitState(
+                const PlaybackState(
+                  backend: PlaybackBackend.desktopLibmpv,
+                  status: PlaybackStatus.playing,
+                  position: Duration(seconds: 35),
+                  duration: Duration(minutes: 1),
+                ),
+              );
+              await tester.pump();
+              expect(adapter.seekCalls, [
+                const Duration(seconds: 20),
+                const Duration(seconds: 40),
+              ]);
+            },
+            createHttpClient: (_) => _FakeHttpClient(
+              jsonEncode([
                 {'start': 10.0, 'end': 20.0},
                 {'start': 30.0, 'end': 40.0},
-              ])));
+              ]),
+            ),
+          );
         },
       );
 
@@ -2963,14 +3230,15 @@ void main() {
           );
 
           final httpClient = _FakeHttpClient(
-            jsonEncode([{'start': 10.0, 'end': 20.0}]),
+            jsonEncode([
+              {'start': 10.0, 'end': 20.0},
+            ]),
           );
 
           await HttpOverrides.runZoned(() async {
             await tester.pumpWidget(
               MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
                 home: PlayerScreen(
                   args: const PlayerArgs(
@@ -3035,14 +3303,15 @@ void main() {
           );
 
           final httpClient = _FakeHttpClient(
-            jsonEncode([{'start': 10.0, 'end': 20.0}]),
+            jsonEncode([
+              {'start': 10.0, 'end': 20.0},
+            ]),
           );
 
           await HttpOverrides.runZoned(() async {
             await tester.pumpWidget(
               MaterialApp(
-                localizationsDelegates:
-                    AppLocalizations.localizationsDelegates,
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
                 home: PlayerScreen(
                   args: const PlayerArgs(
@@ -3050,8 +3319,7 @@ void main() {
                     title: 'Real Host EDL Fixture',
                     type: 'vod',
                     metadata: <String, Object?>{
-                      'edl_url':
-                          'https://m3u.bearald.com/dvr/real/path/edl',
+                      'edl_url': 'https://m3u.bearald.com/dvr/real/path/edl',
                     },
                   ),
                   orchestrator: orchestrator,


### PR DESCRIPTION
## Summary

Adds commercial-skip support for completed DVR recordings that have comskip/EDL data: fetches the EDL segment list and either auto-skips detected commercial breaks or shows a confirm-to-skip prompt, per a new "Commercial Skipping" settings toggle.

Also includes several correctness fixes discovered while live-testing against a real production server:

- **Fail-safe default**: if `comskipSettings` is ever null (a wiring bug), the player now falls back to the confirm prompt instead of silently auto-skipping.
- **EDL localhost workaround**: the m3u-editor backend can return `edl_url` pointing at its own loopback host (`http://localhost/...`) instead of the public server — likely an `APP_URL`/`route()` config issue server-side (see note below). The client now rewrites a localhost/127.0.0.1 host in `edl_url` to the connected Xtream server's real host before fetching, so comskip works even when the backend has this misconfiguration.
- **`_asNullableString` hardening**: this shared parsing helper was stringifying non-`String` JSON values (e.g. an empty array became the literal `"[]"`), which could crash `NetworkImage` loads for thumbnail/cover/etc. fields. Now only accepts `String`/`num`.
- **Seek-precision + race fixes**: an earlier version of the auto-skip guard permanently suppressed re-skipping a segment once skipped, breaking scrub-back/replay/restart. Replaced with a stateless model (matching m3u-editor's own web player) plus a `ceil()`-precision fix for sub-second EDL boundaries and a pending-seek-target guard to prevent a stuck seek-loop when the orchestrator's position reports lag during buffering. The same fix is now shared consistently across all three seek paths (auto-skip, the manual confirm button, and manual rewind/fast-forward).

## Known follow-up (out of scope for this PR)

The EDL-localhost issue is very likely rooted in `DvrRecording.php`'s use of bare `route()` for `edl_url`, which resolves against `config('app.url')` — the same class of bug a recent m3u-editor security-hardening PR (closing unauthenticated proxy access) already fixed for other proxy/stream URLs via request-aware URL resolution, but the DVR EDL route wasn't included in that pass. Worth a follow-up fix in `m3u-editor` itself; the client-side workaround here is a safety net, not a replacement for that.

## Test plan

- [x] `flutter analyze lib test` — no issues
- [x] `flutter test` — 621/621 passing
- [x] Live-verified against a real production server: auto-skip fires correctly across multiple commercial breaks in a single recording, scrub-back/replay/restart all correctly re-trigger, no stuck/looping seeks, manual rewind during a pending auto-skip confirmation is respected