### PR TITLE
fix(player): dismiss visible controls on background tap

### DIFF
--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -1017,37 +1017,42 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
                     // Playback controls overlay
                     if (_overlayVisible && _errorMessage == null)
-                      PlaybackControls(
-                        isPlaying: _isPlaying,
-                        isLive: _isLive,
-                        canSeek: _canSeek,
-                        currentPosition: _currentPosition,
-                        duration: _duration,
-                        onPlayPause: _togglePlayPause,
-                        onSeek: _seekTo,
-                        onBack: _goBack,
-                        audioTracks: _audioTracks,
-                        subtitleTracks: _subtitleTracks,
-                        selectedAudioTrackId: _selectedAudioTrackId,
-                        selectedSubtitleTrackId: _selectedSubtitleTrackId,
-                        isAudioTrackSelectionKnown: _isAudioTrackSelectionKnown,
-                        isSubtitleTrackSelectionKnown:
-                            _isSubtitleTrackSelectionKnown,
-                        onAudioTrackSelected: _handleAudioTrackSelected,
-                        onSubtitleTrackSelected: _handleSubtitleTrackSelected,
-                        fallbackReason: _showPlaybackDiagnostics
-                            ? _fallbackReason
-                            : null,
-                        playPauseFocusNode: _controlsFocusNode,
-                        onNextChannel: widget.onNextChannel,
-                        onPreviousChannel: widget.onPreviousChannel,
-                        onRecordNow:
-                            (_isLive &&
-                                widget.onRecordProgram != null &&
-                                _epgData?.current != null)
-                            ? () => widget.onRecordProgram!(_epgData!.current)
-                            : null,
-                        isRecording: widget.isRecordingCurrentChannel,
+                      GestureDetector(
+                        behavior: HitTestBehavior.translucent,
+                        onTap: _hideOverlay,
+                        child: PlaybackControls(
+                          isPlaying: _isPlaying,
+                          isLive: _isLive,
+                          canSeek: _canSeek,
+                          currentPosition: _currentPosition,
+                          duration: _duration,
+                          onPlayPause: _togglePlayPause,
+                          onSeek: _seekTo,
+                          onBack: _goBack,
+                          audioTracks: _audioTracks,
+                          subtitleTracks: _subtitleTracks,
+                          selectedAudioTrackId: _selectedAudioTrackId,
+                          selectedSubtitleTrackId: _selectedSubtitleTrackId,
+                          isAudioTrackSelectionKnown:
+                              _isAudioTrackSelectionKnown,
+                          isSubtitleTrackSelectionKnown:
+                              _isSubtitleTrackSelectionKnown,
+                          onAudioTrackSelected: _handleAudioTrackSelected,
+                          onSubtitleTrackSelected: _handleSubtitleTrackSelected,
+                          fallbackReason: _showPlaybackDiagnostics
+                              ? _fallbackReason
+                              : null,
+                          playPauseFocusNode: _controlsFocusNode,
+                          onNextChannel: widget.onNextChannel,
+                          onPreviousChannel: widget.onPreviousChannel,
+                          onRecordNow:
+                              (_isLive &&
+                                  widget.onRecordProgram != null &&
+                                  _epgData?.current != null)
+                              ? () => widget.onRecordProgram!(_epgData!.current)
+                              : null,
+                          isRecording: widget.isRecordingCurrentChannel,
+                        ),
                       ),
 
                     if (_showPlaybackDiagnostics &&
@@ -1078,10 +1083,13 @@ class _PlayerScreenState extends State<PlayerScreen> {
                         top: overlayTop,
                         left: overlayLeft,
                         width: overlayWidth,
-                        child: EpgOverlay(
-                          currentTitle: _epgData!.current.displayTitle,
-                          currentProgress: _epgData!.progress,
-                          nextTitle: _epgData?.next?.displayTitle,
+                        child: GestureDetector(
+                          onTap: _hideOverlay,
+                          child: EpgOverlay(
+                            currentTitle: _epgData!.current.displayTitle,
+                            currentProgress: _epgData!.progress,
+                            nextTitle: _epgData?.next?.displayTitle,
+                          ),
                         ),
                       ),
 
@@ -1093,11 +1101,14 @@ class _PlayerScreenState extends State<PlayerScreen> {
                         top: overlayTop,
                         left: overlayLeft,
                         width: overlayWidth,
-                        child: NowPlayingOverlay(
-                          badgeLabel: _nowPlayingBadgeLabel(context),
-                          title: _nowPlayingTitle(),
-                          subtitle: _nowPlayingSubtitle(context),
-                          description: _nowPlayingDescription(),
+                        child: GestureDetector(
+                          onTap: _hideOverlay,
+                          child: NowPlayingOverlay(
+                            badgeLabel: _nowPlayingBadgeLabel(context),
+                            title: _nowPlayingTitle(),
+                            subtitle: _nowPlayingSubtitle(context),
+                            description: _nowPlayingDescription(),
+                          ),
                         ),
                       ),
 

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1192,6 +1192,188 @@ void main() {
   });
 
   group('PlayerScreen', () {
+    testWidgets(
+      'hides visible controls when the overlay background is tapped',
+      (
+        tester,
+      ) async {
+        await tester.binding.setSurfaceSize(const Size(1200, 800));
+        addTearDown(() => tester.binding.setSurfaceSize(null));
+        final adapter = FakePlayerAdapter(
+          capabilities: PlaybackCapabilities.desktopLibmpv,
+          textureId: 42,
+        );
+        final orchestrator = PlaybackOrchestrator(
+          platform: PlaybackPlatform.desktop,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.desktopLibmpv: adapter,
+          },
+          transcodeGateway: FakeTranscodeGateway(),
+        );
+        addTearDown(orchestrator.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: PlayerScreen(
+              args: const PlayerArgs(
+                streamUrl: 'https://example.com/live.m3u8',
+                title: 'Overlay Fixture',
+                type: 'live',
+              ),
+              orchestrator: orchestrator,
+              epgService: EpgService(clock: () => DateTime.utc(2026)),
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.byType(PlaybackControls), findsOneWidget);
+
+        await tester.tapAt(const Offset(1100, 400));
+        await tester.pump();
+
+        expect(find.byType(PlaybackControls), findsNothing);
+      },
+    );
+
+    testWidgets('keeps visible controls open when play pause is tapped', (
+      tester,
+    ) async {
+      final adapter = FakePlayerAdapter(
+        capabilities: PlaybackCapabilities.desktopLibmpv,
+        textureId: 42,
+      );
+      final orchestrator = PlaybackOrchestrator(
+        platform: PlaybackPlatform.desktop,
+        adapters: <PlaybackBackend, PlayerAdapter>{
+          PlaybackBackend.desktopLibmpv: adapter,
+        },
+        transcodeGateway: FakeTranscodeGateway(),
+      );
+      addTearDown(orchestrator.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlayerScreen(
+            args: const PlayerArgs(
+              streamUrl: 'https://example.com/live.m3u8',
+              title: 'Control Fixture',
+              type: 'live',
+            ),
+            orchestrator: orchestrator,
+            epgService: EpgService(clock: () => DateTime.utc(2026)),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pump();
+
+      expect(adapter.playCallCount, 1);
+      expect(find.byType(PlaybackControls), findsOneWidget);
+    });
+
+    testWidgets('hides visible controls when the live EPG overlay is tapped', (
+      tester,
+    ) async {
+      final now = DateTime.utc(2026, 1, 1, 12);
+      final adapter = FakePlayerAdapter(
+        capabilities: PlaybackCapabilities.desktopLibmpv,
+        textureId: 42,
+      );
+      final orchestrator = PlaybackOrchestrator(
+        platform: PlaybackPlatform.desktop,
+        adapters: <PlaybackBackend, PlayerAdapter>{
+          PlaybackBackend.desktopLibmpv: adapter,
+        },
+        transcodeGateway: FakeTranscodeGateway(),
+      );
+      addTearDown(orchestrator.dispose);
+      final epgService = EpgService(clock: () => now)
+        ..loadPrograms(<EpgProgram>[
+          EpgProgram(
+            channelId: 'bbc.one',
+            title: 'Current News',
+            description: 'Fixture bulletin',
+            start: now.subtract(const Duration(minutes: 10)),
+            end: now.add(const Duration(minutes: 20)),
+          ),
+        ]);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: PlayerScreen(
+            args: const PlayerArgs(
+              streamUrl: 'https://example.com/live.m3u8',
+              title: 'EPG Tap Fixture',
+              type: 'live',
+              epgChannelId: 'bbc.one',
+            ),
+            orchestrator: orchestrator,
+            epgService: epgService,
+          ),
+        ),
+      );
+      await tester.pump();
+      adapter.emitState(
+        const PlaybackState(
+          backend: PlaybackBackend.desktopLibmpv,
+          status: PlaybackStatus.ready,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      expect(find.byType(EpgOverlay), findsOneWidget);
+
+      await tester.tap(find.byType(EpgOverlay));
+      await tester.pump();
+
+      expect(find.byType(PlaybackControls), findsNothing);
+    });
+
+    testWidgets(
+      'hides visible controls when the Now Playing overlay is tapped',
+      (
+        tester,
+      ) async {
+        final adapter = FakePlayerAdapter(
+          capabilities: PlaybackCapabilities.desktopLibmpv,
+          textureId: 42,
+        );
+        final orchestrator = PlaybackOrchestrator(
+          platform: PlaybackPlatform.desktop,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.desktopLibmpv: adapter,
+          },
+          transcodeGateway: FakeTranscodeGateway(),
+        );
+        addTearDown(orchestrator.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: PlayerScreen(
+              args: const PlayerArgs(
+                streamUrl: 'https://example.com/movie.mkv',
+                title: 'Now Playing Tap Fixture',
+                type: 'vod',
+              ),
+              orchestrator: orchestrator,
+              epgService: EpgService(clock: () => DateTime.utc(2026)),
+            ),
+          ),
+        );
+        await tester.pump();
+        expect(find.byType(NowPlayingOverlay), findsOneWidget);
+
+        await tester.tap(find.byType(NowPlayingOverlay));
+        await tester.pump();
+
+        expect(find.byType(PlaybackControls), findsNothing);
+      },
+    );
+
     testWidgets('renders desktop libmpv texture when backend is ready', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary

- allow taps on the visible player overlay background to dismiss playback controls
- dismiss controls when tapping the non-interactive live EPG or VOD/series Now Playing surfaces
- preserve gesture priority for play/pause, seek, track selectors, dialogs, and comskip controls
- add real `PlayerScreen` widget regressions for background, control, EPG, and Now Playing taps

## Testing

- `dart format --output=none --set-exit-if-changed lib test`
- `flutter analyze lib test`
- four exact overlay/control regression tests
- full `player_screen_test.dart`: 89 passed
- `flutter test --concurrency=1`: 965 passed
- `flutter test --concurrency=4`: 965 passed, matching the 4-vCPU public GitHub runner
- `./android/gradlew -p android :app:testDebugUnitTest`: 211 tasks, build successful
- `flutter build apk --debug`: passed
- `flutter build linux --release`: passed
- independent stable-hash review: approved, no logic or security findings

## Verification note

The 20-worker local host exposed unrelated timing-sensitive shared-state failures with unconstrained `flutter test`. The exact base currently has green GitHub CI, and the candidate passed the full suite at the public GitHub runner's 4-worker parity. The PR remained Draft until all exact-head GitHub checks completed successfully.

Closes #171
