### PR TITLE
feat(dvr): show storage usage against quota

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -859,6 +859,7 @@ class AppShellState extends ConsumerState<AppShell>
             recordings: _appState.dvrRecordings,
             isLoading: _appState.isLoadingContent,
             isConfigured: _appState.isConfigured,
+            storageInfo: ref.watch(dvrStorageInfoProvider),
             onPlay: _openPlayerDirect,
             onCancelRecording: (uuid) => _appState.cancelDvrRecording(uuid),
             onCancelAndDeleteRecording: _cancelAndDeleteRecording,

--- a/flutter_client/lib/features/dvr/dvr_recordings_screen.dart
+++ b/flutter_client/lib/features/dvr/dvr_recordings_screen.dart
@@ -223,13 +223,13 @@ class _DvrStorageSummary extends StatelessWidget {
       ),
     );
   }
+}
 
-  String _formatBytes(int bytes) {
-    final gib = bytes / (1024 * 1024 * 1024);
-    if (gib >= 1) return '${gib.toStringAsFixed(1)} GB';
-    final mib = bytes / (1024 * 1024);
-    return '${mib.toStringAsFixed(0)} MB';
-  }
+String _formatBytes(int bytes) {
+  final gib = bytes / (1024 * 1024 * 1024);
+  if (gib >= 1) return '${gib.toStringAsFixed(1)} GB';
+  final mib = bytes / (1024 * 1024);
+  return '${mib.toStringAsFixed(0)} MB';
 }
 
 class _RecordingList extends StatelessWidget {
@@ -393,7 +393,7 @@ class _RecordingCard extends StatelessWidget {
                             if (recording.fileSizeBytes != null &&
                                 recording.fileSizeBytes! > 0)
                               _Badge(
-                                label: _sizeLabel(recording.fileSizeBytes!),
+                                label: _formatBytes(recording.fileSizeBytes!),
                               ),
                           ],
                         ),
@@ -436,13 +436,6 @@ class _RecordingCard extends StatelessWidget {
     if (hours > 0 && minutes > 0) return '${hours}h ${minutes}m';
     if (hours > 0) return '${hours}h';
     return '${minutes}m';
-  }
-
-  String _sizeLabel(int bytes) {
-    final gib = bytes / (1024 * 1024 * 1024);
-    if (gib >= 1) return '${gib.toStringAsFixed(1)} GB';
-    final mib = bytes / (1024 * 1024);
-    return '${mib.toStringAsFixed(0)} MB';
   }
 }
 

