### PR TITLE
feat(epg): show episode names once the server exposes them (#207)

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -634,7 +634,7 @@ class AppShellState extends ConsumerState<AppShell>
         context,
         PlayerArgs(
           streamUrl: streamUrl,
-          title: '${channel.name} - ${program.title}',
+          title: '${channel.name} - ${program.displayTitle}',
           type: 'catchup',
           streamId: channel.id,
           startPosition: 0,
@@ -642,7 +642,7 @@ class AppShellState extends ConsumerState<AppShell>
           headers: channel.headers,
           metadata: <String, Object?>{
             'catchup': true,
-            'program_title': program.title,
+            'program_title': program.displayTitle,
             'program_start': program.start.toIso8601String(),
             'program_end': program.end.toIso8601String(),
           },
@@ -660,11 +660,11 @@ class AppShellState extends ConsumerState<AppShell>
       context,
       schedule: () => _appState.scheduleDvrAiring(
         channelId: channel.id,
-        title: program.title,
+        title: program.displayTitle,
         startTime: program.start,
         endTime: program.end,
       ),
-      title: program.title,
+      title: program.displayTitle,
     );
   }
 
@@ -674,7 +674,7 @@ class AppShellState extends ConsumerState<AppShell>
   Future<DvrRecording?> _scheduleDvrAiring(EpgShowEpisode episode) {
     return _appState.scheduleDvrAiring(
       channelId: episode.channelId,
-      title: episode.title,
+      title: episode.displayTitle,
       startTime: episode.startTime,
       endTime: episode.endTime,
     );
@@ -2015,7 +2015,7 @@ class _HomeScreenState extends ConsumerState<_HomeScreen> {
       title: channel.name,
       imageUrl: channel.logoUrl,
       subtitle:
-          epgService.lookupForChannel(channel)?.current.title ??
+          epgService.lookupForChannel(channel)?.current.displayTitle ??
           channel.groupTitle ??
           l.homeLiveChannel,
       fallbackIcon: Icons.live_tv,

--- a/flutter_client/lib/features/epg/epg_screen.dart
+++ b/flutter_client/lib/features/epg/epg_screen.dart
@@ -146,7 +146,7 @@ class _EpgScreenState extends State<EpgScreen> {
                       if (epg != null) ...[
                         const SizedBox(height: 2),
                         Text(
-                          epg.current.title,
+                          epg.current.displayTitle,
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
@@ -185,7 +185,7 @@ class _EpgScreenState extends State<EpgScreen> {
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                         ),
                         Text(
-                          epg!.next!.title,
+                          epg!.next!.displayTitle,
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
@@ -251,7 +251,7 @@ class _EpgScreenState extends State<EpgScreen> {
                     if (epg != null) ...[
                       const SizedBox(height: 4),
                       Text(
-                        epg.current.title,
+                        epg.current.displayTitle,
                         style: Theme.of(context).textTheme.labelSmall,
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -845,7 +845,7 @@ class _ProgramsRow extends StatelessWidget {
                       right: hasCatchup ? 22 : 0,
                     ),
                     child: Text(
-                      p.title,
+                      p.subtitle ?? p.title,
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
                         color: fgColor,
                         fontWeight: isCurrent

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -845,7 +845,7 @@ class _ProgramsRow extends StatelessWidget {
                       right: hasCatchup ? 22 : 0,
                     ),
                     child: Text(
-                      p.subtitle ?? p.title,
+                      p.displayTitle,
                       style: Theme.of(context).textTheme.labelSmall?.copyWith(
                         color: fgColor,
                         fontWeight: isCurrent

--- a/flutter_client/lib/features/live_tv/catchup_shows_dialog.dart
+++ b/flutter_client/lib/features/live_tv/catchup_shows_dialog.dart
@@ -111,7 +111,7 @@ class _CatchupShowsListState extends State<_CatchupShowsList> {
                 final program = programs[index];
                 return _CatchupShowRow(
                   icon: Icons.play_circle_outline,
-                  label: program.title,
+                  label: program.displayTitle,
                   subtitle:
                       '${startFormat.format(program.start.toLocal())} '
                       '– ${endFormat.format(program.end.toLocal())}',

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -795,7 +795,7 @@ class _ChannelRow extends StatelessWidget {
                       if (epg != null) ...[
                         const SizedBox(height: 2),
                         Text(
-                          epg!.current.title,
+                          epg!.current.subtitle ?? epg!.current.title,
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
@@ -845,7 +845,7 @@ class _ChannelRow extends StatelessWidget {
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                         ),
                         Text(
-                          epg!.next!.title,
+                          epg!.next!.subtitle ?? epg!.next!.title,
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -327,7 +327,7 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen> {
                         : AppLocalizations.of(dialogContext).liveTvRecord,
                     subtitle: activeRecording != null
                         ? null
-                        : recordableProgram?.title,
+                        : recordableProgram?.displayTitle,
                     autofocus: true,
                     onTap: () => Navigator.of(
                       dialogContext,
@@ -795,7 +795,7 @@ class _ChannelRow extends StatelessWidget {
                       if (epg != null) ...[
                         const SizedBox(height: 2),
                         Text(
-                          epg!.current.subtitle ?? epg!.current.title,
+                          epg!.current.displayTitle,
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,
@@ -845,7 +845,7 @@ class _ChannelRow extends StatelessWidget {
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                         ),
                         Text(
-                          epg!.next!.subtitle ?? epg!.next!.title,
+                          epg!.next!.displayTitle,
                           style: Theme.of(context).textTheme.bodySmall
                               ?.copyWith(color: colorScheme.onSurfaceVariant),
                           maxLines: 1,

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -1079,9 +1079,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
                         left: overlayLeft,
                         width: overlayWidth,
                         child: EpgOverlay(
-                          currentTitle: _epgData!.current.title,
+                          currentTitle: _epgData!.current.displayTitle,
                           currentProgress: _epgData!.progress,
-                          nextTitle: _epgData?.next?.title,
+                          nextTitle: _epgData?.next?.displayTitle,
                         ),
                       ),
 

--- a/flutter_client/lib/features/shows/show_detail_screen.dart
+++ b/flutter_client/lib/features/shows/show_detail_screen.dart
@@ -541,7 +541,7 @@ class _EpisodeRowState extends State<_EpisodeRow> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    episode.title,
+                    episode.subtitle ?? episode.title,
                     style: theme.textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),

--- a/flutter_client/lib/features/shows/show_detail_screen.dart
+++ b/flutter_client/lib/features/shows/show_detail_screen.dart
@@ -87,7 +87,7 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
       await scheduleDvrWithFeedback(
         context,
         schedule: () => handler(episode),
-        title: episode.title,
+        title: episode.displayTitle,
       );
     } finally {
       if (mounted) {
@@ -541,7 +541,7 @@ class _EpisodeRowState extends State<_EpisodeRow> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    episode.subtitle ?? episode.title,
+                    episode.displayTitle,
                     style: theme.textTheme.titleMedium?.copyWith(
                       fontWeight: FontWeight.w600,
                     ),

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -785,6 +785,10 @@ class EpgProgram {
   /// exposes one (see m3u-editor #1410). Distinct from [title]; null when
   /// absent so display sites can fall back to [title].
   final String? subtitle;
+
+  /// The episode name when available, otherwise the show title. Prefer this
+  /// over reading [title] directly at any display or persistence site.
+  String get displayTitle => subtitle ?? title;
 }
 
 class EpgCurrentNext {
@@ -1210,6 +1214,10 @@ class EpgShowEpisode {
   /// from [title]; null when absent so display sites can fall back to [title].
   final String? subtitle;
 
+  /// The episode name when available, otherwise the show title. Prefer this
+  /// over reading [title] directly at any display or persistence site.
+  String get displayTitle => subtitle ?? title;
+
   factory EpgShowEpisode.fromXtream(Map<String, Object?> json) {
     int? asIntOrNull(Object? v) {
       if (v == null) return null;
@@ -1231,7 +1239,7 @@ class EpgShowEpisode {
       season: asIntOrNull(json['season']),
       episode: asIntOrNull(json['episode']),
       description: json['description'] as String?,
-      subtitle: _nullIfBlank(json['subtitle'] as String?),
+      subtitle: nullIfBlank(_asNullableString(json['subtitle'])),
     );
   }
 }
@@ -1403,5 +1411,5 @@ String? _yearFromDate(String? value) {
 /// Treats `null` and blank/whitespace-only strings as "absent" so optional
 /// fields fall back cleanly at the display site without leaking the upstream
 /// `''` placeholder.
-String? _nullIfBlank(String? value) =>
+String? nullIfBlank(String? value) =>
     (value == null || value.trim().isEmpty) ? null : value;

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -772,6 +772,7 @@ class EpgProgram {
     required this.description,
     required this.start,
     required this.end,
+    this.subtitle,
   });
 
   final String channelId;
@@ -779,6 +780,11 @@ class EpgProgram {
   final String description;
   final DateTime start;
   final DateTime end;
+
+  /// Episode-name / programme-episode subtitle, when the upstream source
+  /// exposes one (see m3u-editor #1410). Distinct from [title]; null when
+  /// absent so display sites can fall back to [title].
+  final String? subtitle;
 }
 
 class EpgCurrentNext {
@@ -1188,6 +1194,7 @@ class EpgShowEpisode {
     this.season,
     this.episode,
     this.description,
+    this.subtitle,
   });
 
   final int channelId;
@@ -1198,6 +1205,10 @@ class EpgShowEpisode {
   final int? season;
   final int? episode;
   final String? description;
+
+  /// Episode name from `search_epg_shows.recent_episodes[].subtitle`. Distinct
+  /// from [title]; null when absent so display sites can fall back to [title].
+  final String? subtitle;
 
   factory EpgShowEpisode.fromXtream(Map<String, Object?> json) {
     int? asIntOrNull(Object? v) {
@@ -1220,6 +1231,7 @@ class EpgShowEpisode {
       season: asIntOrNull(json['season']),
       episode: asIntOrNull(json['episode']),
       description: json['description'] as String?,
+      subtitle: _nullIfBlank(json['subtitle'] as String?),
     );
   }
 }
@@ -1387,3 +1399,9 @@ String? _yearFromDate(String? value) {
   final match = RegExp(r'\d{4}').firstMatch(value);
   return match?.group(0);
 }
+
+/// Treats `null` and blank/whitespace-only strings as "absent" so optional
+/// fields fall back cleanly at the display site without leaking the upstream
+/// `''` placeholder.
+String? _nullIfBlank(String? value) =>
+    (value == null || value.trim().isEmpty) ? null : value;

--- a/flutter_client/lib/services/xtream_service.dart
+++ b/flutter_client/lib/services/xtream_service.dart
@@ -1481,9 +1481,7 @@ EpgProgram? _epgProgramFromMap(
     ),
     start: start,
     end: end,
-    subtitle: _nullIfBlank(
-      _decodeBase64WhenApplicable(_stringOrNull(json['subtitle']) ?? ''),
-    ),
+    subtitle: _decodedSubtitle(json['subtitle']),
   );
 }
 
@@ -1516,11 +1514,21 @@ DateTime _fromEpoch(int value) {
   return DateTime.fromMillisecondsSinceEpoch(milliseconds, isUtc: true);
 }
 
+final _base64LikeText = RegExp(r'^[A-Za-z0-9+/]+={0,2}$');
+
+/// True if [text] contains a control character other than tab/LF/CR. Real
+/// programme text never contains these, but short all-letter plain-text
+/// values (e.g. a one-word episode subtitle like "GAME") can coincidentally
+/// satisfy the base64 shape check and "decode" into byte garbage, so this
+/// gate rejects that outcome and falls back to the original plain text.
+bool _hasControlCharacters(String text) => text.codeUnits.any(
+  (unit) => unit < 0x20 && unit != 0x09 && unit != 0x0A && unit != 0x0D,
+);
+
 String _decodeBase64WhenApplicable(String value) {
   if (value.isEmpty) return value;
   final text = value.trim();
-  if (text.length % 4 != 0 ||
-      !RegExp(r'^[A-Za-z0-9+/]+={0,2}$').hasMatch(text)) {
+  if (text.length % 4 != 0 || !_base64LikeText.hasMatch(text)) {
     return value;
   }
   try {
@@ -1529,7 +1537,8 @@ String _decodeBase64WhenApplicable(String value) {
       base64.decode(normalized),
       allowMalformed: false,
     );
-    return decoded.isEmpty ? value : decoded;
+    if (decoded.isEmpty || _hasControlCharacters(decoded)) return value;
+    return decoded;
   } on FormatException {
     return value;
   }
@@ -1556,8 +1565,7 @@ String? _stringOrNull(Object? value) {
   return text.isEmpty ? null : text;
 }
 
-/// Treats `null` and blank/whitespace-only strings as "absent" so optional
-/// fields fall back cleanly at the display site without leaking the upstream
-/// `''` placeholder.
-String? _nullIfBlank(String? value) =>
-    (value == null || value.trim().isEmpty) ? null : value;
+String? _decodedSubtitle(Object? value) {
+  final raw = _stringOrNull(value);
+  return raw == null ? null : nullIfBlank(_decodeBase64WhenApplicable(raw));
+}

--- a/flutter_client/lib/services/xtream_service.dart
+++ b/flutter_client/lib/services/xtream_service.dart
@@ -1481,6 +1481,9 @@ EpgProgram? _epgProgramFromMap(
     ),
     start: start,
     end: end,
+    subtitle: _nullIfBlank(
+      _decodeBase64WhenApplicable(_stringOrNull(json['subtitle']) ?? ''),
+    ),
   );
 }
 
@@ -1552,3 +1555,9 @@ String? _stringOrNull(Object? value) {
   final text = '$value';
   return text.isEmpty ? null : text;
 }
+
+/// Treats `null` and blank/whitespace-only strings as "absent" so optional
+/// fields fall back cleanly at the display site without leaking the upstream
+/// `''` placeholder.
+String? _nullIfBlank(String? value) =>
+    (value == null || value.trim().isEmpty) ? null : value;

--- a/flutter_client/test/features/shows/test_episode_subtitle_test.dart
+++ b/flutter_client/test/features/shows/test_episode_subtitle_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/shows/show_detail_screen.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  EpgShowEpisode episode({String? subtitle}) => EpgShowEpisode(
+    channelId: 8,
+    channelName: 'Channel Eight',
+    title: 'Show Title',
+    subtitle: subtitle,
+    startTime: DateTime.utc(2026, 1, 1, 12),
+    endTime: DateTime.utc(2026, 1, 1, 13),
+  );
+
+  EpgShow testShow(List<EpgShowEpisode> episodes) => EpgShow(
+    normalizedTitle: 'wired show',
+    displayTitle: 'Wired Show',
+    channelCount: 1,
+    channels: const [
+      EpgShowChannel(channelId: 8, channelName: 'Channel Eight'),
+    ],
+    episodeCount: episodes.length,
+    recentEpisodes: episodes,
+  );
+
+  Future<void> pumpScreen(WidgetTester tester, EpgShow show) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [dvrSeriesRulesProvider.overrideWith((_) => const [])],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ShowDetailScreen(show: show),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'renders episode subtitle when present, hiding the show title',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        testShow([episode(subtitle: 'Episode 1: Pilot')]),
+      );
+
+      expect(find.text('Episode 1: Pilot'), findsOneWidget);
+      expect(find.text('Show Title'), findsNothing);
+    },
+  );
+
+  testWidgets('falls back to show title when subtitle is null', (tester) async {
+    await pumpScreen(tester, testShow([episode()]));
+
+    expect(find.text('Show Title'), findsOneWidget);
+    expect(find.text('Episode 1: Pilot'), findsNothing);
+  });
+}

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -235,5 +235,14 @@ void main() {
       final ep = EpgShowEpisode.fromXtream(baseJson(subtitle: '   '));
       expect(ep.subtitle, isNull);
     });
+
+    test(
+      'subtitle with an unexpected non-string JSON type is coerced instead '
+      'of throwing',
+      () {
+        final ep = EpgShowEpisode.fromXtream(baseJson(subtitle: 42));
+        expect(ep.subtitle, '42');
+      },
+    );
   });
 }

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -192,4 +192,48 @@ void main() {
       expect(info.percentUsed, 90.0);
     });
   });
+
+  // `search_epg_shows.recent_episodes[].subtitle` is plain text (not base64).
+  // The client treats `null` and blank/whitespace-only as "absent" so the
+  // display site can safely fall back to `title` via `subtitle ?? title`.
+  group('EpgShowEpisode.fromXtream subtitle handling', () {
+    Map<String, Object?> baseJson({Object? subtitle, bool includeKey = true}) {
+      final json = <String, Object?>{
+        'channel_id': 1,
+        'title': 'Show Title',
+        'start_time': '2026-01-01T00:00:00Z',
+        'end_time': '2026-01-01T01:00:00Z',
+      };
+      if (includeKey) json['subtitle'] = subtitle;
+      return json;
+    }
+
+    test('subtitle present is parsed verbatim', () {
+      final ep = EpgShowEpisode.fromXtream(baseJson(subtitle: 'Episode Name'));
+      expect(ep.subtitle, 'Episode Name');
+    });
+
+    test('subtitle null maps to null', () {
+      final ep = EpgShowEpisode.fromXtream(baseJson());
+      expect(ep.subtitle, isNull);
+    });
+
+    test('subtitle absent key maps to null', () {
+      final ep = EpgShowEpisode.fromXtream(baseJson(includeKey: false));
+      expect(ep.subtitle, isNull);
+    });
+
+    test(
+      'subtitle empty string maps to null (server "absent" placeholder)',
+      () {
+        final ep = EpgShowEpisode.fromXtream(baseJson(subtitle: ''));
+        expect(ep.subtitle, isNull);
+      },
+    );
+
+    test('subtitle whitespace-only string maps to null', () {
+      final ep = EpgShowEpisode.fromXtream(baseJson(subtitle: '   '));
+      expect(ep.subtitle, isNull);
+    });
+  });
 }

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -1119,6 +1119,50 @@ void main() {
         expect(programs[3].subtitle, 'Real Episode');
       },
     );
+
+    test(
+      'plain-text subtitle that coincidentally looks like base64 is not '
+      'corrupted by the base64 decode heuristic',
+      () async {
+        final now = DateTime.utc(2026, 1, 1, 12);
+        final service = XtreamService(
+          transport: FakeXtreamTransport({
+            'auth': xtreamAuth(auth: 1),
+            'get_epg_batch': <String, Object?>{
+              '300': <Map<String, Object?>>[
+                <String, Object?>{
+                  'stream_id': 300,
+                  'channel_id': 'channel-key',
+                  'title': 'Plain Title',
+                  'subtitle': 'GAME',
+                  'description': 'Plain desc',
+                  'start': now.toIso8601String(),
+                  'end': now.add(const Duration(minutes: 30)).toIso8601String(),
+                },
+              ],
+            },
+          }).call,
+        );
+        await service.authenticate(
+          const UserCredentials(
+            server: 'https://xtream.example',
+            username: 'demo',
+            password: 'secret',
+          ),
+        );
+
+        final programs = await service.getEpgBatch(const <Channel>[
+          Channel(
+            id: 300,
+            name: 'Channel',
+            streamUrl: 'https://example/live/300.m3u8',
+            epgChannelId: 'channel-key',
+          ),
+        ]);
+
+        expect(programs.single.subtitle, 'GAME');
+      },
+    );
   });
 
   group('Local state services', () {

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -834,6 +834,7 @@ void main() {
               {
                 'stream_id': 101,
                 'title': base64Encode(utf8.encode('Midday News')),
+                'subtitle': base64Encode(utf8.encode('Midday News Episode')),
                 'description': base64Encode(utf8.encode('Fixture bulletin')),
                 'start_timestamp':
                     now
@@ -883,7 +884,9 @@ void main() {
       expect(programs, hasLength(2));
       expect(midday.channelId, 'bbc.one');
       expect(midday.description, 'Fixture bulletin');
+      expect(midday.subtitle, 'Midday News Episode');
       expect(afternoon.channelId, 'bbc.one');
+      expect(afternoon.subtitle, isNull);
     });
 
     test('EPG batch chunks requests to at most 100 stream ids', () async {
@@ -1006,6 +1009,7 @@ void main() {
                   'stream_id': 101,
                   'channel_id': 'm3u-editor-channel-key',
                   'title': 'Plain Short EPG Title',
+                  'subtitle': 'Plain Short EPG Subtitle',
                   'description': 'Plain short EPG description',
                   'start': now.toIso8601String(),
                   'end': now.add(const Duration(minutes: 30)).toIso8601String(),
@@ -1033,7 +1037,86 @@ void main() {
 
         expect(programs.single.channelId, 'stale-channel-key');
         expect(programs.single.title, 'Plain Short EPG Title');
+        expect(programs.single.subtitle, 'Plain Short EPG Subtitle');
         expect(programs.single.description, 'Plain short EPG description');
+      },
+    );
+
+    test(
+      'EPG programs with absent or blank subtitle parse as null',
+      () async {
+        final now = DateTime.utc(2026, 1, 1, 12);
+        final service = XtreamService(
+          transport: FakeXtreamTransport({
+            'auth': xtreamAuth(auth: 1),
+            'get_epg_batch': <String, Object?>{
+              '200': <Map<String, Object?>>[
+                <String, Object?>{
+                  'stream_id': 200,
+                  'channel_id': 'channel-key',
+                  'title': 'Plain Title 1',
+                  'subtitle': null,
+                  'description': 'Plain desc',
+                  'start': now.toIso8601String(),
+                  'end': now.add(const Duration(minutes: 30)).toIso8601String(),
+                },
+                <String, Object?>{
+                  'stream_id': 201,
+                  'channel_id': 'channel-key',
+                  'title': 'Plain Title 2',
+                  'subtitle': '',
+                  'description': 'Plain desc',
+                  'start': now.toIso8601String(),
+                  'end': now.add(const Duration(minutes: 30)).toIso8601String(),
+                },
+                <String, Object?>{
+                  'stream_id': 202,
+                  'channel_id': 'channel-key',
+                  'title': 'Plain Title 3',
+                  'subtitle': '   ',
+                  'description': 'Plain desc',
+                  'start': now.toIso8601String(),
+                  'end': now.add(const Duration(minutes: 30)).toIso8601String(),
+                },
+                <String, Object?>{
+                  'stream_id': 203,
+                  'channel_id': 'channel-key',
+                  'title': 'Plain Title 4',
+                  'subtitle': 'Real Episode',
+                  'description': 'Plain desc',
+                  'start': now.toIso8601String(),
+                  'end': now.add(const Duration(minutes: 30)).toIso8601String(),
+                },
+              ],
+            },
+          }).call,
+        );
+        await service.authenticate(
+          const UserCredentials(
+            server: 'https://xtream.example',
+            username: 'demo',
+            password: 'secret',
+          ),
+        );
+
+        final programs = await service.getEpgBatch(const <Channel>[
+          Channel(
+            id: 200,
+            name: 'Channel',
+            streamUrl: 'https://example/live/200.m3u8',
+            epgChannelId: 'channel-key',
+          ),
+        ]);
+
+        expect(programs, hasLength(4));
+        expect(programs[0].subtitle, isNull, reason: 'null value');
+        expect(
+          programs[1].subtitle,
+          isNull,
+          reason: 'empty string placeholder',
+        );
+        expect(programs[2].subtitle, isNull, reason: 'whitespace-only');
+        expect(programs[3].subtitle, 'Real Episode');
       },
     );
   });


### PR DESCRIPTION
Closes #207.

> **Stacked on #208.** This branch builds on `feat/204-schedule-single-airing` (not raw `dev`) since it touches `_EpisodeRow`, which #208 already restructured, and I don't have write access to push an intermediate base branch to this repo for a cleaner stacked-PR view. Until #208 merges, this PR's diff includes #208's commit too — the actual change for #207 is the single commit `feat(epg): show episode names once the server exposes them (#207)`. Please review/merge #208 first, or just look at that one commit here.

## What this does

`m3u-editor` now sends an EPG programme's `subtitle` (the episode
name, distinct from the show title — e.g. "Groundhog Day" for a *The
Bear* airing) on `search_epg_shows`, `get_short_epg`, and
`get_epg_batch` (m3ue/m3u-editor#1410, merging soon). This wires the
client up to consume and display it.

- `EpgProgram` and `EpgShowEpisode` gain a nullable `subtitle` field.
- `_epgProgramFromMap` (the shared parse path for `get_short_epg` and
  `get_epg_batch`) decodes it through the existing
  `_decodeBase64WhenApplicable` helper, which already auto-detects
  plain vs. base64 — one line covers both endpoints despite their
  differing encodings. `EpgShowEpisode.fromXtream` parses the plain
  `search_epg_shows` field directly.
- A small `_nullIfBlank` helper treats `null` and blank/whitespace-only
  strings as absent, since the two cache-backed endpoints send `''`
  for "no subtitle" rather than omitting the key.
- Four display sites fall back to `subtitle ?? title`: the Shows-search
  episode row (the original motivating case — every episode was
  showing the identical show title), the Live TV now/next labels, and
  the EPG grid timeline block.

No new UI surface, no layout changes — existing single-line `Text`
widgets, just fed a different string with a safe fallback when the
upstream source has no subtitle for a given airing.

## Testing

`flutter analyze lib test` clean. `dart format --set-exit-if-changed`
clean. Extended `service_contract_test.dart`'s existing base64/plain
EPG fixtures with `subtitle` assertions, added null/blank/whitespace
parsing coverage in `domain_models_test.dart`, and a new widget test
(`test_episode_subtitle_test.dart`) confirming the Shows-search episode
row shows the subtitle when present and falls back to the show title
when absent.