### PR TITLE
feat(settings): clarify playlist Xtream credentials on sign-in

### DIFF
--- a/flutter_client/lib/features/settings/settings_screen.dart
+++ b/flutter_client/lib/features/settings/settings_screen.dart
@@ -342,6 +342,7 @@ class _ConnectionFormBodyState extends State<_ConnectionFormBody>
             ),
             const SizedBox(height: 24),
             _buildError(theme, displayError),
+            _buildCredentialHelp(theme, l),
             ..._buildSignInFields(l, autofocusServer: true),
           ],
         ),
@@ -419,6 +420,7 @@ class _ConnectionFormBodyState extends State<_ConnectionFormBody>
                     ),
                     const SizedBox(height: 24),
                     _buildError(theme, displayError),
+                    _buildCredentialHelp(theme, l),
                     ..._buildSignInFields(l, autofocusServer: false),
                   ],
                 ),
@@ -437,6 +439,18 @@ class _ConnectionFormBodyState extends State<_ConnectionFormBody>
       child: Text(
         displayError,
         style: TextStyle(color: theme.colorScheme.error),
+      ),
+    );
+  }
+
+  Widget _buildCredentialHelp(ThemeData theme, AppLocalizations l) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Text(
+        l.settingsConnectionSettingsHelp,
+        style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
       ),
     );
   }

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -154,6 +154,7 @@
   "settingsFillAllFields": "Bitte fülle alle Felder aus",
   "settingsConnectionSettings": "Verbindungseinstellungen",
   "settingsConnectionSettingsSubtitle": "Gib deine Xtream-Codes-Daten ein",
+  "settingsConnectionSettingsHelp": "Verwende die Xtream-Verbindungsdaten der Playlist aus m3u-editor, nicht deinen m3u-editor-Web-Login. Du benoetigst die Server-URL, den Xtream-Benutzernamen und das Xtream-Passwort.",
   "settingsServerUrl": "Server-URL",
   "settingsUsername": "Benutzername",
   "settingsPassword": "Passwort",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -179,6 +179,7 @@
   "settingsFillAllFields": "Please fill in all fields",
   "settingsConnectionSettings": "Connection Settings",
   "settingsConnectionSettingsSubtitle": "Enter your Xtream codes details",
+  "settingsConnectionSettingsHelp": "Use the playlist Xtream connection details from m3u-editor, not your m3u-editor web login. You need the server URL, Xtream username and Xtream password.",
   "settingsServerUrl": "Server URL",
   "settingsUsername": "Username",
   "settingsPassword": "Password",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -154,6 +154,7 @@
   "settingsFillAllFields": "Por favor completa todos los campos",
   "settingsConnectionSettings": "Configuración de conexión",
   "settingsConnectionSettingsSubtitle": "Ingresa los datos de tu Xtream Codes",
+  "settingsConnectionSettingsHelp": "Usa los datos de conexión Xtream de la lista de reproducción de m3u-editor, no tu inicio de sesión web de m3u-editor. Necesitas la URL del servidor, el nombre de usuario Xtream y la contraseña Xtream.",
   "settingsServerUrl": "URL del servidor",
   "settingsUsername": "Usuario",
   "settingsPassword": "Contraseña",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -154,6 +154,7 @@
   "settingsFillAllFields": "Veuillez remplir tous les champs",
   "settingsConnectionSettings": "Paramètres de connexion",
   "settingsConnectionSettingsSubtitle": "Entrez vos identifiants Xtream Codes",