--- a/flutter_client/lib/features/dvr/dvr_recordings_screen.dart
+++ b/flutter_client/lib/features/dvr/dvr_recordings_screen.dart
@@ -15,6 +15,7 @@ class DvrRecordingsScreen extends StatelessWidget {
     required this.isLoading,
     required this.isConfigured,
     required this.onPlay,
+    this.storageInfo,
     this.onCancelRecording,
     this.onCancelAndDeleteRecording,
     this.onDeleteRecording,
@@ -24,6 +25,7 @@ class DvrRecordingsScreen extends StatelessWidget {
   final List<DvrRecording> recordings;
   final bool isLoading;
   final bool isConfigured;
+  final DvrStorageInfo? storageInfo;
   final void Function(PlayerArgs args) onPlay;
   final Future<void> Function(String uuid)? onCancelRecording;
   final Future<void> Function(String uuid)? onCancelAndDeleteRecording;
@@ -60,6 +62,10 @@ class DvrRecordingsScreen extends StatelessWidget {
               l10n.dvrRecordingsSubtitle,
               style: Theme.of(context).textTheme.bodyMedium,
             ),
+            if (storageInfo != null) ...[
+              const SizedBox(height: 12),
+              _DvrStorageSummary(info: storageInfo!),
+            ],
             const SizedBox(height: MediaBrowsingMetrics.contentPadding),
             Expanded(
               child: isLoading
@@ -84,6 +90,145 @@ class DvrRecordingsScreen extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+/// Non-interactive DVR storage meter, shown in the screen header. `info` is
+/// only ever passed when the server supports `get_dvr_storage`, so this
+/// widget doesn't need its own "unsupported" state — the caller simply
+/// omits it. The bar is color-coded by percent used, matching the
+/// success/warning/danger thresholds (<75% / 75-89% / >=90%) used by
+/// m3u-editor's admin-side DvrStorageOverviewWidget.
+class _DvrStorageSummary extends StatelessWidget {
+  const _DvrStorageSummary({required this.info});
+
+  final DvrStorageInfo info;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final quotaBytes = info.quotaBytes;
+    final percentUsed = info.percentUsed;
+    final hasQuota = quotaBytes != null && percentUsed != null;
+
+    final usedLabel = _formatBytes(info.usedBytes);
+    final summary = quotaBytes == null
+        ? l10n.dvrStorageUsedUnlimited(usedLabel)
+        : l10n.dvrStorageUsedWithQuota(usedLabel, _formatBytes(quotaBytes));
+
+    final Color barColor;
+    if (percentUsed == null) {
+      barColor = colorScheme.primary;
+    } else if (percentUsed >= 90) {
+      barColor = colorScheme.error;
+    } else if (percentUsed >= 75) {
+      barColor = Colors.amber.shade600;
+    } else {
+      barColor = colorScheme.primary;
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: barColor.withValues(alpha: 0.14),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Icon(Icons.sd_storage, color: barColor, size: 22),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      l10n.dvrStorageTitle,
+                      style: theme.textTheme.labelMedium?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    Text(
+                      summary,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              if (hasQuota)
+                Text(
+                  '${percentUsed.round()}%',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: barColor,
+                  ),
+                )
+              else
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                  child: Text(
+                    l10n.dvrStorageUnlimited,
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: colorScheme.onPrimaryContainer,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text(
+            l10n.dvrStorageRecordingCount(info.recordingCount),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          if (hasQuota) ...[
+            const SizedBox(height: 10),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(999),
+              child: LinearProgressIndicator(
+                value: (percentUsed / 100).clamp(0.0, 1.0),
+                minHeight: 10,
+                backgroundColor: colorScheme.surfaceContainerHighest,
+                valueColor: AlwaysStoppedAnimation<Color>(barColor),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _formatBytes(int bytes) {
+    final gib = bytes / (1024 * 1024 * 1024);
+    if (gib >= 1) return '${gib.toStringAsFixed(1)} GB';
+    final mib = bytes / (1024 * 1024);
+    return '${mib.toStringAsFixed(0)} MB';
   }
 }
 

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -365,5 +365,34 @@
   "dvrDeleteFailed": "Aufnahme konnte nicht gelöscht werden",
   "liveTvStopRecording": "Aufnahme stoppen",
   "playerRecordNowTooltip": "Aktuelle Sendung aufnehmen",
-  "playerStopRecordingTooltip": "Aufnahme stoppen"
+  "playerStopRecordingTooltip": "Aufnahme stoppen",
+  "dvrStorageTitle": "DVR-Speicher",
+  "dvrStorageUnlimited": "Unbegrenzt",
+  "dvrStorageUsedUnlimited": "{used} belegt",
+  "@dvrStorageUsedUnlimited": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageUsedWithQuota": "{used} von {quota} belegt",
+  "@dvrStorageUsedWithQuota": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "quota": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageRecordingCount": "{count} Aufnahmen",
+  "@dvrStorageRecordingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -365,5 +365,34 @@
   "dvrDeleteFailed": "Could not delete recording",
   "liveTvStopRecording": "Stop Recording",
   "playerRecordNowTooltip": "Record current program",
-  "playerStopRecordingTooltip": "Stop recording"
+  "playerStopRecordingTooltip": "Stop recording",
+  "dvrStorageTitle": "DVR Storage",
+  "dvrStorageUnlimited": "Unlimited",
+  "dvrStorageUsedUnlimited": "{used} used",
+  "@dvrStorageUsedUnlimited": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageUsedWithQuota": "{used} of {quota} used",
+  "@dvrStorageUsedWithQuota": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "quota": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageRecordingCount": "{count} recordings",
+  "@dvrStorageRecordingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -365,5 +365,34 @@
   "dvrDeleteFailed": "No se pudo eliminar la grabación",
   "liveTvStopRecording": "Detener grabación",
   "playerRecordNowTooltip": "Grabar programa actual",
-  "playerStopRecordingTooltip": "Detener grabación"
+  "playerStopRecordingTooltip": "Detener grabación",
+  "dvrStorageTitle": "Almacenamiento DVR",
+  "dvrStorageUnlimited": "Ilimitado",
+  "dvrStorageUsedUnlimited": "{used} utilizado",
+  "@dvrStorageUsedUnlimited": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageUsedWithQuota": "{used} de {quota} utilizado",
+  "@dvrStorageUsedWithQuota": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "quota": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageRecordingCount": "{count} grabaciones",
+  "@dvrStorageRecordingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -365,5 +365,34 @@
   "dvrDeleteFailed": "Impossible de supprimer l'enregistrement",
   "liveTvStopRecording": "Arrêter l'enregistrement",
   "playerRecordNowTooltip": "Enregistrer le programme en cours",
-  "playerStopRecordingTooltip": "Arrêter l'enregistrement"
+  "playerStopRecordingTooltip": "Arrêter l'enregistrement",
+  "dvrStorageTitle": "Stockage DVR",
+  "dvrStorageUnlimited": "Illimité",
+  "dvrStorageUsedUnlimited": "{used} utilisé",
+  "@dvrStorageUsedUnlimited": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageUsedWithQuota": "{used} sur {quota} utilisé",
+  "@dvrStorageUsedWithQuota": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "quota": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageRecordingCount": "{count} enregistrements",
+  "@dvrStorageRecordingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -1423,6 +1423,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Stop recording'**
   String get playerStopRecordingTooltip;
+
+  /// No description provided for @dvrStorageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'DVR Storage'**
+  String get dvrStorageTitle;
+
+  /// No description provided for @dvrStorageUnlimited.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlimited'**
+  String get dvrStorageUnlimited;
+
+  /// No description provided for @dvrStorageUsedUnlimited.
+  ///
+  /// In en, this message translates to:
+  /// **'{used} used'**
+  String dvrStorageUsedUnlimited(String used);
+
+  /// No description provided for @dvrStorageUsedWithQuota.
+  ///
+  /// In en, this message translates to:
+  /// **'{used} of {quota} used'**
+  String dvrStorageUsedWithQuota(String used, String quota);
+
+  /// No description provided for @dvrStorageRecordingCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} recordings'**
+  String dvrStorageRecordingCount(int count);
 }
 
 class _AppLocalizationsDelegate

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -725,4 +725,25 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get playerStopRecordingTooltip => 'Aufnahme stoppen';
+
+  @override
+  String get dvrStorageTitle => 'DVR-Speicher';
+
+  @override
+  String get dvrStorageUnlimited => 'Unbegrenzt';
+
+  @override
+  String dvrStorageUsedUnlimited(String used) {
+    return '$used belegt';
+  }
+
+  @override
+  String dvrStorageUsedWithQuota(String used, String quota) {
+    return '$used von $quota belegt';
+  }
+
+  @override
+  String dvrStorageRecordingCount(int count) {
+    return '$count Aufnahmen';
+  }
 }

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -724,4 +724,25 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get playerStopRecordingTooltip => 'Stop recording';
+
+  @override
+  String get dvrStorageTitle => 'DVR Storage';
+
+  @override
+  String get dvrStorageUnlimited => 'Unlimited';
+
+  @override
+  String dvrStorageUsedUnlimited(String used) {
+    return '$used used';
+  }
+
+  @override
+  String dvrStorageUsedWithQuota(String used, String quota) {
+    return '$used of $quota used';
+  }
+
+  @override
+  String dvrStorageRecordingCount(int count) {
+    return '$count recordings';
+  }
 }

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -725,4 +725,25 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get playerStopRecordingTooltip => 'Detener grabación';
+
+  @override
+  String get dvrStorageTitle => 'Almacenamiento DVR';
+
+  @override
+  String get dvrStorageUnlimited => 'Ilimitado';
+
+  @override
+  String dvrStorageUsedUnlimited(String used) {
+    return '$used utilizado';
+  }
+
+  @override
+  String dvrStorageUsedWithQuota(String used, String quota) {
+    return '$used de $quota utilizado';
+  }
+
+  @override
+  String dvrStorageRecordingCount(int count) {
+    return '$count grabaciones';
+  }
 }

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -727,4 +727,25 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get playerStopRecordingTooltip => 'Arrêter l\'enregistrement';
+
+  @override
+  String get dvrStorageTitle => 'Stockage DVR';
+
+  @override
+  String get dvrStorageUnlimited => 'Illimité';
+
+  @override
+  String dvrStorageUsedUnlimited(String used) {
+    return '$used utilisé';
+  }
+
+  @override
+  String dvrStorageUsedWithQuota(String used, String quota) {
+    return '$used sur $quota utilisé';
+  }
+
+  @override
+  String dvrStorageRecordingCount(int count) {
+    return '$count enregistrements';
+  }
 }

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -709,4 +709,25 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get playerStopRecordingTooltip => '停止录制';
+
+  @override
+  String get dvrStorageTitle => 'DVR 存储';
+
+  @override
+  String get dvrStorageUnlimited => '无限';
+
+  @override
+  String dvrStorageUsedUnlimited(String used) {
+    return '已使用 $used';
+  }
+
+  @override
+  String dvrStorageUsedWithQuota(String used, String quota) {
+    return '已使用 $used，共 $quota';
+  }
+
+  @override
+  String dvrStorageRecordingCount(int count) {
+    return '$count 个录制';
+  }
 }

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -365,5 +365,34 @@
   "dvrDeleteFailed": "无法删除录制",
   "liveTvStopRecording": "停止录制",
   "playerRecordNowTooltip": "录制当前节目",
-  "playerStopRecordingTooltip": "停止录制"
+  "playerStopRecordingTooltip": "停止录制",
+  "dvrStorageTitle": "DVR 存储",
+  "dvrStorageUnlimited": "无限",
+  "dvrStorageUsedUnlimited": "已使用 {used}",
+  "@dvrStorageUsedUnlimited": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageUsedWithQuota": "已使用 {used}，共 {quota}",
+  "@dvrStorageUsedWithQuota": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "quota": {
+        "type": "String"
+      }
+    }
+  },
+  "dvrStorageRecordingCount": "{count} 个录制",
+  "@dvrStorageRecordingCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/flutter_client/lib/providers/app_providers.dart
+++ b/flutter_client/lib/providers/app_providers.dart
@@ -119,6 +119,10 @@ final dvrRecordingsProvider = Provider<List<DvrRecording>>((ref) {
   return ref.watch(appStateControllerProvider).appState.dvrRecordings;
 });
 
