### PR TITLE
feat(shows-detail): schedule single airing from Shows-DVR search (#204)

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -677,6 +677,18 @@ class AppShellState extends ConsumerState<AppShell>
     }
   }
 
+  /// Schedules a single DVR airing for one Shows-search episode. No
+  /// SnackBar here — the screen owns success/failure feedback (mirroring
+  /// how the live-tv `_scheduleDvr` keeps it out of the scheduling call).
+  Future<DvrRecording?> _scheduleDvrAiring(EpgShowEpisode episode) {
+    return _appState.scheduleDvrAiring(
+      channelId: episode.channelId,
+      title: episode.title,
+      startTime: episode.startTime,
+      endTime: episode.endTime,
+    );
+  }
+
   /// Calls the foundation-agent-owned `XtreamService.createDvrSeriesRule`
   /// and refreshes the cached series rules list so the DVR screen's new
   /// "Series Rules" section reflects the addition immediately.
@@ -1140,6 +1152,7 @@ class AppShellState extends ConsumerState<AppShell>
       onSidebarActivate: _activateSidebar,
       onRecordSeries: _createDvrSeriesRule,
       onDeleteSeriesRule: _deleteDvrSeriesRule,
+      onScheduleEpisode: _scheduleDvrAiring,
       buildTabScreen: _buildTabScreen,
       child: FocusScope(
         node: _contentFocusNode,

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -35,6 +35,7 @@ import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/app_background.dart';
 import 'package:m3u_tv/shared/app_callout.dart';
 import 'package:m3u_tv/shared/dvr_action_dialogs.dart';
+import 'package:m3u_tv/shared/dvr_schedule_feedback.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/shared/notification_toast.dart';
@@ -654,31 +655,21 @@ class AppShellState extends ConsumerState<AppShell>
     BuildContext context,
     Channel channel,
     EpgProgram program,
-  ) async {
-    try {
-      await _appState.scheduleDvr(channel, program);
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            AppLocalizations.of(context).appRecordingScheduled(program.title),
-          ),
-        ),
-      );
-    } on Object catch (error) {
-      if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            AppLocalizations.of(context).appRecordingFailed(error.toString()),
-          ),
-        ),
-      );
-    }
+  ) {
+    return scheduleDvrWithFeedback(
+      context,
+      schedule: () => _appState.scheduleDvrAiring(
+        channelId: channel.id,
+        title: program.title,
+        startTime: program.start,
+        endTime: program.end,
+      ),
+      title: program.title,
+    );
   }
 
   /// Schedules a single DVR airing for one Shows-search episode. No
