### PR TITLE
docs: add HDR playback decision matrix

### DIFF
--- a/docs/migration/hdr-playback-matrix.md
+++ b/docs/migration/hdr-playback-matrix.md
@@ -23,18 +23,45 @@ Native events and diagnostics may contain only normalized non-sensitive transfer
 
 Server transcode is unverified and not HDR-capable until complete generated output and delivery path prove metadata preservation and renderer behavior. It inherits no HDR claim from the source.
 
+## Threat Model
+
+Source HDR metadata can be untrusted, absent, or wrong. Device and display capability can be conditional or unsupported, and source detection can be mislabeled as HDR output active. Server transcode can be accidentally assumed, and diagnostics can leak sensitive metadata. Playback or rendering implementation is also out of scope for this contract. The bounded mitigation is authoritative native evidence, normalized non-sensitive state only, and a fail-closed unverified/blocker outcome until the complete delivery path is verified.
+
+## Acceptance Criteria
+
+- All 8 x 4 target-format cells contain an explicit non-empty normalized decision.
+- Decisions use only the four normalized states above and remain separate from source detection, presentation, fallback, and user communication.
+- Every platform keeps its real-device or real-runtime gate and conservative server fallback.
+- Metadata remains non-sensitive, related-work caveats and citations remain present, and this phase adds no runtime implementation.
+
+## Detection
+
+Detection can establish `source HDR detected` only from authoritative native source metadata. Source detection never proves output, metadata preservation, display mode, tone mapping, or `HDR output active`.
+
+## Presentation
+
+Presentation reports only a verified normalized output state. It must not call source metadata an active HDR output path; without output evidence, the current contract remains `HDR unsupported/unavailable` and the platform gate remains unverified/blocker.
+
+## Fallback
+
+Fallback is conservative: preserve normal SDR playback when safely available, report `HDR unsupported/unavailable` when output is not proven, and never silently assume that server transcode preserves HDR.
+
+## User Communication
+
+User communication is non-sensitive and clearly distinguishes source detection from actual output. It may expose normalized state and non-sensitive color metadata, but never stream URLs, headers, credentials, tokens, or raw native payloads.
+
 ## Decision summary
 
 | Target | Backend and native path | HDR10 | HDR10+ | HLG | Dolby Vision | Metadata preservation | Tone mapping/fallback | Minimum prerequisites and packaging | Real device/runtime |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Android phone/tablet | Media3 ExoPlayer to Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or HDR packaging proof recorded | unverified/blocker |
-| Android TV | Media3 ExoPlayer to Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or HDR packaging proof recorded | unverified/blocker |
-| iOS | media_kit and AVKit via BGRA Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or App Store HDR packaging proof recorded | unverified/blocker |
-| iPadOS | media_kit and AVKit via BGRA Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or App Store HDR packaging proof recorded | unverified/blocker |
-| tvOS | AVKit via Metal-compatible BGRA Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or tvOS packaging proof recorded | unverified/blocker |
-| macOS | media_kit AVFoundation-backed texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or signed/notarized HDR packaging proof recorded | unverified/blocker |
-| Linux | in-process libmpv software RGBA texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | Existing runtime needs libmpv and its distro dependencies; HDR renderer and driver requirements unverified | unverified/blocker |
-| Windows | in-process libmpv RGBA pixel-buffer texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | Existing bundle needs `mpv-2.dll` and dependent runtime DLLs; HDR renderer and driver requirements unverified | unverified/blocker |
+| Android phone/tablet | Media3 ExoPlayer to Flutter texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | No app-specific HDR minimum or HDR packaging proof recorded | unverified/blocker |
+| Android TV | Media3 ExoPlayer to Flutter texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | No app-specific HDR minimum or HDR packaging proof recorded | unverified/blocker |
+| iOS | media_kit and AVKit via BGRA Flutter texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | No app-specific HDR minimum or App Store HDR packaging proof recorded | unverified/blocker |
+| iPadOS | media_kit and AVKit via BGRA Flutter texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | No app-specific HDR minimum or App Store HDR packaging proof recorded | unverified/blocker |
+| tvOS | AVKit via Metal-compatible BGRA Flutter texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | No app-specific HDR minimum or tvOS packaging proof recorded | unverified/blocker |
+| macOS | media_kit AVFoundation-backed texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | No app-specific HDR minimum or signed/notarized HDR packaging proof recorded | unverified/blocker |
+| Linux | in-process libmpv software RGBA texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | Existing runtime needs libmpv and its distro dependencies; HDR renderer and driver requirements unverified | unverified/blocker |
+| Windows | in-process libmpv RGBA pixel-buffer texture | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | HDR unsupported/unavailable | unverified/blocker | unverified/blocker | Existing bundle needs `mpv-2.dll` and dependent runtime DLLs; HDR renderer and driver requirements unverified | unverified/blocker |
 
 The format columns are separate decisions for every target and active backend path. They are not decoder capability assertions. The Android documentation describes device-dependent supported formats, and the mpv manual describes output configuration; neither proves this app's end-to-end output path.
 