+final dvrStorageInfoProvider = Provider<DvrStorageInfo?>((ref) {
+  return ref.watch(appStateControllerProvider).appState.dvrStorageInfo;
+});
+
 final recordingChannelIdsProvider = Provider<Set<int>>((ref) {
   return ref.watch(appStateControllerProvider).appState.recordingChannelIds;
 });

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -240,6 +240,7 @@ class AppStateController extends ChangeNotifier {
   List<VodItem> _vodItems = const <VodItem>[];
   List<Series> _seriesList = const <Series>[];
   List<DvrRecording> _dvrRecordings = const <DvrRecording>[];
+  DvrStorageInfo? _dvrStorageInfo;
   Set<int> _recordingChannelIds = const <int>{};
   List<MediaRequestSummary> _mediaRequests = const <MediaRequestSummary>[];
   List<Progress> _progressList = const <Progress>[];
@@ -270,6 +271,7 @@ class AppStateController extends ChangeNotifier {
   List<VodItem> get vodItems => _vodItems;
   List<Series> get seriesList => _seriesList;
   List<DvrRecording> get dvrRecordings => _dvrRecordings;
+  DvrStorageInfo? get dvrStorageInfo => _dvrStorageInfo;
   Set<int> get recordingChannelIds => _recordingChannelIds;
   List<Progress> get progressList => _progressList;
   List<MediaRequestSummary> get mediaRequests => _mediaRequests;
@@ -433,6 +435,7 @@ class AppStateController extends ChangeNotifier {
       _vodItems = const <VodItem>[];
       _seriesList = const <Series>[];
       _dvrRecordings = const <DvrRecording>[];
+      _dvrStorageInfo = null;
       _recordingChannelIds = const <int>{};
       _mediaRequests = const <MediaRequestSummary>[];
       _activeViewer = const Viewer(
@@ -1085,6 +1088,7 @@ class AppStateController extends ChangeNotifier {
     _vodItems = const <VodItem>[];
     _seriesList = const <Series>[];
     _dvrRecordings = const <DvrRecording>[];
+    _dvrStorageInfo = null;
     _recordingChannelIds = const <int>{};
     _mediaRequests = const <MediaRequestSummary>[];
     _progressList = const <Progress>[];
@@ -1182,6 +1186,7 @@ class AppStateController extends ChangeNotifier {
       debugPrintStack(stackTrace: stackTrace);
     }
     notifyListeners();
+    unawaited(refreshDvrStorage());
     for (final recording in _dvrRecordings) {
       if (recording.channelId != channel.id) continue;
       final start = recording.scheduledStart;
@@ -1251,6 +1256,7 @@ class AppStateController extends ChangeNotifier {
         .toList(growable: false);
     _recordingChannelIds = _extractRecordingChannelIds(_dvrRecordings);
     notifyListeners();
+    unawaited(refreshDvrStorage());
   }
 
   /// Lightweight poll for which channels are currently recording, used to
@@ -1272,6 +1278,21 @@ class AppStateController extends ChangeNotifier {
     } on Object catch (error) {
       debugPrint('DVR: refresh active recordings failed: $error');
     }
+  }
+
+  /// Refreshes DVR storage usage against quota via `get_dvr_storage`.
+  /// Older m3u-editor servers without this action fail the request, which
+  /// we treat as "unsupported" — the storage display just stays hidden
+  /// rather than surfacing an error.
+  Future<void> refreshDvrStorage() async {
+    if (!hasDvrFeature) return;
+    try {
+      _dvrStorageInfo = await xtreamService.getDvrStorage();
+    } on Object catch (error) {
+      debugPrint('DVR: refresh storage failed: $error');
+      _dvrStorageInfo = null;
+    }
+    notifyListeners();
   }
 
   /// Searches guest-enabled Arr integrations via `request_search`. Thin
@@ -1413,6 +1434,7 @@ class AppStateController extends ChangeNotifier {
       _error = null;
       notifyListeners();
       unawaited(_syncFavoritesForActiveViewer());
+      unawaited(refreshDvrStorage());
 
       // Prime EPG for the first screen's worth of channels only; the rest is
       // fetched lazily as screens request it via [ensureEpgForChannels] (e.g.
@@ -1485,6 +1507,7 @@ class AppStateController extends ChangeNotifier {
     _vodItems = vodItems;
     _seriesList = seriesList;
     _dvrRecordings = const <DvrRecording>[];
+    _dvrStorageInfo = null;
     _recordingChannelIds = const <int>{};
     _mediaRequests = const <MediaRequestSummary>[];
     _viewers = viewers;
@@ -1498,6 +1521,7 @@ class AppStateController extends ChangeNotifier {
         : await resumeService.all(activeViewer.ulid);
     _error = null;
     unawaited(_syncFavoritesForActiveViewer());
+    unawaited(refreshDvrStorage());
     return true;
   }
 

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -493,6 +493,35 @@ class DvrRecording {
   }
 }
 
+/// DVR storage usage for the current playlist/guest, from m3u-editor's
+/// `get_dvr_storage` action. `quotaBytes` and `percentUsed` are null when
+/// the account/guest has no configured quota (unlimited storage).
+class DvrStorageInfo {
+  const DvrStorageInfo({
+    required this.usedBytes,
+    required this.recordingCount,
+    required this.scope,
+    this.quotaBytes,
+    this.percentUsed,
+  });
+
+  final int usedBytes;
+  final int? quotaBytes;
+  final double? percentUsed;
+  final int recordingCount;
+  final String scope;
+
+  factory DvrStorageInfo.fromXtream(Map<String, Object?> json) {
+    return DvrStorageInfo(
+      usedBytes: _asIntOrNull(json['used_bytes']) ?? 0,
+      quotaBytes: _asIntOrNull(json['quota_bytes']),
+      percentUsed: _asDoubleOrNull(json['percent_used']),
+      recordingCount: _asIntOrNull(json['recording_count']) ?? 0,
+      scope: _asNullableString(json['scope']) ?? 'account',
+    );
+  }
+}
+
 /// Pushed over Reverb when a favorite is toggled on another device signed
 /// into the same viewer, so this device can apply the change immediately
 /// instead of waiting for its next `get_favorites` pull.

--- a/flutter_client/lib/services/xtream_service.dart
+++ b/flutter_client/lib/services/xtream_service.dart
@@ -476,6 +476,15 @@ class XtreamService {
     return DvrRecording.fromXtream(_asMap(response));
   }
 
+  /// Fetches DVR storage usage against quota via m3u-editor's
+  /// `get_dvr_storage` action. Older servers without this action will
+  /// return an error response, which callers should treat as "unsupported"
+  /// and hide the feature rather than surfacing an error.
+  Future<DvrStorageInfo> getDvrStorage() async {
+    final response = await _request('get_dvr_storage');
+    return DvrStorageInfo.fromXtream(_asMap(response));
+  }
+
   /// Schedules a one-shot DVR recording on m3u-editor's `schedule_dvr` action.
   ///
   /// The m3u-editor endpoint responds with an envelope:

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -1031,6 +1031,99 @@ void main() {
       );
     });
   });
+
+  group('DVR storage refresh', () {
+    const credentials = UserCredentials(
+      server: 'https://fixture.example',
+      username: 'fixture-user',
+      password: 'fixture-password',
+    );
+
+    _FakeXtreamTransport withDvrFeature(_FakeXtreamTransport base) {
+      return base.withResponse('auth', <String, Object?>{
+        'user_info': <String, Object?>{'auth': 1, 'status': 'Active'},
+        'm3u_editor': <String, Object?>{
+          'version': '0.10.0',
+          'features': <String>['dvr'],
+        },
+      });
+    }
+
+    test(
+      'populates dvrStorageInfo from a server that supports get_dvr_storage',
+      () async {
+        final fixture =
+            withDvrFeature(
+              _FakeXtreamTransport.success(),
+            ).withResponse('get_dvr_storage', <String, Object?>{
+              'used_bytes': 2147483648,
+              'quota_bytes': 4294967296,
+              'percent_used': 50.0,
+              'recording_count': 4,
+              'scope': 'account',
+            });
+        final controller = _controller(
+          storage: InMemorySecureStorage(),
+          transport: fixture.call,
+        );
+
+        expect(await controller.connectXtream(credentials), isTrue);
+        expect(controller.hasDvrFeature, isTrue);
+
+        await controller.refreshDvrStorage();
+
+        expect(controller.dvrStorageInfo?.usedBytes, 2147483648);
+        expect(controller.dvrStorageInfo?.quotaBytes, 4294967296);
+        expect(controller.dvrStorageInfo?.recordingCount, 4);
+      },
+    );
+
+    test(
+      'clears dvrStorageInfo when an older server has no get_dvr_storage action',
+      () async {
+        // No `get_dvr_storage` stub, so the fixture throws StateError for it
+        // — mirroring an older m3u-editor server that 404s the action.
+        final fixture = withDvrFeature(_FakeXtreamTransport.success());
+        final controller = _controller(
+          storage: InMemorySecureStorage(),
+          transport: fixture.call,
+        );
+
+        expect(await controller.connectXtream(credentials), isTrue);
+        expect(controller.hasDvrFeature, isTrue);
+
+        await controller.refreshDvrStorage();
+
+        expect(controller.dvrStorageInfo, isNull);
+      },
+    );
+
+    test(
+      'does not call get_dvr_storage when the dvr feature is not advertised',
+      () async {
+        final base = _FakeXtreamTransport.success();
+        final calledActions = <String>[];
+        Future<Object?> spyingTransport(XtreamRequest request) async {
+          calledActions.add(request.action ?? 'auth');
+          return base.call(request);
+        }
+
+        final controller = _controller(
+          storage: InMemorySecureStorage(),
+          transport: spyingTransport,
+        );
+
+        expect(await controller.connectXtream(credentials), isTrue);
+        expect(controller.hasDvrFeature, isFalse);
+        calledActions.clear();
+
+        await controller.refreshDvrStorage();
+
+        expect(calledActions, isEmpty);
+        expect(controller.dvrStorageInfo, isNull);
+      },
+    );
+  });
 }
 
 Map<String, Object?> _epgResponse(String title, DateTime start) => {

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -75,4 +75,64 @@ void main() {
       expect(recording.channelIconUrl, '3.14');
     });
   });