-  /// SnackBar here — the screen owns success/failure feedback (mirroring
+  /// SnackBar here: the screen owns success/failure feedback (mirroring
   /// how the live-tv `_scheduleDvr` keeps it out of the scheduling call).
   Future<DvrRecording?> _scheduleDvrAiring(EpgShowEpisode episode) {
     return _appState.scheduleDvrAiring(

--- a/flutter_client/lib/features/dvr/dvr_recordings_screen.dart
+++ b/flutter_client/lib/features/dvr/dvr_recordings_screen.dart
@@ -13,6 +13,7 @@ import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/dpad_tab_bar.dart';
 import 'package:m3u_tv/shared/dvr_action_dialogs.dart';
+import 'package:m3u_tv/shared/leading_tile.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/shared/row_action_menu.dart';
 
@@ -525,7 +526,7 @@ class _SeriesRuleCard extends StatelessWidget {
                 ),
                 child: Row(
                   children: [
-                    _LeadingTile(
+                    LeadingTile(
                       icon: Icons.fiber_manual_record,
                       selected: selected,
                       selectMode: selectMode,
@@ -1022,7 +1023,7 @@ class _RecordingCard extends StatelessWidget {
                   ),
                   child: Row(
                     children: [
-                      _LeadingTile(
+                      LeadingTile(
                         icon: _recordingStatusIcon(recording.status),
                         selected: selected,
                         selectMode: selectMode,
@@ -1110,61 +1111,6 @@ class _RecordingCard extends StatelessWidget {
       DvrRecordingStatus.deleted => colorScheme.onSurfaceVariant,
       DvrRecordingStatus.unknown => colorScheme.onSurfaceVariant,
     };
-  }
-}
-
-/// Shared leading icon tile for both Recordings and Series Rules rows —
-/// either the row's status/kind icon, or (in select mode) a checkbox.
-/// [icon] is resolved by the caller since each row type derives it
-/// differently (recording status vs. a fixed series-rule glyph).
-class _LeadingTile extends StatelessWidget {
-  const _LeadingTile({
-    required this.icon,
-    required this.selected,
-    required this.selectMode,
-    required this.tileColor,
-  });
-
-  final IconData icon;
-  final bool selected;
-  final bool selectMode;
-  final Color tileColor;
-
-  static const double _size = 44;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-
-    if (selectMode) {
-      final accent = selected ? colorScheme.primary : colorScheme.outline;
-      return Container(
-        width: _size,
-        height: _size,
-        decoration: BoxDecoration(
-          color: selected
-              ? colorScheme.primary.withValues(alpha: 0.14)
-              : Colors.transparent,
-          borderRadius: BorderRadius.circular(10),
-          border: Border.all(color: accent, width: 2),
-        ),
-        child: Icon(
-          selected ? Icons.check_box : Icons.check_box_outline_blank,
-          color: accent,
-        ),
-      );
-    }
-
-    return Container(
-      width: _size,
-      height: _size,
-      decoration: BoxDecoration(
-        color: tileColor.withValues(alpha: 0.14),
-        borderRadius: BorderRadius.circular(10),
-      ),
-      child: Icon(icon, color: tileColor),
-    );
   }
 }
 

--- a/flutter_client/lib/features/shows/show_detail_screen.dart
+++ b/flutter_client/lib/features/shows/show_detail_screen.dart
@@ -10,6 +10,7 @@ import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/dvr_action_dialogs.dart';
+import 'package:m3u_tv/shared/leading_tile.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
 /// Detail screen for a single EPG show. Receives the [EpgShow] as the route
@@ -26,6 +27,7 @@ class ShowDetailScreen extends ConsumerStatefulWidget {
     required this.show,
     this.onRecordSeries,
     this.onDeleteSeriesRule,
+    this.onScheduleEpisode,
   });
 
   final EpgShow show;
@@ -52,12 +54,51 @@ class ShowDetailScreen extends ConsumerStatefulWidget {
   /// invoked when [ShowDetailScreen] detects an existing rule for this show.
   final Future<void> Function(DvrSeriesRule rule)? onDeleteSeriesRule;
 
+  /// Schedules a single DVR airing for one episode row. Wired by AppShell
+  /// against `AppStateController.scheduleDvrAiring`. Null hides the per-row
+  /// Record affordance (screen still works unwired, same convention as
+  /// [onRecordSeries]).
+  final Future<DvrRecording?> Function(EpgShowEpisode episode)?
+  onScheduleEpisode;
+
   @override
   ConsumerState<ShowDetailScreen> createState() => _ShowDetailScreenState();
 }
 
 class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
   bool _isSubmitting = false;
+
+  /// In-flight per-row schedule requests, keyed by
+  /// `channelId|startTime` so same-title airings on different channels (or
+  /// the same channel at different times) are tracked independently. Guards
+  /// against double-tap double-scheduling while the request is in flight.
+  final Set<String> _submittingEpisodeKeys = {};
+
+  Future<void> _scheduleEpisode(EpgShowEpisode episode) async {
+    final handler = widget.onScheduleEpisode;
+    if (handler == null) return;
+    final episodeKey = _episodeRecordKey(episode);
+    if (_submittingEpisodeKeys.contains(episodeKey)) return;
+    setState(() => _submittingEpisodeKeys.add(episodeKey));
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = AppLocalizations.of(context);
+    try {
+      await handler(episode);
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.appRecordingScheduled(episode.title))),
+      );
+    } on Object catch (error) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.appRecordingFailed(error.toString()))),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _submittingEpisodeKeys.remove(episodeKey));
+      }
+    }
+  }
 
   DvrSeriesRule? _findExistingRule(List<DvrSeriesRule> rules) {
     final ruleId = widget.show.seriesRuleId;
@@ -240,14 +281,31 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
               ),
             ),
             const SizedBox(height: MediaBrowsingMetrics.itemGap),
-            ...show.recentEpisodes.map(
-              (episode) => Padding(
-                padding: const EdgeInsets.only(
-                  bottom: MediaBrowsingMetrics.chipGap,
+            if (show.recentEpisodes.isEmpty)
+              Center(
+                child: Text(
+                  l10n.showAiringNone,
+                  style: theme.textTheme.bodyLarge,
                 ),
-                child: _EpisodeRow(episode: episode, localeTag: localized),
+              )
+            else
+              ...show.recentEpisodes.map(
+                (episode) => Padding(
+                  padding: const EdgeInsets.only(
+                    bottom: MediaBrowsingMetrics.itemGap,
+                  ),
+                  child: _EpisodeRow(
+                    episode: episode,
+                    localeTag: localized,
+                    onScheduleEpisode: widget.onScheduleEpisode == null
+                        ? null
+                        : _scheduleEpisode,
+                    isScheduling: _submittingEpisodeKeys.contains(
+                      _episodeRecordKey(episode),
+                    ),
+                  ),
+                ),
               ),
-            ),
           ],
         ),
       ),
@@ -357,8 +415,10 @@ class _Header extends StatelessWidget {
     );
     final actions = _buildActions(l10n);
 