--- a/docs/migration/hdr-playback-matrix.md
+++ b/docs/migration/hdr-playback-matrix.md
@@ -1,0 +1,116 @@
+# HDR Playback Decision Matrix
+
+This is the maintained phase-one HDR contract for current `upstream/dev`. It does not implement HDR playback and makes no HDR delivery claim from a codec, resolution, backend name, or marketing statement. The only outcome vocabulary is **verified**, **platform-contingent**, **unsupported**, and **unverified/blocker**. A format is verified only after the complete source, decoder, renderer, display, and real-device path is recorded here.
+
+## Current facts and boundaries
+
+`PlaybackCapabilities` has no HDR fields, and `PlaybackOrchestrator` has no HDR detection or output-state contract. Android selects the Media3 adapter; iOS and iPadOS select media_kit and AVKit; tvOS selects AVKit; macOS selects media_kit; Linux and Windows select the custom in-process libmpv backend. The source evidence is `flutter_client/lib/navigation/app_router.dart`, `flutter_client/lib/playback/playback_capabilities.dart`, and `flutter_client/lib/playback/playback_orchestrator.dart`.
+
+The Android native plugin supplies an ExoPlayer through a Flutter texture. The iOS and tvOS AVKit plugins request 32-bit BGRA pixel buffers through `AVPlayerItemVideoOutput`; tvOS also requests Metal compatibility. Linux and Windows use libmpv `MPV_RENDER_API_TYPE_SW` and RGBA Flutter pixel-buffer textures. macOS uses media_kit's texture controller. These are rendering-path facts, not HDR metadata-preservation or display-output evidence.
+
+PR #209 is pending Draft. Issue #167 is In review. Neither is current delivered HDR behavior.
+
+## Output contract for future work
+
+Future backend-independent state has exactly these normalized states:
+
+- `source HDR detected`
+- `HDR output active`
+- `HDR tone-mapped to SDR`
+- `HDR unsupported/unavailable`
+
+Native events and diagnostics may contain only normalized non-sensitive transfer characteristics, color primaries, color space, and bit depth. They must not contain stream URLs, headers, credentials, tokens, or raw native payloads.
+
+Server transcode is unverified and not HDR-capable until complete generated output and delivery path prove metadata preservation and renderer behavior. It inherits no HDR claim from the source.
+
+## Decision summary
+
+| Target | Backend and native path | HDR10 | HDR10+ | HLG | Dolby Vision | Metadata preservation | Tone mapping/fallback | Minimum prerequisites and packaging | Real device/runtime |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Android phone/tablet | Media3 ExoPlayer to Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or HDR packaging proof recorded | unverified/blocker |
+| Android TV | Media3 ExoPlayer to Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or HDR packaging proof recorded | unverified/blocker |
+| iOS | media_kit and AVKit via BGRA Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or App Store HDR packaging proof recorded | unverified/blocker |
+| iPadOS | media_kit and AVKit via BGRA Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or App Store HDR packaging proof recorded | unverified/blocker |
+| tvOS | AVKit via Metal-compatible BGRA Flutter texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or tvOS packaging proof recorded | unverified/blocker |
+| macOS | media_kit AVFoundation-backed texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | No app-specific HDR minimum or signed/notarized HDR packaging proof recorded | unverified/blocker |
+| Linux | in-process libmpv software RGBA texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | Existing runtime needs libmpv and its distro dependencies; HDR renderer and driver requirements unverified | unverified/blocker |
+| Windows | in-process libmpv RGBA pixel-buffer texture | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | unverified/blocker | Existing bundle needs `mpv-2.dll` and dependent runtime DLLs; HDR renderer and driver requirements unverified | unverified/blocker |
+
+The format columns are separate decisions for every target and active backend path. They are not decoder capability assertions. The Android documentation describes device-dependent supported formats, and the mpv manual describes output configuration; neither proves this app's end-to-end output path.
+
+## Android phone/tablet
+
+Android phone/tablet real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: `androidExoPlayer`; `Media3PlaybackPlugin.kt` owns ExoPlayer and a Flutter texture. Metadata preservation, HDR surface configuration, and SDR fallback behavior are unverified/blocker. Android's primary Media3 supported-formats documentation is conditional on device decoders and display support; no authoritative application minimum OS, hardware, or display requirement is recorded. Packaging needs an Android release artifact containing the selected Media3 path; no HDR-specific runtime constraint is yet proven.
+
+Child-delivery plan: add normalized Media3 metadata extraction and output decision events; verify the texture/surface renderer does not reduce HDR; add unit tests for all four formats and every output state; gate a release claim on an HDR phone/tablet and HDR display with recorded OS, model, display mode, and observed output. Blockers are the missing shared contract, renderer proof, and device evidence.
+
+## Android TV
+
+Android TV real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: the same `androidExoPlayer` and Flutter texture path as Android phone/tablet. Metadata preservation, HDR surface configuration, tone mapping, and fallback are unverified/blocker. Android TV has no separate app-specific minimum OS, hardware, display, or HDR packaging proof in this repository.
+
+Child-delivery plan: use the Media3 backend with a TV-safe renderer path and D-pad-safe status presentation; test normalized metadata and unsupported-device decisions; require an HDR-capable Android TV and display for HDR10, HDR10+, HLG, and Dolby Vision separately. Blockers are device/vendor conditional behavior, native surface proof, and real-display validation.
+
+## iOS
+
+iOS real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: `appleMediaKit` and `appleAvKit` are selected; the native AVKit plugin exposes BGRA buffers to Flutter. The current code does not prove that color metadata survives that output path or that AVFoundation tone maps on an SDR display. No authoritative application minimum iOS, hardware, display, or packaging prerequisite is recorded.
+
+Child-delivery plan: define the AVFoundation metadata and effective-output observation boundary, prove the renderer path, and add format/state contract tests. Gate each claimed format on a physical supported iPhone, iOS version, and HDR display mode. Blockers are absent native output evidence and device validation.
+
+## iPadOS
+
+iPadOS real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: `appleMediaKit` and `appleAvKit` use the same current Apple texture arrangement. Metadata preservation, tone mapping, fallback, minimum OS/hardware/display requirements, and App Store packaging behavior are unverified/blocker for this app.
+
+Child-delivery plan: implement the same AVFoundation observation contract with iPad-specific device coverage; test four formats and four output states; release-gate on physical iPad HDR display validation. Blockers are renderer proof and device-specific evidence.
+
+## tvOS
+
+tvOS real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: `appleAvKit` uses `AVPlayerItemVideoOutput` with BGRA and Metal compatibility in the tvOS plugin. This does not establish HDR metadata preservation, HDR output, or tone mapping. No authoritative app-specific tvOS, Apple TV hardware, connected-display, or package requirement is recorded.
+
+Child-delivery plan: scope AVKit, the Metal-compatible renderer, and the tvOS app bundle; add native-event normalization and deterministic contract tests; gate all format claims on an Apple TV connected to an HDR display with display mode and observed output recorded. Blockers are the Flutter texture output proof and physical Apple TV validation.
+
+## macOS
+
+macOS real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: `desktopMediaKit` is intentionally selected on macOS and uses media_kit's AVFoundation-backed texture path; libmpv is not planned. The existing desktop feasibility record describes Metal, not HDR metadata or display output. Minimum macOS, hardware, display, and driver requirements, tone mapping, and notarized HDR packaging are unverified/blocker.
+
+Child-delivery plan: make media_kit/AVFoundation metadata and renderer behavior observable without raw payloads; add format/state tests and a signed-bundle check; gate each claim on an HDR Mac display and real macOS runtime. Blockers are the absent end-to-end renderer and packaging evidence.
+
+## Linux
+
+Linux real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: `desktopLibmpv` uses libmpv in-process with `MPV_RENDER_API_TYPE_SW`, `FlPixelBufferTexture`, RGBA upload, and `hwdec=auto-safe`. The documented runtime requires `libmpv.so.2` (with `.1` or `.so` fallback) plus distro dependencies. This software texture output does not prove metadata preservation, HDR display output, or tone mapping. GPU driver, compositor, display, and portable-package HDR requirements are unverified/blocker.
+
+Child-delivery plan: choose and document an HDR-capable libmpv renderer and Linux display-stack packaging; add runtime probe and normalized-event tests; verify the packaged runtime on Wayland and X11 with an HDR-capable display. Blockers are the current software texture path, driver/compositor variance, and absent device evidence.
+
+## Windows
+
+Windows real-device/real-runtime: unverified/blocker
+
+Current backend and renderer: `desktopLibmpv` uses libmpv and an RGBA Flutter pixel-buffer texture. The documented bundle includes `mpv-2.dll`, FFmpeg DLLs, and selected rendering/audio dependencies. That packaging evidence is not HDR metadata, HDR renderer, driver, or display evidence; tone mapping and fallback are unverified/blocker.
+
+Child-delivery plan: select an HDR-capable libmpv renderer and Windows graphics path, bundle its runtime, add normalized metadata and output-state tests, and gate release on a packaged build with an HDR monitor and recorded driver/display mode. Blockers are the current pixel-buffer path and missing real-runtime validation.
+
+## Evidence and maintenance
+
+Primary sources used for conditional platform behavior and future validation:
+
+- Android Media3 supported formats: https://developer.android.com/media/media3/exoplayer/supported-formats
+- Android HDR playback guidance: https://developer.android.com/media/grow/hdr-playback
+- Apple AVFoundation media playback: https://developer.apple.com/documentation/avfoundation/media_playback_and_selection
+- Apple AVPlayerItem: https://developer.apple.com/documentation/avfoundation/avplayeritem
+- mpv manual video-output drivers: https://mpv.io/manual/master/#video-output-drivers
+- mpv manual HDR options: https://mpv.io/manual/master/#options-hdr
+
+Repository evidence is `docs/migration/playback-backend-matrix.md`, `docs/migration/desktop-libmpv-feasibility.md`, and the current backend files named above. Revisit this matrix only with source-backed implementation, automated checks, packaged runtime evidence, and a real HDR device/display result. Do not create child GitHub issues from this plan.