+
+  group('DvrStorageInfo.fromXtream', () {
+    test('parses a quota-scoped response', () {
+      final info = DvrStorageInfo.fromXtream(<String, Object?>{
+        'used_bytes': 5368709120,
+        'quota_bytes': 10737418240,
+        'percent_used': 50.0,
+        'recording_count': 12,
+        'scope': 'guest',
+      });
+
+      expect(info.usedBytes, 5368709120);
+      expect(info.quotaBytes, 10737418240);
+      expect(info.percentUsed, 50.0);
+      expect(info.recordingCount, 12);
+      expect(info.scope, 'guest');
+    });
+
+    test('quota_bytes and percent_used are null for unlimited storage', () {
+      final info = DvrStorageInfo.fromXtream(<String, Object?>{
+        'used_bytes': 1073741824,
+        'quota_bytes': null,
+        'percent_used': null,
+        'recording_count': 3,
+        'scope': 'account',
+      });
+
+      expect(info.quotaBytes, isNull);
+      expect(info.percentUsed, isNull);
+    });
+
+    test('missing numeric fields default to zero rather than throwing', () {
+      final info = DvrStorageInfo.fromXtream(const <String, Object?>{});
+
+      expect(info.usedBytes, 0);
+      expect(info.recordingCount, 0);
+      expect(info.quotaBytes, isNull);
+      expect(info.percentUsed, isNull);
+    });
+
+    test('missing scope defaults to "account"', () {
+      final info = DvrStorageInfo.fromXtream(<String, Object?>{
+        'used_bytes': 0,
+        'recording_count': 0,
+      });
+
+      expect(info.scope, 'account');
+    });
+
+    test('percent_used tolerates an integer JSON value', () {
+      final info = DvrStorageInfo.fromXtream(<String, Object?>{
+        'used_bytes': 0,
+        'quota_bytes': 100,
+        'percent_used': 90,
+        'recording_count': 0,
+      });
+
+      expect(info.percentUsed, 90.0);
+    });
+  });
 }

