### PR TITLE
fix(catchup): interpret retention duration as hours

### DIFF
--- a/flutter_client/lib/features/epg/epg_screen.dart
+++ b/flutter_client/lib/features/epg/epg_screen.dart
@@ -139,7 +139,11 @@ class _EpgScreenState extends State<EpgScreen> {
                           ),
                           if (channel.catchupSupported) ...[
                             const SizedBox(width: 6),
-                            CatchupBadge(days: channel.catchupDays),
+                            CatchupBadge(
+                              days: channel.catchupDays == 0
+                                  ? null
+                                  : channel.catchupDays,
+                            ),
                           ],
                         ],
                       ),
@@ -246,7 +250,11 @@ class _EpgScreenState extends State<EpgScreen> {
                     ),
                     if (channel.catchupSupported) ...[
                       const SizedBox(height: 4),
-                      CatchupBadge(days: channel.catchupDays),
+                      CatchupBadge(
+                        days: channel.catchupDays == 0
+                            ? null
+                            : channel.catchupDays,
+                      ),
                     ],
                     if (epg != null) ...[
                       const SizedBox(height: 4),

--- a/flutter_client/lib/features/epg/timeline_epg_view.dart
+++ b/flutter_client/lib/features/epg/timeline_epg_view.dart
@@ -179,14 +179,25 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
   DateTime _offsetDate(DateTime value, int days) =>
       DateTime(value.year, value.month, value.day + days);
 
-  int get _maxCatchupDays => widget.channels
-      .map(
-        (channel) => EpgService.effectiveCatchupRetentionDays(
-          channel.catchupSupported,
-          channel.catchupDays,
-        ),
-      )
-      .fold(0, math.max);
+  int _catchupNavigationDays(Channel channel) {
+    final retentionHours = channel.catchupRetentionHours;
+    if (retentionHours != null) {
+      return channel.catchupSupported && retentionHours > 0
+          ? retentionHours ~/ Duration.hoursPerDay
+          : 0;
+    }
+    return EpgService.effectiveCatchupRetentionDays(
+      channel.catchupSupported,
+      channel.catchupDays,
+    );
+  }
+
+  int get _maxCatchupDays =>
+      widget.channels.map(_catchupNavigationDays).fold(0, math.max);
+
+  bool _canReplay(Channel channel, EpgProgram program, DateTime now) {
+    return EpgService.canReplayForChannel(channel, program, now);
+  }
 
   void _selectDate(DateTime date) {
     final today = _dateOnly(widget.clock());
@@ -430,6 +441,9 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
                                     totalWidth: _totalW,
                                     rowHeight: _kRowH,
                                     catchupRetentionDays: catchupRetentionDays,
+                                    catchupRetentionHours:
+                                        channel.catchupRetentionHours,
+                                    catchupSupported: channel.catchupSupported,
                                     now: now,
                                     // Curry the row's channel in: _ProgramsRow
                                     // only sees programmes, but resolving a
@@ -438,8 +452,8 @@ class _TimelineEpgViewState extends State<TimelineEpgView> {
                                     recordingStateFor: (program) => widget
                                         .recordingStateFor(channel, program),
                                     onTap: (program) {
-                                      final canReplay = EpgService.canReplay(
-                                        catchupRetentionDays,
+                                      final canReplay = _canReplay(
+                                        channel,
                                         program,
                                         widget.clock(),
                                       );
@@ -658,7 +672,9 @@ class _ChannelCell extends StatelessWidget {
           ),
           if (channel.catchupSupported) ...[
             const SizedBox(width: 4),
-            CatchupBadge(days: channel.catchupDays),
+            CatchupBadge(
+              days: channel.catchupDays == 0 ? null : channel.catchupDays,
+            ),
           ],
         ],
       ),
@@ -753,6 +769,8 @@ class _ProgramsRow extends StatelessWidget {
     required this.rowHeight,
     required this.onTap,
     required this.catchupRetentionDays,
+    this.catchupRetentionHours,
+    required this.catchupSupported,
     required this.now,
     this.onLongPress,
     this.recordingStateFor = _noRecordingState,
@@ -766,6 +784,8 @@ class _ProgramsRow extends StatelessWidget {
   final double rowHeight;
   final void Function(EpgProgram program) onTap;
   final int catchupRetentionDays;
+  final int? catchupRetentionHours;
+  final bool catchupSupported;
   final DateTime now;
 
   /// Opens the favorite/record context menu for the pressed block.
@@ -779,8 +799,15 @@ class _ProgramsRow extends StatelessWidget {
   static EpgRecordingState _noRecordingState(EpgProgram _) =>
       EpgRecordingState.none;
 
-  bool showCatchupIcon(EpgProgram program) =>
-      EpgService.canReplay(catchupRetentionDays, program, now);
+  bool showCatchupIcon(EpgProgram program) {
+    return EpgService.canReplayForRetention(
+      catchupSupported: catchupSupported,
+      catchupDays: catchupRetentionDays,
+      catchupRetentionHours: catchupRetentionHours,
+      program: program,
+      now: now,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/flutter_client/lib/services/cache_service.dart
+++ b/flutter_client/lib/services/cache_service.dart
@@ -170,7 +170,12 @@ Object? _decodeCacheData(String key, Object? raw) {
               epgChannelId: _nullableString(json['epg_channel_id']),
               tvgName: _nullableString(json['tvg_name']),
               catchupSupported: _asBool(json['catchup_supported']),
-              catchupDays: _asIntOrNull(json['catchup_days']),
+              catchupDays: json.containsKey('catchup_days')
+                  ? _positiveIntOrNull(json['catchup_days']) ?? 0
+                  : null,
+              catchupRetentionHours: json.containsKey('catchup_retention_hours')
+                  ? _positiveIntOrNull(json['catchup_retention_hours']) ?? 0
+                  : null,
               catchupSource: _nullableString(json['catchup_source']),
             );
           })
@@ -221,6 +226,8 @@ Map<String, Object?> _channelToJson(Channel channel) => <String, Object?>{
   if (channel.tvgName != null) 'tvg_name': channel.tvgName,
   if (channel.catchupSupported) 'catchup_supported': channel.catchupSupported,
   if (channel.catchupDays != null) 'catchup_days': channel.catchupDays,
+  if (channel.catchupRetentionHours != null)
+    'catchup_retention_hours': channel.catchupRetentionHours,
   if (channel.catchupSource != null) 'catchup_source': channel.catchupSource,
 };
 
@@ -253,6 +260,11 @@ int? _asIntOrNull(Object? value) {
   if (value is int) return value;
   if (value is num) return value.toInt();
   return int.tryParse('$value');
+}
+
+int? _positiveIntOrNull(Object? value) {
+  final parsed = _asIntOrNull(value);
+  return parsed != null && parsed > 0 ? parsed : null;
 }
 
 double? _asDouble(Object? value) =>

--- a/flutter_client/lib/services/cache_service.dart
+++ b/flutter_client/lib/services/cache_service.dart
@@ -174,7 +174,10 @@ Object? _decodeCacheData(String key, Object? raw) {
                   ? _positiveIntOrNull(json['catchup_days']) ?? 0
                   : null,
               catchupRetentionHours: json.containsKey('catchup_retention_hours')
-                  ? _positiveIntOrNull(json['catchup_retention_hours']) ?? 0
+                  ? validCatchupRetentionHours(
+                          json['catchup_retention_hours'],
+                        ) ??
+                        0
                   : null,
               catchupSource: _nullableString(json['catchup_source']),
             );

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -72,6 +72,7 @@ class Channel {
     this.headers = const {},
     this.catchupSupported = false,
     this.catchupDays,
+    this.catchupRetentionHours,
     this.catchupSource,
   });
 
@@ -86,15 +87,24 @@ class Channel {
   final Map<String, String> headers;
   final bool catchupSupported;
   final int? catchupDays;
+  final int? catchupRetentionHours;
   final String? catchupSource;
 
   factory Channel.fromXtream(Map<String, Object?> json, String streamUrl) {
     final catchupSource = _asNullableString(json['catchup_source']);
-    final catchupDays = _asIntOrNull(
-      json['tv_archive_duration'] ??
-          json['catchup_days'] ??
-          json['catchup-days'],
-    );
+    final hasCatchupDays =
+        json.containsKey('catchup_days') || json.containsKey('catchup-days');
+    final catchupRetentionHours =
+        !hasCatchupDays &&
+            (json.containsKey('tv_archive_duration') ||
+                _asBool(json['tv_archive']))
+        ? _positiveIntOrNull(json['tv_archive_duration']) ?? 0
+        : null;
+    final catchupDays = hasCatchupDays
+        ? _positiveIntOrNull(json['catchup_days'] ?? json['catchup-days']) ?? 0
+        : catchupRetentionHours == null
+        ? null
+        : catchupRetentionHours ~/ Duration.hoursPerDay;
     final catchupType = _asNullableString(json['catchup']);
     final hasCatchupType = catchupType != null && catchupType != '0';
     final catchupSupported =
@@ -108,6 +118,7 @@ class Channel {
       epgChannelId: _asNullableString(json['epg_channel_id']),
       catchupSupported: catchupSupported,
       catchupDays: catchupDays,
+      catchupRetentionHours: catchupRetentionHours,
       catchupSource: catchupSource,
     );
   }
@@ -1314,6 +1325,11 @@ int? _asIntOrNull(Object? value) {
   if (value is int) return value;
   if (value is num) return value.toInt();
   return int.tryParse('$value');
+}
+
+int? _positiveIntOrNull(Object? value) {
+  final parsed = _asIntOrNull(value);
+  return parsed != null && parsed > 0 ? parsed : null;
 }
 
 double? _asDoubleOrNull(Object? value) {

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -3,6 +3,7 @@
 enum ContentType { live, vod, episode, aiostreams }
 
 final RegExp _schemePattern = RegExp('^[a-zA-Z][a-zA-Z0-9+.-]*://');
+const int kMaximumCatchupRetentionHours = 24 * 365 * 100;
 
 /// Strips trailing slashes and, if [server] has no explicit URI scheme
 /// (e.g. a bare `192.168.1.10:8080` typed on a TV remote), prefixes it with
@@ -98,7 +99,7 @@ class Channel {
         !hasCatchupDays &&
             (json.containsKey('tv_archive_duration') ||
                 _asBool(json['tv_archive']))
-        ? _positiveIntOrNull(json['tv_archive_duration']) ?? 0
+        ? validCatchupRetentionHours(json['tv_archive_duration']) ?? 0
         : null;
     final catchupDays = hasCatchupDays
         ? _positiveIntOrNull(json['catchup_days'] ?? json['catchup-days']) ?? 0
@@ -1330,6 +1331,17 @@ int? _asIntOrNull(Object? value) {
 int? _positiveIntOrNull(Object? value) {
   final parsed = _asIntOrNull(value);
   return parsed != null && parsed > 0 ? parsed : null;
+}
+
+int? validCatchupRetentionHours(Object? value) {
+  final parsed = value is int
+      ? value
+      : value is String
+      ? int.tryParse(value)
+      : null;
+  return parsed != null && parsed > 0 && parsed <= kMaximumCatchupRetentionHours
+      ? parsed
+      : null;
 }
 
 double? _asDoubleOrNull(Object? value) {

--- a/flutter_client/lib/services/epg_service.dart
+++ b/flutter_client/lib/services/epg_service.dart
@@ -46,6 +46,44 @@ class EpgService extends ChangeNotifier {
     return !program.start.isBefore(earliest);
   }
 
+  static bool canReplayForChannel(
+    Channel channel,
+    EpgProgram program,
+    DateTime now,
+  ) => canReplayForRetention(
+    catchupSupported: channel.catchupSupported,
+    catchupDays: channel.catchupDays,
+    catchupRetentionHours: channel.catchupRetentionHours,
+    program: program,
+    now: now,
+  );
+
+  static bool canReplayForRetention({
+    required bool catchupSupported,
+    required int? catchupDays,
+    required int? catchupRetentionHours,
+    required EpgProgram program,
+    required DateTime now,
+  }) {
+    final retentionHours = catchupRetentionHours;
+    if (retentionHours != null) {
+      return catchupSupported &&
+          retentionHours > 0 &&
+          program.end.isBefore(now) &&
+          !program.start.isBefore(
+            now.subtract(Duration(hours: retentionHours)),
+          );
+    }
+    return canReplay(
+      effectiveCatchupRetentionDays(
+        catchupSupported,
+        catchupDays,
+      ),
+      program,
+      now,
+    );
+  }
+
   final Clock _clock;
   static const retryBackoff = Duration(minutes: 1);
   Duration cacheTtl;
@@ -274,14 +312,9 @@ class EpgService extends ChangeNotifier {
   /// Returns [channel]'s replayable catchup programs, most-recent-first.
   /// Empty if the channel doesn't support catchup or none currently qualify.
   List<EpgProgram> catchupProgramsForChannel(Channel channel) {
-    final retentionDays = effectiveCatchupRetentionDays(
-      channel.catchupSupported,
-      channel.catchupDays,
-    );
-    if (retentionDays <= 0) return const <EpgProgram>[];
     final programs = programsForChannel(
       channel,
-    ).where((p) => canReplay(retentionDays, p, now)).toList();
+    ).where((p) => canReplayForChannel(channel, p, now)).toList();
     return programs.reversed.toList();
   }
 

--- a/flutter_client/test/fixtures/m3u_editor_live_stream_payload.dart
+++ b/flutter_client/test/fixtures/m3u_editor_live_stream_payload.dart
@@ -1,0 +1,16 @@
+const m3uEditorLiveStreamPayload = <String, Object?>{
+  'num': 1,
+  'name': 'CNN HD',
+  'stream_type': 'live',
+  'stream_id': '12345',
+  'stream_icon': 'https://example.com/logos/cnn.png',
+  'epg_channel_id': 'cnn.us',
+  'added': '1640995200',
+  'category_id': '1',
+  'category_ids': <int>[1],
+  'tv_archive': 1,
+  'tv_archive_duration': 24,
+  'custom_sid': 'cnn-hd',
+  'thumbnail': 'https://example.com/logos/cnn.png',
+  'direct_source': '',
+};

--- a/flutter_client/test/services/epg_service_test.dart
+++ b/flutter_client/test/services/epg_service_test.dart
@@ -10,6 +10,7 @@ void main() {
   Channel channel({
     bool catchupSupported = true,
     int? catchupDays,
+    int? catchupRetentionHours,
     String name = 'Test Channel',
   }) => Channel(
     id: 1,
@@ -17,6 +18,7 @@ void main() {
     streamUrl: 'https://streams.example/live/1.m3u8',
     catchupSupported: catchupSupported,
     catchupDays: catchupDays,
+    catchupRetentionHours: catchupRetentionHours,
   );
 
   EpgProgram program(
@@ -106,6 +108,29 @@ void main() {
       final results = service.catchupProgramsForChannel(ch);
       expect(results, hasLength(1));
       expect(results.single.start, earliest);
+    });
+
+    test('uses precise hour retention when it is available', () {
+      final service = serviceAt(fixedNow);
+      final ch = channel(catchupDays: 7, catchupRetentionHours: 4);
+      final expired = program(
+        ch.name,
+        title: 'Expired',
+        start: fixedNow.subtract(const Duration(hours: 5)),
+        end: fixedNow.subtract(const Duration(hours: 4)),
+      );
+      final available = program(
+        ch.name,
+        title: 'Available',
+        start: fixedNow.subtract(const Duration(hours: 3)),
+        end: fixedNow.subtract(const Duration(hours: 2)),
+      );
+      service.loadPrograms([expired, available]);
+
+      expect(
+        service.catchupProgramsForChannel(ch).map((p) => p.title),
+        ['Available'],
+      );
     });
 
     test(

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -264,6 +264,13 @@ void main() {
     });
 
     test('live streams fail closed for invalid catchup retention metadata', () {
+      final missingHoursPayload = Map<String, Object?>.from(
+        m3uEditorLiveStreamPayload,
+      )..remove('tv_archive_duration');
+      final missingHours = Channel.fromXtream(
+        missingHoursPayload,
+        'https://streams.example/live/100.m3u8',
+      );
       final invalidHours = Channel.fromXtream({
         ...m3uEditorLiveStreamPayload,
         'tv_archive_duration': 'bad',
@@ -283,6 +290,8 @@ void main() {
 
       expect(invalidHours.catchupRetentionHours, 0);
       expect(invalidHours.catchupDays, 0);
+      expect(missingHours.catchupRetentionHours, 0);
+      expect(missingHours.catchupDays, 0);
       expect(nullHours.catchupRetentionHours, 0);
       expect(nullHours.catchupDays, 0);
       expect(zeroHours.catchupRetentionHours, 0);

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -313,6 +313,66 @@ void main() {
       expect(negativeDays.catchupDays, 0);
     });
 
+    test('live streams reject fractional and unsafe archive duration metadata', () {
+      // Given: archive durations include fractional, unsafe, and normal values.
+      final fractional = Channel.fromXtream(const {
+        'stream_id': 105,
+        'name': 'Fractional Hours',
+        'tv_archive': 1,
+        'tv_archive_duration': 1.9,
+      }, 'https://streams.example/live/105.m3u8');
+      final oversized = Channel.fromXtream(const {
+        'stream_id': 106,
+        'name': 'Oversized Hours',
+        'tv_archive': 1,
+        'tv_archive_duration': 2562047788015214,
+      }, 'https://streams.example/live/106.m3u8');
+      final maximum = Channel.fromXtream(const {
+        'stream_id': 107,
+        'name': 'Maximum Hours',
+        'tv_archive': 1,
+        'tv_archive_duration': 9223372036854775807,
+      }, 'https://streams.example/live/107.m3u8');
+      final normal = [1, 25, 48, 72].map(
+        (hours) => Channel.fromXtream({
+          'stream_id': 107 + hours,
+          'name': 'Normal $hours Hours',
+          'tv_archive': 1,
+          'tv_archive_duration': hours,
+        }, 'https://streams.example/live/${107 + hours}.m3u8'),
+      );
+      final dayKey = Channel.fromXtream(const {
+        'stream_id': 200,
+        'name': 'Explicit Days',
+        'tv_archive': 1,
+        'tv_archive_duration': 48,
+        'catchup_days': 3,
+      }, 'https://streams.example/live/200.m3u8');
+
+      // When: the channels are parsed from Xtream metadata.
+      final normalChannels = normal.toList(growable: false);
+
+      // Then: unsafe durations are disabled, valid hours are exact, and day keys win.
+      expect(fractional.catchupRetentionHours, 0);
+      expect(fractional.catchupDays, 0);
+      expect(oversized.catchupRetentionHours, 0);
+      expect(oversized.catchupDays, 0);
+      expect(maximum.catchupRetentionHours, 0);
+      expect(maximum.catchupDays, 0);
+      expect(
+        normalChannels.map((channel) => channel.catchupRetentionHours),
+        [1, 25, 48, 72],
+      );
+      expect(normalChannels.map((channel) => channel.catchupDays), [
+        0,
+        1,
+        2,
+        3,
+      ]);
+      expect(dayKey.catchupRetentionHours, isNull);
+      expect(dayKey.catchupDays, 3);
+    });
+
     test('builds Xtream catchup timeshift URL from program window', () async {
       final service = XtreamService(
         transport: FakeXtreamTransport({'auth': xtreamAuth(auth: 1)}).call,
@@ -1244,6 +1304,34 @@ void main() {
 
       expect(restored?.data.single.catchupDays, 7);
       expect(restored?.data.single.catchupRetentionHours, isNull);
+    });
+
+    test('cache rejects unsafe catchup retention hours', () async {
+      final file = io.File(
+        '${io.Directory.systemTemp.path}/m3u_tv_cache_unsafe_catchup_${DateTime.now().microsecondsSinceEpoch}.json',
+      );
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+      final store = PersistentJsonStore(file: file);
+      await store.write('m3ue_cache_liveStreams', <String, Object?>{
+        'timestamp': DateTime.now().toIso8601String(),
+        'data': [
+          {
+            'stream_id': 101,
+            'name': 'BBC One',
+            'stream_url': 'https://streams.example/live/bbc-one.m3u8',
+            'catchup_supported': true,
+            'catchup_retention_hours': 9223372036854775807,
+          },
+        ],
+      });
+
+      final restored = await CacheService(store: store).get<List<Channel>>(
+        'liveStreams',
+      );
+
+      expect(restored?.data.single.catchupRetentionHours, 0);
     });
 
     test('favorites add and remove channel ids', () async {

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -11,6 +11,8 @@ import 'package:m3u_tv/services/resume_service.dart';
 import 'package:m3u_tv/services/viewer_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
 
+import '../fixtures/m3u_editor_live_stream_payload.dart';
+
 void main() {
   group('XtreamService contract', () {
     test(
@@ -209,29 +211,14 @@ void main() {
       final service = XtreamService(
         transport: FakeXtreamTransport({
           'auth': xtreamAuth(auth: 1),
-          'get_live_streams': [
-            {
-              ...liveStream(101, 'BBC One', '10', 'bbc.one'),
-              'tv_archive': 1,
-              'tv_archive_duration': '4',
-            },
-            {
-              ...liveStream(102, 'BBC Two', '10', 'bbc.two'),
-              'tv_archive': 1,
-              'tv_archive_duration': '24',
-            },
-            {
-              ...liveStream(103, 'BBC Three', '10', 'bbc.three'),
-              'tv_archive': 1,
-              'tv_archive_duration': '48',
-            },
-            {
-              ...liveStream(104, 'BBC Four', '10', 'bbc.four'),
-              'tv_archive': 1,
-              'tv_archive_duration': '168',
-            },
-            liveStream(105, 'BBC Five', '10', 'bbc.five'),
-          ],
+          'get_live_streams': [4, 24, 48, 168]
+              .map(
+                (hours) => <String, Object?>{
+                  ...m3uEditorLiveStreamPayload,
+                  'tv_archive_duration': hours,
+                },
+              )
+              .toList(growable: false),
         }).call,
       );
       await service.authenticate(
@@ -250,29 +237,23 @@ void main() {
         24,
         48,
         168,
-        isNull,
       ]);
       expect(channels.map((channel) => channel.catchupDays), [
         0,
         1,
         2,
         7,
-        isNull,
       ]);
-      expect(channels.last.catchupSupported, isFalse);
+      expect(channels.every((channel) => channel.catchupSupported), isTrue);
     });
 
     test('live streams retain direct M3U catchup day semantics', () {
-      final underscore = Channel.fromXtream(const {
-        'stream_id': 101,
-        'name': 'Underscore Days',
-        'tv_archive': 1,
+      final underscore = Channel.fromXtream({
+        ...m3uEditorLiveStreamPayload,
         'catchup_days': '7',
       }, 'https://streams.example/live/101.m3u8');
-      final hyphen = Channel.fromXtream(const {
-        'stream_id': 102,
-        'name': 'Hyphen Days',
-        'tv_archive': 1,
+      final hyphen = Channel.fromXtream({
+        ...m3uEditorLiveStreamPayload,
         'catchup-days': '2',
       }, 'https://streams.example/live/102.m3u8');
 
@@ -283,95 +264,69 @@ void main() {
     });
 
     test('live streams fail closed for invalid catchup retention metadata', () {
-      final invalidHours = Channel.fromXtream(const {
-        'stream_id': 101,
-        'name': 'Invalid Hours',
-        'tv_archive': 1,
+      final invalidHours = Channel.fromXtream({
+        ...m3uEditorLiveStreamPayload,
         'tv_archive_duration': 'bad',
       }, 'https://streams.example/live/101.m3u8');
-      final unavailableHours = Channel.fromXtream(const {
-        'stream_id': 102,
-        'name': 'Unavailable Hours',
-        'tv_archive': 1,
+      final nullHours = Channel.fromXtream({
+        ...m3uEditorLiveStreamPayload,
+        'tv_archive_duration': null,
       }, 'https://streams.example/live/102.m3u8');
-      final zeroDays = Channel.fromXtream(const {
-        'stream_id': 103,
-        'name': 'Zero Days',
-        'tv_archive': 1,
-        'catchup_days': 0,
-      }, 'https://streams.example/live/102.m3u8');
-      final negativeDays = Channel.fromXtream(const {
-        'stream_id': 104,
-        'name': 'Negative Days',
-        'tv_archive': 1,
-        'catchup-days': -1,
+      final zeroHours = Channel.fromXtream({
+        ...m3uEditorLiveStreamPayload,
+        'tv_archive_duration': 0,
       }, 'https://streams.example/live/103.m3u8');
+      final negativeHours = Channel.fromXtream({
+        ...m3uEditorLiveStreamPayload,
+        'tv_archive_duration': -1,
+      }, 'https://streams.example/live/104.m3u8');
 
       expect(invalidHours.catchupRetentionHours, 0);
-      expect(unavailableHours.catchupRetentionHours, 0);
-      expect(zeroDays.catchupDays, 0);
-      expect(negativeDays.catchupDays, 0);
+      expect(invalidHours.catchupDays, 0);
+      expect(nullHours.catchupRetentionHours, 0);
+      expect(nullHours.catchupDays, 0);
+      expect(zeroHours.catchupRetentionHours, 0);
+      expect(zeroHours.catchupDays, 0);
+      expect(negativeHours.catchupRetentionHours, 0);
+      expect(negativeHours.catchupDays, 0);
     });
 
-    test('live streams reject fractional and unsafe archive duration metadata', () {
-      // Given: archive durations include fractional, unsafe, and normal values.
-      final fractional = Channel.fromXtream(const {
-        'stream_id': 105,
-        'name': 'Fractional Hours',
-        'tv_archive': 1,
-        'tv_archive_duration': 1.9,
-      }, 'https://streams.example/live/105.m3u8');
-      final oversized = Channel.fromXtream(const {
-        'stream_id': 106,
-        'name': 'Oversized Hours',
-        'tv_archive': 1,
-        'tv_archive_duration': 2562047788015214,
-      }, 'https://streams.example/live/106.m3u8');
-      final maximum = Channel.fromXtream(const {
-        'stream_id': 107,
-        'name': 'Maximum Hours',
-        'tv_archive': 1,
-        'tv_archive_duration': 9223372036854775807,
-      }, 'https://streams.example/live/107.m3u8');
-      final normal = [1, 25, 48, 72].map(
-        (hours) => Channel.fromXtream({
-          'stream_id': 107 + hours,
-          'name': 'Normal $hours Hours',
-          'tv_archive': 1,
-          'tv_archive_duration': hours,
-        }, 'https://streams.example/live/${107 + hours}.m3u8'),
-      );
-      final dayKey = Channel.fromXtream(const {
-        'stream_id': 200,
-        'name': 'Explicit Days',
-        'tv_archive': 1,
-        'tv_archive_duration': 48,
-        'catchup_days': 3,
-      }, 'https://streams.example/live/200.m3u8');
+    test(
+      'live streams reject fractional and unsafe archive duration metadata',
+      () {
+        final fractional = Channel.fromXtream({
+          ...m3uEditorLiveStreamPayload,
+          'tv_archive_duration': 1.9,
+        }, 'https://streams.example/live/105.m3u8');
+        final maximumAllowed = Channel.fromXtream({
+          ...m3uEditorLiveStreamPayload,
+          'tv_archive_duration': 876000,
+        }, 'https://streams.example/live/106.m3u8');
+        final aboveMaximum = Channel.fromXtream({
+          ...m3uEditorLiveStreamPayload,
+          'tv_archive_duration': 876001,
+        }, 'https://streams.example/live/107.m3u8');
+        final maximum = Channel.fromXtream({
+          ...m3uEditorLiveStreamPayload,
+          'tv_archive_duration': 9223372036854775807,
+        }, 'https://streams.example/live/107.m3u8');
+        final dayKey = Channel.fromXtream({
+          ...m3uEditorLiveStreamPayload,
+          'tv_archive_duration': 48,
+          'catchup_days': 3,
+        }, 'https://streams.example/live/200.m3u8');
 
-      // When: the channels are parsed from Xtream metadata.
-      final normalChannels = normal.toList(growable: false);
-
-      // Then: unsafe durations are disabled, valid hours are exact, and day keys win.
-      expect(fractional.catchupRetentionHours, 0);
-      expect(fractional.catchupDays, 0);
-      expect(oversized.catchupRetentionHours, 0);
-      expect(oversized.catchupDays, 0);
-      expect(maximum.catchupRetentionHours, 0);
-      expect(maximum.catchupDays, 0);
-      expect(
-        normalChannels.map((channel) => channel.catchupRetentionHours),
-        [1, 25, 48, 72],
-      );
-      expect(normalChannels.map((channel) => channel.catchupDays), [
-        0,
-        1,
-        2,
-        3,
-      ]);
-      expect(dayKey.catchupRetentionHours, isNull);
-      expect(dayKey.catchupDays, 3);
-    });
+        expect(fractional.catchupRetentionHours, 0);
+        expect(fractional.catchupDays, 0);
+        expect(maximumAllowed.catchupRetentionHours, 876000);
+        expect(aboveMaximum.catchupRetentionHours, 0);
+        expect(aboveMaximum.catchupDays, 0);
+        expect(maximum.catchupRetentionHours, 0);
+        expect(maximum.catchupDays, 0);
+        expect(dayKey.catchupRetentionHours, isNull);
+        expect(dayKey.catchupDays, 3);
+      },
+    );
 
     test('builds Xtream catchup timeshift URL from program window', () async {
       final service = XtreamService(

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -205,7 +205,7 @@ void main() {
       expect(transport.lastHeaders['X-M3UE-Client'], 'm3u-tv');
     });
 
-    test('live streams parse Xtream catchup metadata', () async {
+    test('live streams preserve Xtream archive duration in hours', () async {
       final service = XtreamService(
         transport: FakeXtreamTransport({
           'auth': xtreamAuth(auth: 1),
@@ -213,9 +213,24 @@ void main() {
             {
               ...liveStream(101, 'BBC One', '10', 'bbc.one'),
               'tv_archive': 1,
-              'tv_archive_duration': '7',
+              'tv_archive_duration': '4',
             },
-            liveStream(102, 'BBC Two', '10', 'bbc.two'),
+            {
+              ...liveStream(102, 'BBC Two', '10', 'bbc.two'),
+              'tv_archive': 1,
+              'tv_archive_duration': '24',
+            },
+            {
+              ...liveStream(103, 'BBC Three', '10', 'bbc.three'),
+              'tv_archive': 1,
+              'tv_archive_duration': '48',
+            },
+            {
+              ...liveStream(104, 'BBC Four', '10', 'bbc.four'),
+              'tv_archive': 1,
+              'tv_archive_duration': '168',
+            },
+            liveStream(105, 'BBC Five', '10', 'bbc.five'),
           ],
         }).call,
       );
@@ -230,9 +245,72 @@ void main() {
       final channels = await service.getLiveStreams();
 
       expect(channels.first.catchupSupported, isTrue);
-      expect(channels.first.catchupDays, 7);
+      expect(channels.map((channel) => channel.catchupRetentionHours), [
+        4,
+        24,
+        48,
+        168,
+        isNull,
+      ]);
+      expect(channels.map((channel) => channel.catchupDays), [
+        0,
+        1,
+        2,
+        7,
+        isNull,
+      ]);
       expect(channels.last.catchupSupported, isFalse);
-      expect(channels.last.catchupDays, isNull);
+    });
+
+    test('live streams retain direct M3U catchup day semantics', () {
+      final underscore = Channel.fromXtream(const {
+        'stream_id': 101,
+        'name': 'Underscore Days',
+        'tv_archive': 1,
+        'catchup_days': '7',
+      }, 'https://streams.example/live/101.m3u8');
+      final hyphen = Channel.fromXtream(const {
+        'stream_id': 102,
+        'name': 'Hyphen Days',
+        'tv_archive': 1,
+        'catchup-days': '2',
+      }, 'https://streams.example/live/102.m3u8');
+
+      expect(underscore.catchupDays, 7);
+      expect(underscore.catchupRetentionHours, isNull);
+      expect(hyphen.catchupDays, 2);
+      expect(hyphen.catchupRetentionHours, isNull);
+    });
+
+    test('live streams fail closed for invalid catchup retention metadata', () {
+      final invalidHours = Channel.fromXtream(const {
+        'stream_id': 101,
+        'name': 'Invalid Hours',
+        'tv_archive': 1,
+        'tv_archive_duration': 'bad',
+      }, 'https://streams.example/live/101.m3u8');
+      final unavailableHours = Channel.fromXtream(const {
+        'stream_id': 102,
+        'name': 'Unavailable Hours',
+        'tv_archive': 1,
+      }, 'https://streams.example/live/102.m3u8');
+      final zeroDays = Channel.fromXtream(const {
+        'stream_id': 103,
+        'name': 'Zero Days',
+        'tv_archive': 1,
+        'catchup_days': 0,
+      }, 'https://streams.example/live/102.m3u8');
+      final negativeDays = Channel.fromXtream(const {
+        'stream_id': 104,
+        'name': 'Negative Days',
+        'tv_archive': 1,
+        'catchup-days': -1,
+      }, 'https://streams.example/live/103.m3u8');
+
+      expect(invalidHours.catchupRetentionHours, 0);
+      expect(unavailableHours.catchupRetentionHours, 0);
+      expect(zeroDays.catchupDays, 0);
+      expect(negativeDays.catchupDays, 0);
     });
 
     test('builds Xtream catchup timeshift URL from program window', () async {
@@ -1106,7 +1184,7 @@ void main() {
       },
     );
 
-    test('cache preserves channel catchup metadata', () async {
+    test('cache preserves precise channel catchup retention metadata', () async {
       final file = io.File(
         '${io.Directory.systemTemp.path}/m3u_tv_cache_catchup_${DateTime.now().microsecondsSinceEpoch}.json',
       );
@@ -1121,7 +1199,7 @@ void main() {
           name: 'BBC One',
           streamUrl: 'https://streams.example/live/bbc-one.m3u8',
           catchupSupported: true,
-          catchupDays: 7,
+          catchupRetentionHours: 168,
           catchupSource: 'https://archive.example/{utc}/{duration}',
         ),
       ]);
@@ -1131,11 +1209,41 @@ void main() {
       ).get<List<Channel>>('liveStreams');
 
       expect(restored?.data.single.catchupSupported, isTrue);
-      expect(restored?.data.single.catchupDays, 7);
+      expect(restored?.data.single.catchupRetentionHours, 168);
+      expect(restored?.data.single.catchupDays, isNull);
       expect(
         restored?.data.single.catchupSource,
         'https://archive.example/{utc}/{duration}',
       );
+    });
+
+    test('cache reads legacy catchup_days as days', () async {
+      final file = io.File(
+        '${io.Directory.systemTemp.path}/m3u_tv_cache_legacy_catchup_${DateTime.now().microsecondsSinceEpoch}.json',
+      );
+      addTearDown(() async {
+        if (await file.exists()) await file.delete();
+      });
+      final store = PersistentJsonStore(file: file);
+      await store.write('m3ue_cache_liveStreams', <String, Object?>{
+        'timestamp': DateTime.now().toIso8601String(),
+        'data': [
+          {
+            'stream_id': 101,
+            'name': 'BBC One',
+            'stream_url': 'https://streams.example/live/bbc-one.m3u8',
+            'catchup_supported': true,
+            'catchup_days': 7,
+          },
+        ],
+      });
+
+      final restored = await CacheService(store: store).get<List<Channel>>(
+        'liveStreams',
+      );
+
+      expect(restored?.data.single.catchupDays, 7);
+      expect(restored?.data.single.catchupRetentionHours, isNull);
     });
 
     test('favorites add and remove channel ids', () async {

--- a/flutter_client/test/ui/features/epg_screen_test.dart
+++ b/flutter_client/test/ui/features/epg_screen_test.dart
@@ -199,6 +199,32 @@ void main() {
       expect(find.byIcon(Icons.replay_rounded), findsOneWidget);
       expect(find.text('7d'), findsOneWidget);
     });
+
+    testWidgets('hourly catchup retention does not display zero days', (
+      tester,
+    ) async {
+      const channelsWithHourlyCatchup = [
+        Channel(
+          id: 1,
+          name: 'BBC One',
+          streamUrl: 'http://example.com/1.m3u8',
+          epgChannelId: 'bbc.one',
+          catchupSupported: true,
+          catchupRetentionHours: 4,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        _TestApp(
+          channels: channelsWithHourlyCatchup,
+          epgService: epgService,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.replay_rounded), findsOneWidget);
+      expect(find.text('0d'), findsNothing);
+    });
   });
 }
 

--- a/flutter_client/test/ui/features/timeline_epg_view_test.dart
+++ b/flutter_client/test/ui/features/timeline_epg_view_test.dart
@@ -589,6 +589,136 @@ void main() {
     });
 
     testWidgets(
+      'partial hourly retention replays exactly without exposing a prior day',
+      (tester) async {
+        final now = DateTime(2026, 7, 31, 12);
+        const channel = Channel(
+          id: 101,
+          name: 'Four Hour Archive',
+          streamUrl: 'https://streams.example/live/101.m3u8',
+          epgChannelId: 'four-hours',
+          catchupSupported: true,
+          catchupRetentionHours: 4,
+        );
+        const unsupportedChannel = Channel(
+          id: 102,
+          name: 'Unsupported Archive',
+          streamUrl: 'https://streams.example/live/102.m3u8',
+          epgChannelId: 'unsupported-hours',
+          catchupRetentionHours: 4,
+        );
+        final replayable = EpgProgram(
+          channelId: 'four-hours',
+          title: 'At Hourly Cutoff',
+          description: 'Replayable fixture',
+          start: DateTime(2026, 7, 31, 8),
+          end: DateTime(2026, 7, 31, 11),
+        );
+        final expired = EpgProgram(
+          channelId: 'four-hours',
+          title: 'Outside Four Hours',
+          description: 'Expired fixture',
+          start: DateTime(2026, 7, 31, 6),
+          end: DateTime(2026, 7, 31, 7),
+        );
+        final unsupported = EpgProgram(
+          channelId: 'unsupported-hours',
+          title: 'No Catchup Support',
+          description: 'Unavailable fixture',
+          start: DateTime(2026, 7, 31, 9),
+          end: DateTime(2026, 7, 31, 10),
+        );
+        final requestedDates = <DateTime>[];
+        final replayedPrograms = <EpgProgram>[];
+        final selectedChannels = <Channel>[];
+        final epg = EpgService(clock: () => now)
+          ..loadPrograms([replayable, expired, unsupported]);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData.dark(useMaterial3: true),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: SizedBox(
+                width: 800,
+                height: 300,
+                child: TimelineEpgView(
+                  channels: const [channel, unsupportedChannel],
+                  epgService: epg,
+                  onChannelSelect: selectedChannels.add,
+                  onCatchupProgramSelect: (_, program) {
+                    replayedPrograms.add(program);
+                  },
+                  onEnsureEpg: (_, {startDate, endDate}) {
+                    requestedDates.add(startDate!);
+                  },
+                  clock: () => now,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          _dateControlFocusable(
+            tester,
+            const ValueKey('timeline-previous-day'),
+          ).enabled,
+          isFalse,
+        );
+        await tester.tap(find.byKey(const ValueKey('timeline-previous-day')));
+        await tester.pump();
+        expect(find.text('Jul 31, 2026'), findsOneWidget);
+        expect(requestedDates, everyElement(DateTime(2026, 7, 31)));
+
+        final replayableBlock = find.byKey(
+          ValueKey(
+            'timeline-program-${replayable.channelId}-${replayable.start.toIso8601String()}',
+          ),
+        );
+        final expiredBlock = find.byKey(
+          ValueKey(
+            'timeline-program-${expired.channelId}-${expired.start.toIso8601String()}',
+          ),
+        );
+        final unsupportedBlock = find.byKey(
+          ValueKey(
+            'timeline-program-${unsupported.channelId}-${unsupported.start.toIso8601String()}',
+          ),
+        );
+        expect(
+          find.descendant(
+            of: replayableBlock,
+            matching: find.byIcon(Icons.replay_rounded),
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.descendant(
+            of: expiredBlock,
+            matching: find.byIcon(Icons.replay_rounded),
+          ),
+          findsNothing,
+        );
+        expect(
+          find.descendant(
+            of: unsupportedBlock,
+            matching: find.byIcon(Icons.replay_rounded),
+          ),
+          findsNothing,
+        );
+
+        tester.widget<DpadInkWell>(replayableBlock).onTap?.call();
+        tester.widget<DpadInkWell>(expiredBlock).onTap?.call();
+        tester.widget<DpadInkWell>(unsupportedBlock).onTap?.call();
+        expect(replayedPrograms, [replayable]);
+        expect(selectedChannels, [channel, unsupportedChannel]);
+      },
+    );
+
+    testWidgets(
       'spring-forward navigation and window keep calendar boundaries',
       (tester) async {
         final now = DateTime(2026, 3, 30, 12);


### PR DESCRIPTION
## Summary

- Interprets m3u-editor `tv_archive_duration` as validated hours while preserving direct day-valued `catchup_days` and `catchup-days` precedence.
- Fails closed for malformed, unsafe, and invalid retention values, including cache decode validation.
- Adds real m3u-editor-shaped fixture coverage plus missing-key and retention boundary evidence.

Closes #187

## Verification

Implementation local gate results:

- `flutter analyze lib test`: PASS
- service contract tests: 37 PASS
- full Flutter suite: 917 PASS, 7 skipped
- full Flutter serial suite: 917 PASS, 7 skipped
- Linux debug build and `ldd`: PASS
- Android unit tests and assemble: BUILD SUCCESSFUL

Independent exact-head review: PASS for `4b1607d74ece811b5693daf1f642e28a4d75a34e` against frozen `m3ue/m3u-tv:dev` `ac4a9eba90db204e54f587f78187d309b617aa00`.

Security review: CHANGES REQUESTED for exact head `4b1607d74ece811b5693daf1f642e28a4d75a34e`. A reproducible P2 remains in explicit and cached `catchup_days`: fractional values are truncated into replay access and unbounded values can expand or wrap retention cutoffs. All current CI checks pass, but CI does not override the Security verdict. This PR intentionally remains Draft and must not be merged or marked ready.