--- a/flutter_client/test/playback/hdr_playback_matrix_contract_test.dart
+++ b/flutter_client/test/playback/hdr_playback_matrix_contract_test.dart
@@ -2,6 +2,152 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+const _targets = <String>[
+  'Android phone/tablet',
+  'Android TV',
+  'iOS',
+  'iPadOS',
+  'tvOS',
+  'macOS',
+  'Linux',
+  'Windows',
+];
+
+const _formats = <String>['HDR10', 'HDR10+', 'HLG', 'Dolby Vision'];
+
+const _decisions = <String>{
+  'source HDR detected',
+  'HDR output active',
+  'HDR tone-mapped to SDR',
+  'HDR unsupported/unavailable',
+};
+
+void _validateDocument(String text) {
+  for (final section in <String>[
+    'Threat Model',
+    'Acceptance Criteria',
+    'Detection',
+    'Presentation',
+    'Fallback',
+    'User Communication',
+  ]) {
+    if (!RegExp(
+      '^## ${RegExp.escape(section)}\$',
+      multiLine: true,
+    ).hasMatch(text)) {
+      throw StateError('The $section section is missing.');
+    }
+  }
+
+  final lines = text.split('\n');
+  final headerIndex = lines.indexWhere(
+    (line) =>
+        _tableCells(line).isNotEmpty && _tableCells(line).first == 'Target',
+  );
+  if (headerIndex == -1 || headerIndex + 1 >= lines.length) {
+    throw StateError('The decision table header is missing.');
+  }
+
+  final header = _tableCells(lines[headerIndex]);
+  final separator = _tableCells(lines[headerIndex + 1]);
+  if (header.length < 2 || separator.length != header.length) {
+    throw StateError('The decision table is malformed.');
+  }
+  if (separator.any((cell) => !RegExp(r'^:?-{3,}:?$').hasMatch(cell))) {
+    throw StateError('The decision table separator is malformed.');
+  }
+
+  final formatIndexes = <String, int>{};
+  for (final format in _formats) {
+    final indexes = <int>[
+      for (var index = 0; index < header.length; index++)
+        if (header[index] == format) index,
+    ];
+    if (indexes.length != 1) {
+      throw StateError('The $format column is missing or duplicated.');
+    }
+    formatIndexes[format] = indexes.single;
+  }
+
+  final rowsByTarget = <String, List<String>>{};
+  for (
+    var index = headerIndex + 2;
+    index < lines.length && lines[index].trimLeft().startsWith('|');
+    index++
+  ) {
+    final row = _tableCells(lines[index]);
+    if (row.length != header.length) {
+      throw StateError('The decision table row is malformed.');
+    }
+    final target = row.first;
+    if (!_targets.contains(target)) {
+      throw StateError('The decision table has an unexpected target row.');
+    }
+    if (rowsByTarget.containsKey(target)) {
+      throw StateError('The $target row is duplicated.');
+    }
+    rowsByTarget[target] = row;
+  }
+
+  if (rowsByTarget.length != _targets.length) {
+    throw StateError('The decision table has missing target rows.');
+  }
+  for (final target in _targets) {
+    final row = rowsByTarget[target];
+    if (row == null) {
+      throw StateError('The $target row is missing.');
+    }
+    for (final format in _formats) {
+      final decision = row[formatIndexes[format]!];
+      if (decision.isEmpty || !_decisions.contains(decision)) {
+        throw StateError('The $target $format decision is invalid.');
+      }
+    }
+  }
+
+  for (final target in _targets) {
+    if (!text.contains('## $target') ||
+        !text.contains(
+          '$target real-device/real-runtime: unverified/blocker',
+        ) ||
+        !text.contains('## $target\n\n') &&
+            !text.contains('## $target\r\n\r\n')) {
+      throw StateError('The $target real-device gate is missing.');
+    }
+  }
+
+  for (final requiredText in <String>[
+    'PR #209 is pending Draft',
+    'Issue #167 is In review',
+    'Server transcode is unverified and not HDR-capable until complete generated output and delivery path prove metadata preservation and renderer behavior.',
+    'Native events and diagnostics may contain only normalized non-sensitive transfer characteristics, color primaries, color space, and bit depth.',
+    'They must not contain stream URLs, headers, credentials, tokens, or raw native payloads.',
+    'Child-delivery plan:',
+    'https://developer.android.com/media/media3/exoplayer/supported-formats',
+    'https://developer.apple.com/documentation/avfoundation/media_playback_and_selection',
+    'https://mpv.io/manual/master/#options-hdr',
+  ]) {
+    if (!text.contains(requiredText)) {
+      throw StateError('Required evidence is missing: $requiredText');
+    }
+  }
+  if (text.contains('\u2013') || text.contains('\u2014')) {
+    throw StateError('The document contains a prohibited dash character.');
+  }
+}
+
+List<String> _tableCells(String line) {
+  final trimmed = line.trim();
+  if (!trimmed.startsWith('|') || !trimmed.endsWith('|')) {
+    return const <String>[];
+  }
+  return trimmed
+      .substring(1, trimmed.length - 1)
+      .split('|')
+      .map((cell) => cell.trim())
+      .toList();
+}
+
 void main() {
   test('HDR playback matrix records the phase-one delivery contract', () {
     final document = File('../docs/migration/hdr-playback-matrix.md');
@@ -9,56 +155,21 @@ void main() {
     expect(document.existsSync(), isTrue);
     final text = document.readAsStringSync();
 
-    for (final target in <String>[
-      'Android phone/tablet',
-      'Android TV',
-      'iOS',
-      'iPadOS',
-      'tvOS',
-      'macOS',
-      'Linux',
-      'Windows',
-    ]) {
-      expect(text, contains('## $target'));
-      expect(
-        text,
-        contains('$target real-device/real-runtime: unverified/blocker'),
-      );
-    }
+    _validateDocument(text);
+  });
 
-    for (final format in <String>['HDR10', 'HDR10+', 'HLG', 'Dolby Vision']) {
-      expect(text, contains(format));
-    }
-    for (final state in <String>[
-      'source HDR detected',
-      'HDR output active',
-      'HDR tone-mapped to SDR',
-      'HDR unsupported/unavailable',
-    ]) {
-      expect(text, contains(state));
-    }
+  test('HDR playback matrix rejects a blank Android phone/tablet HDR10 cell', () {
+    final text = File(
+      '../docs/migration/hdr-playback-matrix.md',
+    ).readAsStringSync();
+    _validateDocument(text);
 
-    expect(text, contains('PR #209 is pending Draft'));
-    expect(text, contains('Issue #167 is In review'));
-    expect(
-      text,
-      contains(
-        'Server transcode is unverified and not HDR-capable until complete generated output and delivery path prove metadata preservation and renderer behavior.',
-      ),
+    final mutated = text.replaceFirst(
+      '| Android phone/tablet | Media3 ExoPlayer to Flutter texture | HDR unsupported/unavailable |',
+      '| Android phone/tablet | Media3 ExoPlayer to Flutter texture |  |',
     );
-    expect(
-      text,
-      contains(
-        'Native events and diagnostics may contain only normalized non-sensitive transfer characteristics, color primaries, color space, and bit depth.',
-      ),
-    );
-    expect(
-      text,
-      contains(
-        'They must not contain stream URLs, headers, credentials, tokens, or raw native payloads.',
-      ),
-    );
-    expect(text, contains('| Target | Backend and native path |'));
-    expect(text, contains('| HDR10 | HDR10+ | HLG | Dolby Vision |'));
+
+    expect(mutated, isNot(equals(text)));
+    expect(() => _validateDocument(mutated), throwsStateError);
   });
 }

--- a/flutter_client/test/playback/hdr_playback_matrix_contract_test.dart
+++ b/flutter_client/test/playback/hdr_playback_matrix_contract_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('HDR playback matrix records the phase-one delivery contract', () {
+    final document = File('../docs/migration/hdr-playback-matrix.md');
+
+    expect(document.existsSync(), isTrue);
+    final text = document.readAsStringSync();
+
+    for (final target in <String>[
+      'Android phone/tablet',
+      'Android TV',
+      'iOS',
+      'iPadOS',
+      'tvOS',
+      'macOS',
+      'Linux',
+      'Windows',
+    ]) {
+      expect(text, contains('## $target'));
+      expect(
+        text,
+        contains('$target real-device/real-runtime: unverified/blocker'),
+      );
+    }
+
+    for (final format in <String>['HDR10', 'HDR10+', 'HLG', 'Dolby Vision']) {
+      expect(text, contains(format));
+    }
+    for (final state in <String>[
+      'source HDR detected',
+      'HDR output active',
+      'HDR tone-mapped to SDR',
+      'HDR unsupported/unavailable',
+    ]) {
+      expect(text, contains(state));
+    }
+
+    expect(text, contains('PR #209 is pending Draft'));
+    expect(text, contains('Issue #167 is In review'));
+    expect(
+      text,
+      contains(
+        'Server transcode is unverified and not HDR-capable until complete generated output and delivery path prove metadata preservation and renderer behavior.',
+      ),
+    );
+    expect(
+      text,
+      contains(
+        'Native events and diagnostics may contain only normalized non-sensitive transfer characteristics, color primaries, color space, and bit depth.',
+      ),
+    );
+    expect(
+      text,
+      contains(
+        'They must not contain stream URLs, headers, credentials, tokens, or raw native payloads.',
+      ),
+    );
+    expect(text, contains('| Target | Backend and native path |'));
+    expect(text, contains('| HDR10 | HDR10+ | HLG | Dolby Vision |'));
+  });
+}


### PR DESCRIPTION
Part of #168

Adds the phase-one evidence-backed HDR decision matrix and deterministic document contract test. No playback or native runtime behavior changes.