-    return Card(
+    return Material(
       color: theme.colorScheme.surfaceContainerHigh,
+      borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
+      clipBehavior: Clip.antiAlias,
       child: Padding(
         padding: const EdgeInsets.all(MediaBrowsingMetrics.contentPadding),
         child: LayoutBuilder(
@@ -393,36 +453,46 @@ class _Header extends StatelessWidget {
 }
 
 class _EpisodeRow extends StatelessWidget {
-  const _EpisodeRow({required this.episode, required this.localeTag});
+  const _EpisodeRow({
+    required this.episode,
+    required this.localeTag,
+    this.onScheduleEpisode,
+    this.isScheduling = false,
+  });
+
   final EpgShowEpisode episode;
   final String localeTag;
+
+  /// One-shot Record action for this single airing. Null hides the
+  /// affordance (screen not wired); airings already over hide it too.
+  final Future<void> Function(EpgShowEpisode episode)? onScheduleEpisode;
+
+  /// True while this row's schedule request is in flight — disables the
+  /// Record button so a double-tap can't schedule the same airing twice.
+  final bool isScheduling;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
     final timeLabel = DateFormat.yMMMd(
       localeTag,
     ).add_jm().format(episode.startTime.toLocal());
+    // Don't offer to record an airing that has already ended (same check
+    // as the live-tv context menu's `pressedProgram.end.isAfter(now)`).
+    final canSchedule =
+        onScheduleEpisode != null && episode.endTime.isAfter(DateTime.now());
 
     return DpadInkWell(
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
       color: theme.colorScheme.surfaceContainerHigh,
       child: Padding(
         padding: const EdgeInsets.all(MediaBrowsingMetrics.contentPadding),
         child: Row(
           children: [
-            Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.tertiaryContainer,
-                borderRadius: BorderRadius.circular(50),
-              ),
-              child: Icon(
-                Icons.play_arrow,
-                color: theme.colorScheme.onTertiaryContainer,
-                size: 22,
-              ),
+            LeadingTile(
+              icon: Icons.schedule,
+              tileColor: theme.colorScheme.primary,
             ),
             const SizedBox(width: MediaBrowsingMetrics.contentPadding),
             Expanded(
@@ -431,15 +501,23 @@ class _EpisodeRow extends StatelessWidget {
                 children: [
                   Text(
                     episode.title,
-                    style: theme.textTheme.titleSmall,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: 2),
-                  Text(
-                    '${episode.channelName} $timeLabel',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: theme.colorScheme.onSurfaceVariant,
+                  Text.rich(
+                    TextSpan(
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                      children: [
+                        TextSpan(text: episode.channelName),
+                        const TextSpan(text: ' · '),
+                        TextSpan(text: timeLabel),
+                      ],
                     ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
@@ -447,9 +525,35 @@ class _EpisodeRow extends StatelessWidget {
                 ],
               ),
             ),
+            if (canSchedule) ...[
+              const SizedBox(width: MediaBrowsingMetrics.chipGap),
+              // Direct AppIconButton rather than RowActionMenu: record is the
+              // only action on episode rows, so the "more" overflow that
+              // RowActionMenu exists to provide is semantically empty here —
+              // using it would force a 2-tap UX (tap more_vert → tap record)
+              // for what is currently a single tap. AppIconButton already
+              // handles D-pad focus and touch adaptation itself, so there's
+              // no missing touch/TV behavior for the wrapper to add. If a
+              // future change adds a second per-row action (e.g. cancel a
+              // scheduled recording from the episode row), revisit and
+              // route both through RowActionMenu at that point.
+              AppIconButton(
+                icon: Icons.fiber_manual_record,
+                tooltip: l10n.liveTvRecord,
+                onPressed: isScheduling
+                    ? null
+                    : () => onScheduleEpisode!(episode),
+              ),
+            ],
           ],
         ),
       ),
     );
   }
 }
+
+/// Unique per-airing key for the in-flight guard — `channelId|startTime`
+/// stays distinct even when the same title airs on another channel or at a
+/// different time.
+String _episodeRecordKey(EpgShowEpisode episode) =>
+    '${episode.channelId}|${episode.startTime.toIso8601String()}';

--- a/flutter_client/lib/features/shows/show_detail_screen.dart
+++ b/flutter_client/lib/features/shows/show_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +12,7 @@ import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/dvr_action_dialogs.dart';
+import 'package:m3u_tv/shared/dvr_schedule_feedback.dart';
 import 'package:m3u_tv/shared/leading_tile.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
@@ -80,18 +83,11 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
     final episodeKey = _episodeRecordKey(episode);
     if (_submittingEpisodeKeys.contains(episodeKey)) return;
     setState(() => _submittingEpisodeKeys.add(episodeKey));
-    final messenger = ScaffoldMessenger.of(context);
-    final l10n = AppLocalizations.of(context);
     try {
-      await handler(episode);
-      if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(l10n.appRecordingScheduled(episode.title))),
-      );
-    } on Object catch (error) {
-      if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(l10n.appRecordingFailed(error.toString()))),
+      await scheduleDvrWithFeedback(
+        context,
+        schedule: () => handler(episode),
+        title: episode.title,
       );
     } finally {
       if (mounted) {
@@ -342,9 +338,9 @@ class _Header extends StatelessWidget {
   final VoidCallback onOpenOptions;
   final VoidCallback? onDeleteRule;
 
-  // Below this width the title + action buttons no longer fit on one row —
-  // on a phone, forcing them into a Row starves the title's Expanded column
-  // down to a sliver, wrapping every word onto its own line.
+  // Below this width the title + action buttons no longer fit on one row
+  // (on a phone, forcing them into a Row starves the title's Expanded column
+  // down to a sliver, wrapping every word onto its own line).
   static const double _narrowBreakpoint = 420;
 
   Widget? _buildActions(AppLocalizations l10n) {
@@ -415,9 +411,11 @@ class _Header extends StatelessWidget {
     );
     final actions = _buildActions(l10n);
 
-    return Material(
+    return Card(
       color: theme.colorScheme.surfaceContainerHigh,
-      borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
+      ),
       clipBehavior: Clip.antiAlias,
       child: Padding(
         padding: const EdgeInsets.all(MediaBrowsingMetrics.contentPadding),
@@ -452,7 +450,7 @@ class _Header extends StatelessWidget {
   }
 }
 
-class _EpisodeRow extends StatelessWidget {
+class _EpisodeRow extends StatefulWidget {
   const _EpisodeRow({
     required this.episode,
     required this.localeTag,
@@ -467,12 +465,55 @@ class _EpisodeRow extends StatelessWidget {
   /// affordance (screen not wired); airings already over hide it too.
   final Future<void> Function(EpgShowEpisode episode)? onScheduleEpisode;
 
-  /// True while this row's schedule request is in flight — disables the
-  /// Record button so a double-tap can't schedule the same airing twice.
+  /// True while this row's schedule request is in flight (disables the
+  /// Record button so a double-tap can't schedule the same airing twice).
   final bool isScheduling;
 
   @override
+  State<_EpisodeRow> createState() => _EpisodeRowState();
+}
+
+class _EpisodeRowState extends State<_EpisodeRow> {
+  Timer? _endTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleEndTimer();
+  }
+
+  @override
+  void didUpdateWidget(_EpisodeRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.episode.endTime != widget.episode.endTime) {
+      _scheduleEndTimer();
+    }
+  }
+
+  void _scheduleEndTimer() {
+    _endTimer?.cancel();
+    final remaining = widget.episode.endTime.difference(DateTime.now());
+    if (remaining.isNegative) return;
+    // Rebuilds once the airing ends so canSchedule (and the Record button)
+    // stops reflecting a now-stale "still airing" state without requiring
+    // the user to trigger some unrelated rebuild first.
+    _endTimer = Timer(remaining, () {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _endTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final episode = widget.episode;
+    final localeTag = widget.localeTag;
+    final onScheduleEpisode = widget.onScheduleEpisode;
+    final isScheduling = widget.isScheduling;
     final theme = Theme.of(context);
     final l10n = AppLocalizations.of(context);
     final timeLabel = DateFormat.yMMMd(
@@ -491,8 +532,8 @@ class _EpisodeRow extends StatelessWidget {
         child: Row(
           children: [
             LeadingTile(
-              icon: Icons.schedule,
-              tileColor: theme.colorScheme.primary,
+              icon: Icons.play_arrow,
+              tileColor: theme.colorScheme.tertiary,
             ),
             const SizedBox(width: MediaBrowsingMetrics.contentPadding),
             Expanded(
@@ -529,8 +570,8 @@ class _EpisodeRow extends StatelessWidget {
               const SizedBox(width: MediaBrowsingMetrics.chipGap),
               // Direct AppIconButton rather than RowActionMenu: record is the
               // only action on episode rows, so the "more" overflow that
-              // RowActionMenu exists to provide is semantically empty here —
-              // using it would force a 2-tap UX (tap more_vert → tap record)
+              // RowActionMenu exists to provide is semantically empty here;
+              // using it would force a 2-tap UX (tap more_vert -> tap record)
               // for what is currently a single tap. AppIconButton already
               // handles D-pad focus and touch adaptation itself, so there's
               // no missing touch/TV behavior for the wrapper to add. If a
@@ -542,7 +583,7 @@ class _EpisodeRow extends StatelessWidget {
                 tooltip: l10n.liveTvRecord,
                 onPressed: isScheduling
                     ? null
-                    : () => onScheduleEpisode!(episode),
+                    : () => onScheduleEpisode(episode),
               ),
             ],
           ],
@@ -552,7 +593,7 @@ class _EpisodeRow extends StatelessWidget {
   }
 }
 
-/// Unique per-airing key for the in-flight guard — `channelId|startTime`
+/// Unique per-airing key for the in-flight guard: `channelId|startTime`
 /// stays distinct even when the same title airs on another channel or at a
 /// different time.
 String _episodeRecordKey(EpgShowEpisode episode) =>

--- a/flutter_client/lib/navigation/content_actions.dart
+++ b/flutter_client/lib/navigation/content_actions.dart
@@ -21,6 +21,7 @@ class ContentActions extends InheritedWidget {
     required this.onSidebarActivate,
     required this.onRecordSeries,
     required this.onDeleteSeriesRule,
+    this.onScheduleEpisode,
     required this.buildTabScreen,
     required super.child,
   });
@@ -67,6 +68,14 @@ class ContentActions extends InheritedWidget {
   /// it through to the screen so the rule-active state can offer a delete
   /// affordance without a separate round-trip to fetch the rule id.
   final Future<void> Function(DvrSeriesRule rule)? onDeleteSeriesRule;
+
+  /// Schedules a single DVR airing for one `EpgShowEpisode`. Wired by
+  /// AppShell against `AppStateController.scheduleDvrAiring`; the
+  /// `ShowDetailScreen` route passes it through so each episode row can
+  /// offer a one-shot Record affordance (unlike [onRecordSeries], no
+  /// persistent rule is created). Returns the matching recording if the
+  /// post-schedule refresh surfaced one, else null.
+  final Future<DvrRecording?> Function(EpgShowEpisode)? onScheduleEpisode;
 
   /// Builds the full tab screen for the given routeName.
   /// Provided by AppShell so go_router branch builders don't need to import

--- a/flutter_client/lib/navigation/go_router_config.dart
+++ b/flutter_client/lib/navigation/go_router_config.dart
@@ -307,6 +307,7 @@ GoRouter createGoRouter({
                           show: show,
                           onRecordSeries: actions.onRecordSeries,
                           onDeleteSeriesRule: actions.onDeleteSeriesRule,
+                          onScheduleEpisode: actions.onScheduleEpisode,
                         ),
                       );
                     },

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -1838,6 +1838,18 @@ class AppStateController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Schedules a one-shot DVR recording for a single EPG program and
+  /// refreshes the local list. Thin wrapper over [scheduleDvrAiring] — see
+  /// there for the full behavior contract.
+  Future<DvrRecording?> scheduleDvr(Channel channel, EpgProgram program) {
+    return scheduleDvrAiring(
+      channelId: channel.id,
+      title: program.title,
+      startTime: program.start,
+      endTime: program.end,
+    );
+  }
+
   /// Schedules a one-shot DVR recording and refreshes the local list.
   ///
   /// m3u-editor's `schedule_dvr` creates a DVR rule and (when DVR is enabled
@@ -1849,7 +1861,12 @@ class AppStateController extends ChangeNotifier {
   /// Returns the matching recording if the refresh surfaced one for this
   /// channel + start time; otherwise null (the scheduler tick may not have
   /// produced the row yet on slower servers).
-  Future<DvrRecording?> scheduleDvr(Channel channel, EpgProgram program) async {
+  Future<DvrRecording?> scheduleDvrAiring({
+    required int channelId,
+    required String title,
+    required DateTime startTime,
+    required DateTime endTime,
+  }) async {
     final credentials = authNotifier.credentials;
     if (credentials == null) {
       throw StateError('Xtream credentials not configured');
@@ -1858,10 +1875,10 @@ class AppStateController extends ChangeNotifier {
     if (!ownsWork()) return null;
     await xtreamService.scheduleDvrFor(
       credentials,
-      channelId: channel.id,
-      title: program.title,
-      startTime: program.start,
-      endTime: program.end,
+      channelId: channelId,
+      title: title,
+      startTime: startTime,
+      endTime: endTime,
     );
     if (!ownsWork()) return null;
     try {
@@ -1878,10 +1895,10 @@ class AppStateController extends ChangeNotifier {
     notifyListeners();
     unawaited(refreshDvrStorage());
     for (final recording in _dvrRecordings) {
-      if (recording.channelId != channel.id) continue;
+      if (recording.channelId != channelId) continue;
       final start = recording.scheduledStart;
       if (start == null) continue;
-      if (program.start.difference(start).abs() <= const Duration(minutes: 1)) {
+      if (startTime.difference(start).abs() <= const Duration(minutes: 1)) {
         return recording;
       }
     }

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -1735,7 +1735,7 @@ class AppStateController extends ChangeNotifier {
   /// Refreshes the cached DVR recordings list from `get_dvr_recordings`.
   ///
   /// Series rules can produce a matching `DvrRecording` synchronously (see
-  /// [scheduleDvr]'s doc comment for the same server-side behaviour on
+  /// [scheduleDvrAiring]'s doc comment for the same server-side behaviour on
   /// one-shot recordings), so the UI agent should call this after a
   /// successful `createDvrSeriesRule` / `updateDvrSeriesRule` round-trip, not
   /// just after [refreshDvrSeriesRules]. Otherwise, a newly matched recording
@@ -1836,18 +1836,6 @@ class AppStateController extends ChangeNotifier {
       _progressList = await resumeService.all(viewer.ulid);
     }
     notifyListeners();
-  }
-
-  /// Schedules a one-shot DVR recording for a single EPG program and
-  /// refreshes the local list. Thin wrapper over [scheduleDvrAiring] — see
-  /// there for the full behavior contract.
-  Future<DvrRecording?> scheduleDvr(Channel channel, EpgProgram program) {
-    return scheduleDvrAiring(
-      channelId: channel.id,
-      title: program.title,
-      startTime: program.start,
-      endTime: program.end,
-    );
   }
 
   /// Schedules a one-shot DVR recording and refreshes the local list.

--- a/flutter_client/lib/shared/dvr_schedule_feedback.dart
+++ b/flutter_client/lib/shared/dvr_schedule_feedback.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+
+/// Runs [schedule] and shows the shared success/failure SnackBar for a
+/// single DVR airing. Shared between the live-tv context menu
+/// (`AppShell._scheduleDvr`) and the Shows-search episode row
+/// (`ShowDetailScreen._scheduleEpisode`) so both surfaces report the same
+/// way. Returns the scheduled result, or null if scheduling failed or the
+/// context was unmounted by the time the call completed.
+Future<T?> scheduleDvrWithFeedback<T>(
+  BuildContext context, {
+  required Future<T> Function() schedule,
+  required String title,
+}) async {
+  final messenger = ScaffoldMessenger.of(context);
+  final l10n = AppLocalizations.of(context);
+  try {
+    final result = await schedule();
+    if (!context.mounted) return null;
+    messenger.showSnackBar(
+      SnackBar(content: Text(l10n.appRecordingScheduled(title))),
+    );
+    return result;
+  } on Object catch (error) {
+    if (!context.mounted) return null;
+    messenger.showSnackBar(
+      SnackBar(content: Text(l10n.appRecordingFailed(error.toString()))),
+    );
+    return null;
+  }
+}

--- a/flutter_client/lib/shared/leading_tile.dart
+++ b/flutter_client/lib/shared/leading_tile.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 ///
 /// In normal mode renders [icon] in an alpha-tinted background of [tileColor].
 /// In select mode (DVR rows, when the parent screen enables multi-select)
-/// renders a checkbox instead — episodes use normal mode only and don't need
+/// renders a checkbox instead; episodes use normal mode only and don't need
 /// the select-mode behavior. Both [selected] and [selectMode] default to false
 /// so non-DVR callers can pass just [icon] and [tileColor].
 class LeadingTile extends StatelessWidget {

--- a/flutter_client/lib/shared/leading_tile.dart
+++ b/flutter_client/lib/shared/leading_tile.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+/// Rounded-square leading icon tile for list rows, shared by the DVR section
+/// (recordings, series rules) and the Shows episode list. Centralizing the
+/// shape keeps row visual treatment consistent across feature surfaces.
+///
+/// In normal mode renders [icon] in an alpha-tinted background of [tileColor].
+/// In select mode (DVR rows, when the parent screen enables multi-select)
+/// renders a checkbox instead — episodes use normal mode only and don't need
+/// the select-mode behavior. Both [selected] and [selectMode] default to false
+/// so non-DVR callers can pass just [icon] and [tileColor].
+class LeadingTile extends StatelessWidget {
+  const LeadingTile({
+    super.key,
+    required this.icon,
+    required this.tileColor,
+    this.selected = false,
+    this.selectMode = false,
+  });
+
+  final IconData icon;
+  final Color tileColor;
+  final bool selected;
+  final bool selectMode;
+
+  static const double size = 44;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    if (selectMode) {
+      final accent = selected ? colorScheme.primary : colorScheme.outline;
+      return Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          color: selected
+              ? colorScheme.primary.withValues(alpha: 0.14)
+              : Colors.transparent,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: accent, width: 2),
+        ),
+        child: Icon(
+          selected ? Icons.check_box : Icons.check_box_outline_blank,
+          color: accent,
+        ),
+      );
+    }
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: tileColor.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Icon(icon, color: tileColor),
+    );
+  }
+}

--- a/flutter_client/test/features/shows/test_episode_record_action_test.dart
+++ b/flutter_client/test/features/shows/test_episode_record_action_test.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/shows/show_detail_screen.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  final futureEpisode = EpgShowEpisode(
+    channelId: 8,
+    channelName: 'Channel Eight',
+    title: 'Future Ep',
+    startTime: DateTime.now().add(const Duration(hours: 1)),
+    endTime: DateTime.now().add(const Duration(hours: 2)),
+  );
+  final pastEpisode = EpgShowEpisode(
+    channelId: 9,
+    channelName: 'Channel Nine',
+    title: 'Past Ep',
+    startTime: DateTime.now().subtract(const Duration(hours: 2)),
+    endTime: DateTime.now().subtract(const Duration(hours: 1)),
+  );
+
+  EpgShow testShow({required List<EpgShowEpisode> episodes}) => EpgShow(
+    normalizedTitle: 'wired show',
+    displayTitle: 'Wired Show',
+    channelCount: 2,
+    channels: const [
+      EpgShowChannel(channelId: 7, channelName: 'Channel Seven'),
+      EpgShowChannel(channelId: 8, channelName: 'Channel Eight'),
+    ],
+    episodeCount: episodes.length,
+    recentEpisodes: episodes,
+  );
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    required EpgShow show,
+    Future<DvrRecording?> Function(EpgShowEpisode episode)? onScheduleEpisode,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dvrSeriesRulesProvider.overrideWith((_) => const [])],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ShowDetailScreen(
+            show: show,
+            onScheduleEpisode: onScheduleEpisode,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Finder recordIcon(WidgetTester tester) {
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(ShowDetailScreen)),
+    );
+    return find.byTooltip(l10n.liveTvRecord);
+  }
+
+  testWidgets(
+    'tapping an episode record icon invokes onScheduleEpisode with that episode',
+    (tester) async {
+      EpgShowEpisode? captured;
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [futureEpisode, pastEpisode]),
+        onScheduleEpisode: (episode) async {
+          captured = episode;
+          return null;
+        },
+      );
+
+      // Only the future episode gets the affordance; the past one is over.
+      expect(recordIcon(tester), findsOneWidget);
+
+      await tester.tap(recordIcon(tester));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.channelId, futureEpisode.channelId);
+      expect(captured!.title, futureEpisode.title);
+      expect(captured!.startTime, futureEpisode.startTime);
+      expect(captured!.endTime, futureEpisode.endTime);
+
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(ShowDetailScreen)),
+      );
+      expect(
+        find.text(l10n.appRecordingScheduled(futureEpisode.title)),
+        findsOneWidget,
+        reason: 'success SnackBar must surface after the schedule completes',
+      );
+    },
+  );
+
+  testWidgets(
+    'record icon is absent when onScheduleEpisode is not wired',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [futureEpisode]),
+      );
+
+      expect(recordIcon(tester), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'record icon is absent for an airing that has already ended',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [pastEpisode]),
+        onScheduleEpisode: (episode) async => null,
+      );
+
+      expect(recordIcon(tester), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'double-tap guard: a second tap while scheduling is in flight is a no-op',
+    (tester) async {
+      final inFlight = Completer<DvrRecording?>();
+      var invocations = 0;
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [futureEpisode]),
+        onScheduleEpisode: (episode) {
+          invocations += 1;
+          return inFlight.future;
+        },
+      );
+
+      await tester.tap(recordIcon(tester));
+      await tester.pump();
+      expect(invocations, 1);
+
+      // The request is still in flight — the button is disabled, so a second
+      // tap (or fast double-tap) must not reach the callback again.
+      await tester.tap(recordIcon(tester), warnIfMissed: false);
+      await tester.pump();
+      expect(invocations, 1);
+
+      inFlight.complete();
+      await tester.pumpAndSettle();
+      expect(invocations, 1);
+    },
+  );
+
+  testWidgets(
+    'schedule failure surfaces the appRecordingFailed SnackBar',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [futureEpisode]),
+        onScheduleEpisode: (episode) async {
+          throw StateError('server rejected');
+        },
+      );
+
+      await tester.tap(recordIcon(tester));
+      await tester.pumpAndSettle();
+
+      final l10n = AppLocalizations.of(
+        tester.element(find.byType(ShowDetailScreen)),
+      );
+      expect(
+        find.text(l10n.appRecordingFailed('Bad state: server rejected')),
+        findsOneWidget,
+        reason: 'failure SnackBar must surface the thrown error',
+      );
+    },
+  );
+}

--- a/flutter_client/test/features/shows/test_episode_record_action_test.dart
+++ b/flutter_client/test/features/shows/test_episode_record_action_test.dart
@@ -143,7 +143,7 @@ void main() {
       await tester.pump();
       expect(invocations, 1);
 
-      // The request is still in flight — the button is disabled, so a second
+      // The request is still in flight; the button is disabled, so a second
       // tap (or fast double-tap) must not reach the callback again.
       await tester.tap(recordIcon(tester), warnIfMissed: false);
       await tester.pump();

--- a/flutter_client/test/navigation/show_route_contract_test.dart
+++ b/flutter_client/test/navigation/show_route_contract_test.dart
@@ -33,6 +33,12 @@ void main() {
         reason:
             'ShowDetailScreen must receive a non-null onDeleteSeriesRule from ContentActions',
       );
+      expect(
+        source,
+        contains('onScheduleEpisode: actions.onScheduleEpisode'),
+        reason:
+            'ShowDetailScreen must receive a non-null onScheduleEpisode from ContentActions',
+      );
     },
   );
 }

--- a/flutter_client/test/services/dvr_mutation_ownership_test.dart
+++ b/flutter_client/test/services/dvr_mutation_ownership_test.dart
@@ -46,7 +46,12 @@ void main() {
     addTearDown(controller.dispose);
 
     expect(await controller.connectXtream(_accountA), isTrue);
-    final staleSchedule = controller.scheduleDvr(_channel, _program);
+    final staleSchedule = controller.scheduleDvrAiring(
+      channelId: _channel.id,
+      title: _program.title,
+      startTime: _program.start,
+      endTime: _program.end,
+    );
     await transport.scheduleStarted.future;
 
     expect(await controller.connectXtream(_accountB), isTrue);

--- a/flutter_client/test/services/dvr_schedule_airing_test.dart
+++ b/flutter_client/test/services/dvr_schedule_airing_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/aiostreams_favorites_service.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/cache_service.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
+import 'package:m3u_tv/services/resume_service.dart';
+import 'package:m3u_tv/services/reverb_service.dart';
+import 'package:m3u_tv/services/secure_storage.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart';
+import 'package:m3u_tv/services/tv_notification_store.dart';
+import 'package:m3u_tv/services/viewer_service.dart';
+import 'package:m3u_tv/services/xtream_service.dart';
+
+const _credentials = UserCredentials(
+  server: 'https://fixture.invalid',
+  username: 'airing-test',
+  password: 'airing-pass',
+);
+
+final _airingStart = DateTime.utc(2026, 8, 20, 18, 30);
+final _airingEnd = DateTime.utc(2026, 8, 20, 19, 45);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'scheduleDvrAiring posts channel/title/window to schedule_dvr and '
+    'returns the refreshed matching recording',
+    () async {
+      final transport = _AiringTransport();
+      final controller = _controller(transport);
+      addTearDown(controller.dispose);
+
+      expect(await controller.connectXtream(_credentials), isTrue);
+
+      final recording = await controller.scheduleDvrAiring(
+        channelId: 101,
+        title: 'Evening News',
+        startTime: _airingStart,
+        endTime: _airingEnd,
+      );
+
+      expect(transport.scheduleBodies, hasLength(1));
+      final body = transport.scheduleBodies.single;
+      expect(body['channel_id'], '101');
+      expect(body['title'], 'Evening News');
+      expect(body['start_time'], _airingStart.toIso8601String());
+      expect(body['end_time'], _airingEnd.toIso8601String());
+
+      expect(recording, isNotNull);
+      expect(recording!.channelId, 101);
+      expect(recording.title, 'Evening News');
+      // The refreshed list is what the controller now serves.
+      expect(controller.dvrRecordings.single.title, 'Evening News');
+    },
+  );
+
+  test('scheduleDvrAiring propagates schedule_dvr failure', () async {
+    final transport = _AiringTransport()..failSchedule = true;
+    final controller = _controller(transport);
+    addTearDown(controller.dispose);
+
+    expect(await controller.connectXtream(_credentials), isTrue);
+
+    await expectLater(
+      controller.scheduleDvrAiring(
+        channelId: 101,
+        title: 'Evening News',
+        startTime: _airingStart,
+        endTime: _airingEnd,
+      ),
+      throwsA(isA<XtreamDvrScheduleException>()),
+    );
+  });
+}
+
+AppStateController _controller(_AiringTransport transport) {
+  final memory = <String, Object?>{};
+  return AppStateController(
+    xtreamService: XtreamService(
+      transport: transport.call,
+      cache: CacheService(memory: <String, Object?>{}),
+    ),
+    secureStorage: InMemorySecureStorage(),
+    cacheService: CacheService(memory: <String, Object?>{}),
+    favoritesService: FavoritesService(memory: memory),
+    vodFavoritesService: FavoritesService(memory: memory, namespace: 'vod'),
+    seriesFavoritesService: FavoritesService(
+      memory: memory,
+      namespace: 'series',
+    ),
+    aioFavoritesService: AIOStreamsFavoritesService(),
+    resumeService: ResumeService(memory: memory),
+    viewerService: ViewerService(memory: memory),
+    tvNotificationService: _NotificationService(),
+    tvNotificationStore: TvNotificationStore(memory: memory),
+    reverbService: _NoopReverbService(),
+  );
+}
+
+class _AiringTransport {
+  bool failSchedule = false;
+  final List<Map<String, Object?>> scheduleBodies = <Map<String, Object?>>[];
+
+  Future<Object?> call(XtreamRequest request) async {
+    switch (request.action ?? 'auth') {
+      case 'auth':
+        return <String, Object?>{
+          'user_info': <String, Object?>{'auth': 1, 'status': 'Active'},
+          'server_info': <String, Object?>{'timezone': 'UTC'},
+          'm3u_editor': <String, Object?>{
+            'version': '0.10.0',
+            'features': <String>['dvr'],
+          },
+        };
+      case 'get_live_categories':
+      case 'get_vod_categories':
+      case 'get_series_categories':
+      case 'get_live_streams':
+      case 'get_vod_streams':
+      case 'get_series':
+      case 'get_viewers':
+      case 'list_dvr_series_rules':
+        return const <Object?>[];
+      case 'get_dvr_recordings':
+        return <Map<String, Object?>>[
+          <String, Object?>{
+            'uuid': 'rec-airing',
+            'title': 'Evening News',
+            'status': 'scheduled',
+            'channel_id': 101,
+            'scheduled_start': _airingStart.toIso8601String(),
+            'scheduled_end': _airingEnd.toIso8601String(),
+          },
+        ];
+      case 'get_dvr_storage':
+        return <String, Object?>{
+          'used_bytes': 0,
+          'quota_bytes': null,
+          'percent_used': null,
+          'recording_count': 1,
+          'scope': 'account',
+        };
+      case 'schedule_dvr':
+        scheduleBodies.add(Map<String, Object?>.from(request.body));
+        if (failSchedule) {
+          return <String, Object?>{'success': false, 'error': 'slot taken'};
+        }
+        return <String, Object?>{'success': true, 'rule_id': 1};
+      default:
+        throw StateError('No fixture for ${request.action}');
+    }
+  }
+}
+
+class _NotificationService extends TvNotificationService {
+  @override
+  Future<(TvPlaylistSession, List<TvNotificationItem>)> fetchUnread(
+    UserCredentials creds, {
+    List<String>? channels,
+  }) async => const (
+    TvPlaylistSession(
+      notifiableId: 1,
+      notifiableType: 'playlist',
+      isAdmin: false,
+      channelName: '',
+      reverb: ReverbConfig(host: '', port: 0, scheme: 'wss', appKey: ''),
+    ),
+    <TvNotificationItem>[],
+  );
+}
+
+class _NoopReverbService extends ReverbService {
+  @override
+  Future<void> disconnect() async {}
+}


### PR DESCRIPTION
Closes #204.

Adds the ability to schedule a DVR recording for a single airing from
the Shows-DVR detail screen (previously: only "Record Series" was
exposed, which captures every future episode whether the user wants
it or not).

- Threads an `onScheduleEpisode` callback through `ContentActions` →
  go_router → `ShowDetailScreen` → `AppStateController`.
- New `scheduleDvrAiring(channelId, title, startTime, endTime)`
  primitive (backed by m3u-editor's `schedule_dvr`); the old
  `scheduleDvr(Channel, EpgProgram)` is preserved as a thin wrapper.
- Trailing `AppIconButton` on each `_EpisodeRow`, gated on airing-not-
  yet-ended + a per-row double-tap guard.
- 2-key SnackBar pattern (success/failure) — the same keys the existing
  Live TV catchup record flow uses; no new ARB strings.

Also brings the Shows detail screen into style parity with the DVR
section: row radius/gap tokens, title weight, a flat `Material` header
(no Material 3 shadow), a centered empty-state for an empty
`recentEpisodes`, a shared `LeadingTile` widget (promoted out of the
DVR screen, zero behavior change there), and a restructured meta line.
The Record action is kept as a direct `AppIconButton` rather than
wrapped in `RowActionMenu` — that abstraction declutters *multiple*
per-row actions behind a menu, but episode rows only ever have one, so
wrapping it would force a 2-tap interaction for no behavioral gain
(documented inline).

Phase 2 (multi-select scheduling) is deferred — `search_epg_shows`
hard-caps `recent_episodes` at 5 per show server-side (`array_slice`
in `XtreamApiController::searchEpgShows`), so it needs an
`m3u-editor` change first. Related follow-up: m3ue/m3u-tv#207 / server
side m3ue/m3u-editor#1409 (separate scope — EPG episode-name/subtitle
exposure, found during this work but not part of this PR).

## Testing

`dart format --set-exit-if-changed lib test` → clean.
`flutter analyze lib test` → no issues.
`flutter test` on the affected suites → 72/72 pass (widget tests for
the new episode Record action, unit tests for `scheduleDvrAiring`,
route-wiring regression test, plus the full DVR recordings-screen
suite to confirm the `LeadingTile` extraction didn't regress DVR).