--- a/flutter_client/test/ui/features/dvr_recordings_screen_test.dart
+++ b/flutter_client/test/ui/features/dvr_recordings_screen_test.dart
@@ -318,6 +318,93 @@ void main() {
       expect(cancelAndDeleteCalls, 0);
       expect(find.text('Stop recording — Live News'), findsNothing);
     });
+
+    testWidgets('hides the storage summary when storageInfo is absent', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_TestApp(recordings: [_completedRecording()]));
+      await tester.pumpAndSettle();
+
+      expect(find.text('DVR Storage'), findsNothing);
+    });
+
+    testWidgets('shows used/quota and percentage when a quota is configured', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _TestApp(
+          recordings: [_completedRecording()],
+          storageInfo: const DvrStorageInfo(
+            usedBytes: 5368709120, // 5.0 GB
+            quotaBytes: 10737418240, // 10.0 GB
+            percentUsed: 50,
+            recordingCount: 12,
+            scope: 'account',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('DVR Storage'), findsOneWidget);
+      expect(find.text('5.0 GB of 10.0 GB used'), findsOneWidget);
+      expect(find.text('50%'), findsOneWidget);
+      expect(find.text('12 recordings'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      expect(find.text('Unlimited'), findsNothing);
+    });
+
+    testWidgets(
+      'shows an "Unlimited" badge and no percentage without a quota',
+      (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          _TestApp(
+            recordings: [_completedRecording()],
+            storageInfo: const DvrStorageInfo(
+              usedBytes: 1073741824, // 1.0 GB
+              recordingCount: 3,
+              scope: 'account',
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('1.0 GB used'), findsOneWidget);
+        expect(find.text('Unlimited'), findsOneWidget);
+        expect(find.text('3 recordings'), findsOneWidget);
+        expect(find.byType(LinearProgressIndicator), findsNothing);
+      },
+    );
+
+    testWidgets('storage bar turns error-colored at >= 90% used', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _TestApp(
+          recordings: [_completedRecording()],
+          storageInfo: const DvrStorageInfo(
+            usedBytes: 9500000000,
+            quotaBytes: 10000000000,
+            percentUsed: 95,
+            recordingCount: 20,
+            scope: 'account',
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final indicator = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      final expectedColor = ThemeData.dark(
+        useMaterial3: true,
+      ).colorScheme.error;
+      expect(
+        (indicator.valueColor! as AlwaysStoppedAnimation<Color>).value,
+        expectedColor,
+      );
+    });
   });
 }
 
@@ -328,6 +415,7 @@ class _TestApp extends StatelessWidget {
     this.onCancelRecording,
     this.onCancelAndDeleteRecording,
     this.onDeleteRecording,
+    this.storageInfo,
   });
 
   final List<DvrRecording> recordings;