+  "settingsConnectionSettingsHelp": "Utilisez les informations de connexion Xtream de la playlist m3u-editor, pas votre connexion web m3u-editor. Vous avez besoin de l'URL du serveur, du nom d'utilisateur Xtream et du mot de passe Xtream.",
   "settingsServerUrl": "URL du serveur",
   "settingsUsername": "Nom d'utilisateur",
   "settingsPassword": "Mot de passe",

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -824,6 +824,12 @@ abstract class AppLocalizations {
   /// **'Enter your Xtream codes details'**
   String get settingsConnectionSettingsSubtitle;
 
+  /// No description provided for @settingsConnectionSettingsHelp.
+  ///
+  /// In en, this message translates to:
+  /// **'Use the playlist Xtream connection details from m3u-editor, not your m3u-editor web login. You need the server URL, Xtream username and Xtream password.'**
+  String get settingsConnectionSettingsHelp;
+
   /// No description provided for @settingsServerUrl.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -396,6 +396,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Gib deine Xtream-Codes-Daten ein';
 
   @override
+  String get settingsConnectionSettingsHelp =>
+      'Verwende die Xtream-Verbindungsdaten der Playlist aus m3u-editor, nicht deinen m3u-editor-Web-Login. Du benoetigst die Server-URL, den Xtream-Benutzernamen und das Xtream-Passwort.';
+
+  @override
   String get settingsServerUrl => 'Server-URL';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -394,6 +394,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Enter your Xtream codes details';
 
   @override
+  String get settingsConnectionSettingsHelp =>
+      'Use the playlist Xtream connection details from m3u-editor, not your m3u-editor web login. You need the server URL, Xtream username and Xtream password.';
+
+  @override
   String get settingsServerUrl => 'Server URL';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -396,6 +396,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Ingresa los datos de tu Xtream Codes';
 
   @override
+  String get settingsConnectionSettingsHelp =>
+      'Usa los datos de conexión Xtream de la lista de reproducción de m3u-editor, no tu inicio de sesión web de m3u-editor. Necesitas la URL del servidor, el nombre de usuario Xtream y la contraseña Xtream.';
+
+  @override
   String get settingsServerUrl => 'URL del servidor';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -396,6 +396,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Entrez vos identifiants Xtream Codes';
 
   @override
+  String get settingsConnectionSettingsHelp =>
+      'Utilisez les informations de connexion Xtream de la playlist m3u-editor, pas votre connexion web m3u-editor. Vous avez besoin de l\'URL du serveur, du nom d\'utilisateur Xtream et du mot de passe Xtream.';
+
+  @override
   String get settingsServerUrl => 'URL du serveur';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -386,6 +386,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get settingsConnectionSettingsSubtitle => '输入您的 Xtream Codes 信息';
 
   @override
+  String get settingsConnectionSettingsHelp =>
+      '请使用 m3u-editor 播放列表的 Xtream 连接信息，而不是 m3u-editor 网页登录账号。您需要服务器地址、Xtream 用户名和 Xtream 密码。';
+
+  @override
   String get settingsServerUrl => '服务器地址';
 
   @override

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -154,6 +154,7 @@
   "settingsFillAllFields": "请填写所有字段",
   "settingsConnectionSettings": "连接设置",
   "settingsConnectionSettingsSubtitle": "输入您的 Xtream Codes 信息",
+  "settingsConnectionSettingsHelp": "请使用 m3u-editor 播放列表的 Xtream 连接信息，而不是 m3u-editor 网页登录账号。您需要服务器地址、Xtream 用户名和 Xtream 密码。",
   "settingsServerUrl": "服务器地址",
   "settingsUsername": "用户名",
   "settingsPassword": "密码",

--- a/flutter_client/test/ui/settings/settings_test.dart
+++ b/flutter_client/test/ui/settings/settings_test.dart
@@ -444,6 +444,112 @@ void main() {
   // --- SettingsScreen widget ---
 
   group('SettingsScreen', () {
+    testWidgets(
+      'shows credential guidance on disconnected first-launch compact viewport',
+      (tester) async {
+        addTearDown(tester.view.resetPhysicalSize);
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+
+        final notifier = AuthNotifier(
+          xtreamService: XtreamService(transport: _FakeTransport({}).call),
+          secureStorage: InMemorySecureStorage(),
+        );
+
+        await tester.pumpWidget(_settingsApp(notifier));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Server URL'), findsOneWidget);
+        expect(
+          find.textContaining('playlist Xtream connection details'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('server URL'), findsOneWidget);
+        expect(find.textContaining('Xtream username'), findsOneWidget);
+        expect(find.textContaining('Xtream password'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'shows credential guidance on disconnected TV-sized viewport',
+      (tester) async {
+        addTearDown(tester.view.resetPhysicalSize);
+        tester.view.physicalSize = const Size(1920, 1080);
+        tester.view.devicePixelRatio = 1.0;
+
+        final notifier = AuthNotifier(
+          xtreamService: XtreamService(transport: _FakeTransport({}).call),
+          secureStorage: InMemorySecureStorage(),
+        );
+
+        await tester.pumpWidget(_settingsApp(notifier));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Server URL'), findsOneWidget);
+        expect(
+          find.textContaining('playlist Xtream connection details'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('server URL'), findsOneWidget);
+        expect(find.textContaining('Xtream username'), findsOneWidget);
+        expect(find.textContaining('Xtream password'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'shows credential guidance on disconnected Settings sign-in tab',
+      (tester) async {
+        final notifier = AuthNotifier(
+          xtreamService: XtreamService(transport: _FakeTransport({}).call),
+          secureStorage: InMemorySecureStorage(),
+        );
+        final pairingService = DevicePairingService();
+        addTearDown(pairingService.dispose);
+
+        await tester.pumpWidget(
+          _settingsApp(notifier, devicePairingService: pairingService),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Sign In'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Server URL'), findsOneWidget);
+        expect(
+          find.textContaining('playlist Xtream connection details'),
+          findsOneWidget,
+        );
+        expect(find.textContaining('server URL'), findsOneWidget);
+        expect(find.textContaining('Xtream username'), findsOneWidget);
+        expect(find.textContaining('Xtream password'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'does not show setup guidance when connected or in outage mode',
+      (tester) async {
+        final notifier = AuthNotifier(
+          xtreamService: XtreamService(transport: _FakeTransport({}).call),
+          secureStorage: InMemorySecureStorage(),
+        );
+
+        await tester.pumpWidget(
+          _settingsApp(
+            notifier,
+            isConfiguredOverride: true,
+            sourceError: 'Server is currently unavailable.',
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Server is currently unavailable.'), findsOneWidget);
+        expect(
+          find.textContaining('playlist Xtream connection details'),
+          findsNothing,
+        );
+      },
+    );
+
     testWidgets('shows connection form when not configured', (tester) async {
       final notifier = AuthNotifier(
         xtreamService: XtreamService(transport: _FakeTransport({}).call),


### PR DESCRIPTION
Adds localized help to the disconnected connection form and Settings sign-in tab so users enter playlist Xtream credentials from m3u-editor instead of their web login. Lists server URL, Xtream username and Xtream password.

Closes #129