### PR TITLE
fix(tv): stop a held select key leaking into the menu it opens

### DIFF
--- a/flutter_client/lib/shared/dpad_ink_well.dart
+++ b/flutter_client/lib/shared/dpad_ink_well.dart
@@ -63,15 +63,21 @@ class _DpadInkWellState extends State<DpadInkWell> {
   // swallows) to the newly focused widget, and a child with `onLongSelect`
   // wired would see its 500ms timer re-armed on every repeat.
   //
-  // On mount, we sample `HardwareKeyboard.logicalKeysPressed` and arm a
-  // global handler ONLY if a select key is already held. The handler
-  // disarms itself on the next select KeyUp. Widgets mounted with no key
-  // held are never armed, so a blanket ignore-window does not regress
-  // normal D-pad taps.
-  bool _ignoreSelect = false;
+  // Only the autofocused item inside the newly-built menu can ever receive
+  // that routed phantom KeyDownEvent, so only it needs to arm the guard.
+  // On mount, we sample the specific select key(s) already held (not just
+  // "a select key is held") and arm a global handler that clears each held
+  // key on its own KeyUp. The guard disarms only once none of the keys held
+  // at mount are still down, so an unrelated select-mapped key (e.g. a
+  // keyboard Enter pressed alongside a held remote select button) can't
+  // prematurely disarm it. Widgets mounted with no key held are never
+  // armed, so a blanket ignore-window does not regress normal D-pad taps.
+  Set<LogicalKeyboardKey> _heldSelectKeys = const {};
   bool _guardChecked = false;
   bool _handlerRegistered = false;
   DpadKeySet? _cachedKeySet;
+
+  bool get _ignoreSelect => _heldSelectKeys.isNotEmpty;
 
   @override
   void dispose() {
@@ -89,13 +95,16 @@ class _DpadInkWellState extends State<DpadInkWell> {
     super.didChangeDependencies();
     if (_guardChecked) return;
     _guardChecked = true;
+    // Only the autofocused item in a freshly-built menu can receive the
+    // routed phantom KeyDownEvent, so only it needs the guard armed.
+    if (!widget.autofocus) return;
     final keys = Dpad.keySetOf(context);
     _cachedKeySet = keys;
-    final selectHeld = HardwareKeyboard.instance.logicalKeysPressed.any(
+    final heldSelectKeys = HardwareKeyboard.instance.logicalKeysPressed.where(
       keys.isSelect,
     );
-    if (selectHeld) {
-      _ignoreSelect = true;
+    if (heldSelectKeys.isNotEmpty) {
+      _heldSelectKeys = heldSelectKeys.toSet();
       HardwareKeyboard.instance.addHandler(_onGlobalKey);
       _handlerRegistered = true;
       DpadInkWell.debugActiveGlobalHandlers++;
@@ -106,13 +115,13 @@ class _DpadInkWellState extends State<DpadInkWell> {
     final keys = _cachedKeySet;
     if (event is KeyUpEvent &&
         keys != null &&
-        keys.isSelect(event.logicalKey)) {
-      _ignoreSelect = false;
-      if (_handlerRegistered) {
-        HardwareKeyboard.instance.removeHandler(_onGlobalKey);
-        _handlerRegistered = false;
-        DpadInkWell.debugActiveGlobalHandlers--;
-      }
+        keys.isSelect(event.logicalKey) &&
+        _heldSelectKeys.remove(event.logicalKey) &&
+        _heldSelectKeys.isEmpty &&
+        _handlerRegistered) {
+      HardwareKeyboard.instance.removeHandler(_onGlobalKey);
+      _handlerRegistered = false;
+      DpadInkWell.debugActiveGlobalHandlers--;
     }
     // Always let the event continue to propagate; this is a guard, not a
     // consumer.

--- a/flutter_client/lib/shared/dpad_ink_well.dart
+++ b/flutter_client/lib/shared/dpad_ink_well.dart
@@ -1,5 +1,6 @@
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 
@@ -42,6 +43,11 @@ class DpadInkWell extends StatefulWidget {
   final double? scrollPadding;
   final Clip clipBehavior;
 
+  /// Count of [HardwareKeyboard] global handlers this class currently has
+  /// registered and not yet released. Exposed for leak-detection tests.
+  @visibleForTesting
+  static int debugActiveGlobalHandlers = 0;
+
   @override
   State<DpadInkWell> createState() => _DpadInkWellState();
 }
@@ -50,16 +56,92 @@ class _DpadInkWellState extends State<DpadInkWell> {
   final FocusNode _focusNode = FocusNode();
   bool _hovered = false;
 
+  // The long-select menu opens at the threshold mid-hold. A freshly-mounted
+  // autofocused child inside that menu must NOT act on the select button
+  // the user is still physically holding: Android TV's auto-repeat delivers
+  // fresh `KeyDownEvent`s (not `KeyRepeatEvent`, which the dpad package
+  // swallows) to the newly focused widget, and a child with `onLongSelect`
+  // wired would see its 500ms timer re-armed on every repeat.
+  //
+  // On mount, we sample `HardwareKeyboard.logicalKeysPressed` and arm a
+  // global handler ONLY if a select key is already held. The handler
+  // disarms itself on the next select KeyUp. Widgets mounted with no key
+  // held are never armed, so a blanket ignore-window does not regress
+  // normal D-pad taps.
+  bool _ignoreSelect = false;
+  bool _guardChecked = false;
+  bool _handlerRegistered = false;
+  DpadKeySet? _cachedKeySet;
+
   @override
   void dispose() {
+    if (_handlerRegistered) {
+      HardwareKeyboard.instance.removeHandler(_onGlobalKey);
+      _handlerRegistered = false;
+      DpadInkWell.debugActiveGlobalHandlers--;
+    }
     _focusNode.dispose();
     super.dispose();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_guardChecked) return;
+    _guardChecked = true;
+    final keys = Dpad.keySetOf(context);
+    _cachedKeySet = keys;
+    final selectHeld = HardwareKeyboard.instance.logicalKeysPressed.any(
+      keys.isSelect,
+    );
+    if (selectHeld) {
+      _ignoreSelect = true;
+      HardwareKeyboard.instance.addHandler(_onGlobalKey);
+      _handlerRegistered = true;
+      DpadInkWell.debugActiveGlobalHandlers++;
+    }
+  }
+
+  bool _onGlobalKey(KeyEvent event) {
+    final keys = _cachedKeySet;
+    if (event is KeyUpEvent &&
+        keys != null &&
+        keys.isSelect(event.logicalKey)) {
+      _ignoreSelect = false;
+      if (_handlerRegistered) {
+        HardwareKeyboard.instance.removeHandler(_onGlobalKey);
+        _handlerRegistered = false;
+        DpadInkWell.debugActiveGlobalHandlers--;
+      }
+    }
+    // Always let the event continue to propagate; this is a guard, not a
+    // consumer.
+    return false;
   }
 
   void _onTap() {
     if (!widget.enabled) return;
     _focusNode.requestFocus();
     widget.onTap?.call();
+  }
+
+  void _onDpadSelect() {
+    if (_ignoreSelect) return;
+    _onTap();
+  }
+
+  void _onDpadLongSelect() {
+    if (_ignoreSelect) return;
+    final onLongTap = widget.onLongTap;
+    if (onLongTap == null) return;
+    // Fire synchronously. The dpad package invokes onLongSelect from a Timer
+    // callback, never from build, so opening a route here is safe.
+    // addPostFrameCallback is NOT safe here: it registers a callback but does
+    // not schedule a frame, so on a real device the menu sat queued until the
+    // key release triggered the next rebuild — the "menu only opens on
+    // release" bug. Widget tests miss this because pump() forces frames.
+    _focusNode.requestFocus();
+    onLongTap();
   }
 
   bool get _isInteractive =>
@@ -92,8 +174,8 @@ class _DpadInkWellState extends State<DpadInkWell> {
       onExit: (_) => _setHovered(false),
       child: DpadFocusable(
         focusNode: _focusNode,
-        onSelect: widget.onTap == null ? null : _onTap,
-        onLongSelect: widget.onLongTap,
+        onSelect: widget.onTap == null ? null : _onDpadSelect,
+        onLongSelect: widget.onLongTap == null ? null : _onDpadLongSelect,
         enabled: widget.enabled,
         // InkWell handles touch taps; DpadFocusable.onSelect handles D-pad key
         // events. The default tapToSelect: true wraps the child in a
@@ -102,15 +184,17 @@ class _DpadInkWellState extends State<DpadInkWell> {
         // DpadScroll.ensureVisible that can interrupt a fling with an
         // animateTo() counter-animation.
         tapToSelect: false,
-        builder: (context, state, child) => DpadEffect.wrap(
-          context,
-          effects,
-          DpadFocusState(
-            focused: state.focused || _hovered,
-            pressed: state.pressed,
-          ),
-          child,
-        ),
+        builder: (context, state, child) {
+          return DpadEffect.wrap(
+            context,
+            effects,
+            DpadFocusState(
+              focused: state.focused || _hovered,
+              pressed: state.pressed,
+            ),
+            child,
+          );
+        },
         autofocus: widget.autofocus,
         entry: widget.entry,
         scrollPadding: widget.scrollPadding,
@@ -119,6 +203,9 @@ class _DpadInkWellState extends State<DpadInkWell> {
           borderRadius: widget.borderRadius,
           clipBehavior: widget.clipBehavior,
           child: InkWell(
+            // Touch path is intentionally NOT guarded — the guard exists
+            // for inherited D-pad holds from a parent long-press, not for
+            // touch input.
             onTap: widget.enabled && widget.onTap != null ? _onTap : null,
             onLongPress: widget.enabled ? widget.onLongTap : null,
             borderRadius: widget.borderRadius,

--- a/flutter_client/test/ui/shared/dpad_ink_well_test.dart
+++ b/flutter_client/test/ui/shared/dpad_ink_well_test.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
@@ -38,6 +39,336 @@ void main() {
     expect(_focusBorderOpacity(tester), 1.0);
     expect(FocusManager.instance.primaryFocus, same(focusBeforeHover));
   });
+
+  group(
+    'Option D: long-press fires at threshold; inherited hold is ignored',
+    () {
+      testWidgets('a) long-press fires AT the threshold, mid-hold', (
+        tester,
+      ) async {
+        var longTapCount = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            home: Scaffold(
+              body: Center(
+                child: DpadInkWell(
+                  autofocus: true,
+                  onLongTap: () => longTapCount++,
+                  borderRadius: BorderRadius.circular(8),
+                  child: const SizedBox(
+                    width: 160,
+                    height: 72,
+                    child: Center(child: Text('Hold me')),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+        // NOTE: this asserts onLongTap fires at the threshold, but it CANNOT
+        // detect a deferred dispatch. pump() always runs a full frame and
+        // flushes post-frame callbacks registered during it, so an
+        // addPostFrameCallback dispatch passes here while failing on a real
+        // device, where nothing schedules a frame during a hold and the menu
+        // waits for the release rebuild. Verified: reintroducing the deferral
+        // keeps this test green. Device testing is the only guard for that.
+        await tester.pump(const Duration(milliseconds: 600));
+
+        expect(
+          longTapCount,
+          1,
+          reason:
+              'onLongTap must fire AT the threshold, mid-hold, without waiting '
+              'for a further frame — otherwise the menu only opens on release',
+        );
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+        await tester.pumpAndSettle();
+      });
+
+      testWidgets('b) short press fires onTap, not onLongTap', (tester) async {
+        var tapCount = 0;
+        var longTapCount = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            home: Scaffold(
+              body: Center(
+                child: DpadInkWell(
+                  autofocus: true,
+                  onTap: () => tapCount++,
+                  onLongTap: () => longTapCount++,
+                  borderRadius: BorderRadius.circular(8),
+                  child: const SizedBox(
+                    width: 160,
+                    height: 72,
+                    child: Center(child: Text('Tap me')),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+        await tester.pumpAndSettle();
+
+        expect(tapCount, 1);
+        expect(longTapCount, 0);
+      });
+
+      testWidgets(
+        'c) REGRESSION: autofocused child of mid-hold menu ignores inherited '
+        'select; fires on fresh press',
+        (tester) async {
+          var innerTapCount = 0;
+          await tester.pumpWidget(
+            MaterialApp(
+              theme: ThemeData.dark(useMaterial3: true),
+              home: _LongPressMenuHost(
+                innerTapRecorder: () => innerTapCount++,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Hold select on the outer item. At ~500ms the dpad long-press
+          // timer fires and onLongTap opens a fresh route containing an
+          // autofocused inner DpadInkWell. The user is still holding.
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+          await tester.pump(const Duration(milliseconds: 600));
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text('Inner'),
+            findsOneWidget,
+            reason:
+                'menu must open at threshold with the inner item autofocused',
+          );
+
+          // Android TV's auto-repeat delivers fresh KeyDownEvents (not
+          // KeyRepeatEvent). The autofocused inner item must NOT activate on
+          // a key-down whose matching key-up it never observed.
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+          await tester.pumpAndSettle();
+          expect(
+            innerTapCount,
+            0,
+            reason: 'REGRESSION: inherited select hold must not activate inner',
+          );
+
+          // Second auto-repeat tick while still held — also must not fire.
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+          await tester.pumpAndSettle();
+          expect(innerTapCount, 0);
+
+          // Release. The held key is now released; the guard disarms.
+          await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+          await tester.pumpAndSettle();
+
+          // A fresh press after release must activate the inner item.
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+          await tester.pumpAndSettle();
+          await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+          await tester.pumpAndSettle();
+
+          expect(
+            innerTapCount,
+            1,
+            reason: 'fresh press after release must activate the inner item',
+          );
+        },
+      );
+
+      testWidgets('d) widget mounted with NO select held is not armed', (
+        tester,
+      ) async {
+        var tapCount = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            home: Scaffold(
+              body: Center(
+                child: DpadInkWell(
+                  autofocus: true,
+                  onTap: () => tapCount++,
+                  borderRadius: BorderRadius.circular(8),
+                  child: const SizedBox(
+                    width: 160,
+                    height: 72,
+                    child: Center(child: Text('Tap me')),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          DpadInkWell.debugActiveGlobalHandlers,
+          0,
+          reason:
+              'no key held at mount → no global handler should be registered',
+        );
+
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+        await tester.pumpAndSettle();
+
+        expect(
+          tapCount,
+          1,
+          reason: 'normal short press must fire onTap immediately',
+        );
+        expect(
+          DpadInkWell.debugActiveGlobalHandlers,
+          0,
+          reason: 'a normal press must not leave a handler registered',
+        );
+      });
+
+      testWidgets('e) touch long press still fires onLongTap at threshold', (
+        tester,
+      ) async {
+        var longTapCount = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            home: Scaffold(
+              body: Center(
+                child: DpadInkWell(
+                  onLongTap: () => longTapCount++,
+                  borderRadius: BorderRadius.circular(8),
+                  child: const SizedBox(
+                    width: 160,
+                    height: 72,
+                    child: Center(child: Text('Touch me')),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.longPress(find.byType(DpadInkWell));
+        await tester.pumpAndSettle();
+
+        expect(longTapCount, 1);
+      });
+
+      testWidgets('f) global handler is removed on dispose (no leak)', (
+        tester,
+      ) async {
+        final baseline = DpadInkWell.debugActiveGlobalHandlers;
+
+        // Pre-hold select BEFORE mounting so didChangeDependencies observes a
+        // held key and arms the guard.
+        await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            home: Scaffold(
+              body: Center(
+                child: DpadInkWell(
+                  onTap: () {},
+                  borderRadius: BorderRadius.circular(8),
+                  child: const SizedBox(width: 160, height: 72),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          DpadInkWell.debugActiveGlobalHandlers,
+          baseline + 1,
+          reason: 'widget mounted with select held should register a handler',
+        );
+
+        // Tear down the widget tree. dispose() must unconditionally release
+        // any handler it registered.
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pumpAndSettle();
+
+        expect(
+          DpadInkWell.debugActiveGlobalHandlers,
+          baseline,
+          reason: 'dispose must release the global handler — leak guard',
+        );
+
+        await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+        await tester.pumpAndSettle();
+      });
+    },
+  );
+}
+
+class _LongPressMenuHost extends StatefulWidget {
+  const _LongPressMenuHost({required this.innerTapRecorder});
+
+  final VoidCallback innerTapRecorder;
+
+  @override
+  State<_LongPressMenuHost> createState() => _LongPressMenuHostState();
+}
+
+class _LongPressMenuHostState extends State<_LongPressMenuHost> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: DpadInkWell(
+          autofocus: true,
+          onLongTap: () => _openMenu(context),
+          borderRadius: BorderRadius.circular(8),
+          child: const SizedBox(
+            width: 160,
+            height: 72,
+            child: Center(child: Text('Outer')),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openMenu(BuildContext context) {
+    // showDialog pushes a new route. The inner DpadInkWell mounts inside
+    // a fresh element tree (a fresh Navigator overlay), so its State runs
+    // initState + didChangeDependencies — the same shape as a real TV
+    // context menu in production.
+    return showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return Dialog(
+          child: DpadInkWell(
+            autofocus: true,
+            onTap: () {
+              widget.innerTapRecorder();
+              Navigator.of(dialogContext).pop();
+            },
+            borderRadius: BorderRadius.circular(8),
+            child: const SizedBox(
+              width: 160,
+              height: 72,
+              child: Center(child: Text('Inner')),
+            ),
+          ),
+        );
+      },
+    );
+  }
 }
 
 double _focusBorderOpacity(WidgetTester tester) {

--- a/flutter_client/test/ui/shared/dpad_ink_well_test.dart
+++ b/flutter_client/test/ui/shared/dpad_ink_well_test.dart
@@ -236,6 +236,49 @@ void main() {
         );
       });
 
+      testWidgets(
+        'd2) an unrelated select-mapped key press/release does not disarm '
+        'the guard while the originally-held key is still down',
+        (tester) async {
+          var innerTapCount = 0;
+          await tester.pumpWidget(
+            MaterialApp(
+              theme: ThemeData.dark(useMaterial3: true),
+              home: _LongPressMenuHost(
+                innerTapRecorder: () => innerTapCount++,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+          await tester.pump(const Duration(milliseconds: 600));
+          await tester.pumpAndSettle();
+          expect(find.text('Inner'), findsOneWidget);
+
+          // A different select-mapped key (e.g. a connected keyboard's
+          // Enter) is pressed and released while select is still held.
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.enter);
+          await tester.sendKeyUpEvent(LogicalKeyboardKey.enter);
+          await tester.pumpAndSettle();
+
+          // The originally-held select key is still down; auto-repeat must
+          // still be ignored.
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.select);
+          await tester.pumpAndSettle();
+          expect(
+            innerTapCount,
+            0,
+            reason:
+                'an unrelated select-mapped key up must not disarm the '
+                'guard while the original held key is still down',
+          );
+
+          await tester.sendKeyUpEvent(LogicalKeyboardKey.select);
+          await tester.pumpAndSettle();
+        },
+      );
+
       testWidgets('e) touch long press still fires onLongTap at threshold', (
         tester,
       ) async {
@@ -281,6 +324,7 @@ void main() {
             home: Scaffold(
               body: Center(
                 child: DpadInkWell(
+                  autofocus: true,
                   onTap: () {},
                   borderRadius: BorderRadius.circular(8),
                   child: const SizedBox(width: 160, height: 72),


### PR DESCRIPTION
## Problem

Long-pressing a channel or an EPG programme block **schedules a recording immediately** instead of opening the context menu. The menu is effectively skipped. Reported on a physical Android TV remote.

Two behaviours combine:

1. **The menu opens while the button is still held.** `dpad` fires `onLongSelect` from a 500ms `Timer` started on key-down (`focusable.dart:260-269`), so it lands mid-hold.
2. **The opened menu activates on key-DOWN.** `_ContextMenuOption` is a `DpadInkWell` with only `onTap`, so `onLongSelect == null` and dpad activates it on key-down (`focusable.dart:321-327`). The `Record` item is `autofocus: true` (`live_tv_screen.dart:236`).

Android TV delivers auto-repeat as fresh `KeyDownEvent`s, not `KeyRepeatEvent` (which dpad swallows). So: hold → 500ms timer → menu opens → `Record` takes focus → a repeat from the still-held key activates it → dialog pops with `_ChannelContextAction.record`.

dpad *already* has the right guard — `_selectKeyDown` (`focusable.dart:334`) makes a widget ignore a key-up whose key-down it never saw. It's defeated because every repeat `KeyDownEvent` sets that flag at line 322, so a widget mounted mid-hold looks like it saw the original press.

## Scope: this is three call sites, not one

All three reach the same `_openChannelContextMenu`:

| File | Line | Path |
|---|---|---|
| `live_tv_screen.dart` | 629 | Live TV list row |
| `live_tv_screen.dart` | 765 | Live TV logo grid |
| `timeline_epg_view.dart` | 814 | EPG programme block |

The list and grid cases were previously unknown — they're hidden behind `onLongPress` indirection. Where no `Record` item applies, **`Record Series` is autofocused instead** (`autofocus: !hasRecord`) and creates a recurring DVR rule with no confirmation dialog, so the accidental action wasn't always recoverable.

The other 15 `onLongTap` call sites are in-place toggles (favorites, DVR multi-select) that mount no new surface, so they are unaffected.

## Approach

Considered and rejected: a timed ignore-window in the dialog (fragile), and removing `autofocus` from `Record` (breaks D-pad focus). Also rejected deferring long-press to key *release* — it fixes the bug but ships an interaction model no TV platform uses; Android TV and tvOS both open at the threshold.

Implemented instead, in our own wrapper rather than the package (`dpad` is a pub dependency):

**A control never acts on a select press whose key-down it did not observe.**

A `DpadInkWell` that mounts while a select key is already physically held ignores D-pad select and long-select until that key is released and pressed again.

## Changes

`lib/shared/dpad_ink_well.dart`

- On first `didChangeDependencies`, sample `HardwareKeyboard.instance.logicalKeysPressed`; if any key satisfies `Dpad.keySetOf(context).isSelect`, arm the guard and register a `HardwareKeyboard` handler.
- The handler disarms on the matching select `KeyUpEvent`, removes itself, and always returns `false` so events keep propagating.
- `dispose()` removes the handler unconditionally. A `@visibleForTesting` counter asserts no handler outlives its widget.
- Guard applies to new D-pad-only handlers (`_onDpadSelect`, `_onDpadLongSelect`). `_onTap` is shared with `InkWell`'s touch path and is deliberately left ungated — **touch behaviour is unchanged**, and touch has no key-repeat to inherit.
- Widgets mounted with **no** key held are never armed, so this is not a blanket ignore-window.

No platform branching. The rule is the invariant Android and tvOS enforce natively.

### Long-press dispatch fires synchronously

`onLongSelect` dispatches `onLongTap` directly rather than via `addPostFrameCallback`. That call registers a callback but does **not** schedule a frame, and nothing else requests one during a hold — so the menu sat queued until the release rebuild flushed it, making the menu appear only on key release. Calling directly is safe because dpad invokes `onLongSelect` from a `Timer`, never during build.

## Verification

- `dart format` — 0 changed
- `flutter analyze lib test` — No issues found
- `flutter test` — full suite green (828). One run showed the documented `push_token_lifecycle_test.dart` parallel-execution flake; passes 38/38 in isolation and is untouched by this change.
- Mutation-checked: removing the guard fails the regression test and only that test.
- **Verified on an Android TV emulator with a hardware keyboard**, holding select on an EPG block.

### Test coverage caveat, stated plainly

The regression test genuinely drives the reported scenario: it opens a real route via `showDialog`, mounts an autofocused child, delivers repeat `KeyDownEvent`s while held, asserts no activation, then asserts a fresh press after release does activate.

However, **no widget test can catch the deferred-dispatch half of this fix.** `tester.pump()` always runs a full frame and flushes post-frame callbacks registered during it, so the broken version passes the suite while failing on a device. This was confirmed by reintroducing the deferral and watching all tests stay green; the code comment says so rather than implying coverage that doesn't exist. It was found by device testing, which remains the only guard for that class of bug here.

tvOS was not verified on-device.