@@ -335,6 +423,7 @@ class _TestApp extends StatelessWidget {
   final Future<void> Function(String uuid)? onCancelRecording;
   final Future<void> Function(String uuid)? onCancelAndDeleteRecording;
   final Future<void> Function(String uuid)? onDeleteRecording;
+  final DvrStorageInfo? storageInfo;
 
   @override
   Widget build(BuildContext context) {
@@ -350,6 +439,7 @@ class _TestApp extends StatelessWidget {
         onCancelRecording: onCancelRecording,
         onCancelAndDeleteRecording: onCancelAndDeleteRecording,
         onDeleteRecording: onDeleteRecording,
+        storageInfo: storageInfo,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Surfaces DVR storage usage against quota on the Recordings screen — used/quota bytes, percent used, and recording count — via a new `get_dvr_storage` Xtream action.

- Non-interactive storage meter on the DVR Recordings screen header, color-coded by percent used (<75% / 75-89% / >=90%, matching the thresholds used by m3u-editor's own admin-side storage widget).
- Account owners see the whole DVR setting's usage against its global quota; guests (PlaylistAuth) only ever see their own recordings' usage, scoped to their own quota if configured — never the account-wide total.
- Older m3u-editor servers without the `get_dvr_storage` action are treated as "unsupported" — the display just stays hidden, no error surfaced.

Companion backend PR: m3ue/m3u-editor#1360 (adds the `get_dvr_storage` action this consumes).

## Test plan

- [x] `flutter analyze lib test` — no issues
- [x] `flutter test` — 621/621 passing
- [x] `dart format --set-exit-if-changed lib test` — clean