### PR TITLE
fix(player): commercial-skip for recordings played from Movies and Series

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1285,6 +1285,7 @@ class AppShellState extends ConsumerState<AppShell>
                   epgService: _appState.epgService,
                   xtreamService: _appState.xtreamService,
                   comskipSettings: _appState.comskipSettings,
+                  hasDvrFeature: _appState.hasDvrFeature,
                   viewerId: viewerId,
                   onNextChannel: args.type == 'live' ? _openNextChannel : null,
                   onPreviousChannel: args.type == 'live'

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -38,6 +38,7 @@ class PlayerScreen extends StatefulWidget {
     required this.epgService,
     this.xtreamService,
     this.comskipSettings,
+    this.hasDvrFeature = false,
     this.progressReporter,
     this.traktService,
     this.wakelockController = const PlatformWakelockController(),
@@ -56,6 +57,7 @@ class PlayerScreen extends StatefulWidget {
   final EpgService epgService;
   final XtreamService? xtreamService;
   final ComskipSettings? comskipSettings;
+  final bool hasDvrFeature;
   final void Function(Progress progress)? progressReporter;
   final TraktService? traktService;
   final WakelockController wakelockController;
@@ -296,8 +298,13 @@ class _PlayerScreenState extends State<PlayerScreen> {
   /// any fetch failure just leaves [_comskipSegments] empty, so the rest of
   /// the player behaves exactly as if this recording had no EDL at all.
   Future<void> _initComskip(PlayerArgs args) async {
-    final edlUrl = args.metadata['edl_url'] as String?;
-    if (edlUrl == null || edlUrl.isEmpty) return;
+    var edlUrl = args.metadata['edl_url'] as String?;
+    if (edlUrl == null || edlUrl.isEmpty) {
+      if (!widget.hasDvrFeature || widget.xtreamService == null) return;
+      edlUrl = await _resolveEdlUrlFromService(args);
+      if (!mounted || !identical(args, widget.args)) return;
+      if (edlUrl == null || edlUrl.isEmpty) return;
+    }
 
     final client = HttpClient();
     try {
@@ -328,6 +335,34 @@ class _PlayerScreenState extends State<PlayerScreen> {
     } finally {
       client.close();
     }
+  }
+
+  /// Lazily resolves an `edl_url` for play paths that don't carry the field
+  /// on the originating `PlayerArgs` — notably Continue Watching for series
+  /// episodes, which only holds a `Progress` and a `Series` summary.
+  /// Gated on the `hasDvrFeature` flag to keep non-DVR accounts off the
+  /// extra call (the series branch fetches the full `get_series_info`
+  /// payload).
+  Future<String?> _resolveEdlUrlFromService(PlayerArgs args) async {
+    final service = widget.xtreamService;
+    if (service == null) return null;
+    try {
+      if (args.type == 'vod' && args.streamId != null) {
+        final info = await service.getVodInfo(args.streamId!);
+        return info.edlUrl;
+      }
+      if (args.type == 'series' && args.seriesId != null) {
+        final info = await service.getSeriesInfo(args.seriesId!);
+        final episode = info.episodesBySeason.values
+            .expand((eps) => eps)
+            .where((e) => e.id == '${args.streamId}')
+            .firstOrNull;
+        return episode?.edlUrl;
+      }
+    } on Object catch (error) {
+      debugPrint('Comskip: failed to resolve EDL: $error');
+    }
+    return null;
   }
 
   /// Rewrites a localhost/127.0.0.1 EDL host to the connected Xtream server's

--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -188,6 +188,7 @@ class _SeriesDetailsScreenState extends State<SeriesDetailsScreen> {
             'plot': episode.plot
           else if (_seriesInfo?.series.plot != null)
             'plot': _seriesInfo!.series.plot,
+          if (episode.edlUrl != null) 'edl_url': episode.edlUrl,
         },
       ),
     );

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -297,6 +297,7 @@ class _VodDetailsBody extends StatelessWidget {
           if (details.coverUrl != null) 'thumbnail_url': details.coverUrl,
           if (details.tmdbId != null) 'tmdb_id': details.tmdbId,
           if (details.plot != null) 'plot': details.plot,
+          if (details.edlUrl != null) 'edl_url': details.edlUrl,
         },
       ),
     );
@@ -322,6 +323,7 @@ class _ResolvedVodDetails {
   String? get containerExtension =>
       _notEmpty(info?.containerExtension) ?? item.containerExtension;
   int? get tmdbId => info?.tmdbId;
+  String? get edlUrl => _notEmpty(info?.edlUrl);
 }
 
 String? _notEmpty(String? value) {

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -160,6 +160,7 @@ class VodInfo {
     this.backdropUrl,
     this.containerExtension,
     this.tmdbId,
+    this.edlUrl,
   });
 
   final int id;
@@ -176,6 +177,7 @@ class VodInfo {
   final String? backdropUrl;
   final String? containerExtension;
   final int? tmdbId;
+  final String? edlUrl;
 
   factory VodInfo.fromXtream(Map<String, Object?> json) {
     final info = _asMap(json['info']);
@@ -222,6 +224,7 @@ class VodInfo {
         pick(['container_extension', 'containerExtension']),
       ),
       tmdbId: _asIntOrNull(pick(['tmdb_id', 'tmdb'])),
+      edlUrl: _asNullableString(pick(['edl_url'])),
     );
   }
 }
@@ -293,6 +296,7 @@ class Episode {
     this.duration,
     this.releaseDate,
     this.streamUrl,
+    this.edlUrl,
   });
 
   final String id;
@@ -306,6 +310,7 @@ class Episode {
   final String? duration;
   final String? releaseDate;
   final String? streamUrl;
+  final String? edlUrl;
 
   factory Episode.fromXtream(Map<String, Object?> json, {String? streamUrl}) {
     final info =
@@ -337,6 +342,7 @@ class Episode {
         pick(['release_date', 'releasedate', 'air_date']),
       ),
       streamUrl: streamUrl,
+      edlUrl: _asNullableString(pick(['edl_url'])),
     );
   }
 }

--- a/flutter_client/lib/services/xtream_service.dart
+++ b/flutter_client/lib/services/xtream_service.dart
@@ -890,6 +890,7 @@ class XtreamService {
               duration: episode.duration,
               releaseDate: episode.releaseDate,
               streamUrl: episode.streamUrl,
+              edlUrl: episode.edlUrl,
             );
           })
           .toList(growable: false);

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -133,6 +133,59 @@ void main() {
     });
   });
 
+  group('VodInfo.edlUrl from get_vod_info', () {
+    test('reads edl_url nested under info (DVR-backed movie)', () {
+      final info = VodInfo.fromXtream(<String, Object?>{
+        'info': {
+          'edl_url': 'https://xtream.example/dvr/movie/edl',
+        },
+        'movie_data': {
+          'stream_id': 201,
+          'name': 'Recorded Movie',
+          'container_extension': 'mp4',
+        },
+      });
+      expect(info.edlUrl, 'https://xtream.example/dvr/movie/edl');
+    });
+
+    test('null when no edl_url is present anywhere', () {
+      final info = VodInfo.fromXtream(<String, Object?>{
+        'info': {'plot': 'A regular movie'},
+        'movie_data': {
+          'stream_id': 202,
+          'name': 'Regular Movie',
+          'container_extension': 'mp4',
+        },
+      });
+      expect(info.edlUrl, isNull);
+    });
+  });
+
+  group('Episode.edlUrl from get_series_info', () {
+    test('reads top-level edl_url (DVR-backed episode)', () {
+      final episode = Episode.fromXtream(<String, Object?>{
+        'id': '123',
+        'episode_num': 2,
+        'title': 'Target Episode',
+        'container_extension': 'mp4',
+        'season': 1,
+        'edl_url': 'https://xtream.example/dvr/series/ep-edl',
+      });
+      expect(episode.edlUrl, 'https://xtream.example/dvr/series/ep-edl');
+    });
+
+    test('null when edl_url is absent', () {
+      final episode = Episode.fromXtream(<String, Object?>{
+        'id': '124',
+        'episode_num': 1,
+        'title': 'Non-DVR Episode',
+        'container_extension': 'mp4',
+        'season': 1,
+      });
+      expect(episode.edlUrl, isNull);
+    });
+  });
+
   group('DvrStorageInfo.fromXtream', () {
     test('parses a quota-scoped response', () {
       final info = DvrStorageInfo.fromXtream(<String, Object?>{

--- a/flutter_client/test/services/service_contract_test.dart
+++ b/flutter_client/test/services/service_contract_test.dart
@@ -741,6 +741,54 @@ void main() {
       },
     );
 
+    test(
+      'getSeriesInfo preserves edlUrl through the season-0 rebuild',
+      () async {
+        final transport = FakeXtreamTransport({
+          'auth': xtreamAuth(auth: 1),
+          'get_series_info': {
+            'seasons': <Map<String, Object?>>[],
+            'info': seriesItem(301, 'Fixture Show', '30'),
+            'episodes': <String, Object?>{
+              '1': <Map<String, Object?>>[
+                <String, Object?>{
+                  'id': '9001',
+                  'episode_num': 1,
+                  'title': 'DVR Episode',
+                  'container_extension': 'mp4',
+                  'season': 0,
+                  'edl_url': 'https://xtream.example/dvr/series/9001/edl',
+                },
+              ],
+            },
+          },
+        });
+        final service = XtreamService(transport: transport.call);
+        await service.authenticate(
+          const UserCredentials(
+            server: 'https://xtream.example',
+            username: 'demo',
+            password: 'secret',
+          ),
+        );
+
+        final info = await service.getSeriesInfo(301);
+
+        final episode = info.episodesBySeason[1]!.single;
+        expect(episode.id, '9001');
+        expect(
+          episode.seasonNumber,
+          1,
+          reason: 'season-0 in payload should be backfilled from map key',
+        );
+        expect(
+          episode.edlUrl,
+          'https://xtream.example/dvr/series/9001/edl',
+          reason: 'season-0 rebuild must not drop edlUrl',
+        );
+      },
+    );
+
     test('VOD info parses m3u-editor get_vod_info metadata', () async {
       final transport = FakeXtreamTransport({
         'auth': xtreamAuth(auth: 1),

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -3525,6 +3525,491 @@ void main() {
           }, createHttpClient: (_) => httpClient);
         },
       );
+
+      testWidgets(
+        'fast path with edl_url in metadata does not call XtreamService',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final requestedActions = <String>[];
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action != null) {
+                requestedActions.add(request.action!);
+              }
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([
+              {'start': 10.0, 'end': 20.0},
+            ]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: recordingArgs,
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  hasDvrFeature: true,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(
+              requestedActions.contains('get_vod_info'),
+              isFalse,
+              reason:
+                  'Fast path must not call getVodInfo when metadata has edl_url',
+            );
+            expect(
+              requestedActions.contains('get_series_info'),
+              isFalse,
+              reason:
+                  'Fast path must not call getSeriesInfo when metadata has edl_url',
+            );
+            expect(httpClient.requestedUrls.single.host, 'example.com');
+            expect(
+              httpClient.requestedUrls.single.path,
+              '/recording/edl',
+            );
+          }, createHttpClient: (_) => httpClient);
+        },
+      );
+
+      testWidgets(
+        'VOD fallback resolves edl_url via getVodInfo when metadata lacks it',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              if (request.action == 'get_vod_info') {
+                return <String, Object?>{
+                  'info': {
+                    'edl_url': 'https://xtream.example/dvr/vod/edl',
+                  },
+                };
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([
+              {'start': 30.0, 'end': 60.0},
+            ]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: const PlayerArgs(
+                    streamUrl: 'https://xtream.example/recording.mp4',
+                    title: 'VOD Fallback Fixture',
+                    type: 'vod',
+                    streamId: 4242,
+                  ),
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  hasDvrFeature: true,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(httpClient.requestedUrls, isNotEmpty);
+            expect(
+              httpClient.requestedUrls.single.toString(),
+              'https://xtream.example/dvr/vod/edl',
+            );
+          }, createHttpClient: (_) => httpClient);
+        },
+      );
+
+      testWidgets(
+        'series fallback matches episode by id and fetches its edl_url',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              if (request.action == 'get_series_info') {
+                return <String, Object?>{
+                  'seasons': <Map<String, Object?>>[],
+                  'info': <String, Object?>{},
+                  'episodes': <String, Object?>{
+                    '1': <Map<String, Object?>>[
+                      <String, Object?>{
+                        'id': '99',
+                        'episode_num': 1,
+                        'title': 'Not This One',
+                        'container_extension': 'mp4',
+                        'season': 1,
+                      },
+                      <String, Object?>{
+                        'id': '123',
+                        'episode_num': 2,
+                        'title': 'Target Episode',
+                        'container_extension': 'mp4',
+                        'season': 1,
+                        'edl_url': 'https://xtream.example/dvr/series/ep-edl',
+                      },
+                    ],
+                  },
+                };
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([
+              {'start': 90.0, 'end': 120.0},
+            ]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: const PlayerArgs(
+                    streamUrl: 'https://xtream.example/series/123.mp4',
+                    title: 'Series Fallback Fixture',
+                    type: 'series',
+                    streamId: 123,
+                    seriesId: 7,
+                  ),
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  hasDvrFeature: true,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(httpClient.requestedUrls, isNotEmpty);
+            expect(
+              httpClient.requestedUrls.single.toString(),
+              'https://xtream.example/dvr/series/ep-edl',
+            );
+          }, createHttpClient: (_) => httpClient);
+        },
+      );
+      testWidgets(
+        'gate closed: hasDvrFeature false issues no XtreamService call',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final requestedActions = <String>[];
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action != null) {
+                requestedActions.add(request.action!);
+              }
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([
+              {'start': 10.0, 'end': 20.0},
+            ]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: const PlayerArgs(
+                    streamUrl: 'https://xtream.example/recording.mp4',
+                    title: 'Gate Closed Fixture',
+                    type: 'vod',
+                    streamId: 4242,
+                  ),
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(
+              requestedActions.contains('get_vod_info'),
+              isFalse,
+              reason:
+                  'Gate must suppress getVodInfo when hasDvrFeature is false',
+            );
+            expect(
+              requestedActions.contains('get_series_info'),
+              isFalse,
+              reason:
+                  'Gate must suppress getSeriesInfo when hasDvrFeature is false',
+            );
+            expect(httpClient.requestedUrls, isEmpty);
+            expect(find.text('Skipped commercial'), findsNothing);
+            expect(find.text('Skip commercial'), findsNothing);
+          }, createHttpClient: (_) => httpClient);
+        },
+      );
+
+      testWidgets(
+        'fail-open: server returns no edl_url yields no comskip UI and no crash',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              if (request.action == 'get_vod_info') {
+                return <String, Object?>{'info': <String, Object?>{}};
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([
+              {'start': 10.0, 'end': 20.0},
+            ]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: const PlayerArgs(
+                    streamUrl: 'https://xtream.example/recording.mp4',
+                    title: 'Fail-open Fixture',
+                    type: 'vod',
+                    streamId: 4242,
+                  ),
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  hasDvrFeature: true,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(httpClient.requestedUrls, isEmpty);
+            expect(adapter.seekCalls, isEmpty);
+            expect(find.text('Skipped commercial'), findsNothing);
+            expect(find.text('Skip commercial'), findsNothing);
+          }, createHttpClient: (_) => httpClient);
+        },
+      );
+
+      testWidgets(
+        'loopback rewrite applies to a fallback-resolved edl_url',
+        (tester) async {
+          final adapter = FakePlayerAdapter(
+            capabilities: PlaybackCapabilities.desktopLibmpv,
+            textureId: 1,
+          );
+          final orchestrator = buildOrchestrator(adapter);
+          addTearDown(orchestrator.dispose);
+
+          final xtreamService = XtreamService(
+            transport: (request) async {
+              if (request.action == null) {
+                return {
+                  'user_info': {'auth': 1, 'status': 'Active'},
+                  'm3u_editor': {'version': 'fixture'},
+                };
+              }
+              if (request.action == 'get_vod_info') {
+                return <String, Object?>{
+                  'info': {
+                    'edl_url': 'http://localhost/dvr/fallback/edl',
+                  },
+                };
+              }
+              return <String, Object?>{};
+            },
+          );
+          await xtreamService.authenticate(
+            const UserCredentials(
+              server: 'https://xtream.example',
+              username: 'demo',
+              password: 'secret',
+            ),
+          );
+
+          final httpClient = _FakeHttpClient(
+            jsonEncode([
+              {'start': 10.0, 'end': 20.0},
+            ]),
+          );
+
+          await HttpOverrides.runZoned(() async {
+            await tester.pumpWidget(
+              MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: PlayerScreen(
+                  args: const PlayerArgs(
+                    streamUrl: 'https://xtream.example/recording.mp4',
+                    title: 'Loopback Fallback Fixture',
+                    type: 'vod',
+                    streamId: 4242,
+                  ),
+                  orchestrator: orchestrator,
+                  epgService: EpgService(clock: () => DateTime.utc(2026)),
+                  xtreamService: xtreamService,
+                  hasDvrFeature: true,
+                  comskipSettings: ComskipSettings(),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            for (var i = 0; i < 10; i++) {
+              await tester.pump(const Duration(milliseconds: 10));
+            }
+
+            expect(httpClient.requestedUrls, isNotEmpty);
+            final fetched = httpClient.requestedUrls.single;
+            expect(fetched.scheme, 'https');
+            expect(fetched.host, 'xtream.example');
+            expect(fetched.path, '/dvr/fallback/edl');
+          }, createHttpClient: (_) => httpClient);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Problem

Commercial skipping only worked when a DVR recording was played from the **Recordings** screen. That screen was the sole path putting `edl_url` into `PlayerArgs.metadata` (`dvr_recordings_screen.dart:823`), and the player reads it in exactly one place (`_initComskip`). Playing the **exact same file** from Movies or Series reached the player with no EDL, so comskip was silently unavailable.

Not a regression — an unimplemented path.

## What this does

Carries the EDL through the paths that already hold the data, and resolves it lazily for the one that doesn't.

**Fast path — no extra network call.** Both detail screens have already fetched the payload:
- Parse `edl_url` into `VodInfo` and `Episode` (reusing each model's existing `pick()` helper).
- Pass it into player metadata from `vod_details_screen` and `series_details_screen`.

**The season-0 trap.** `getSeriesInfo` rebuilds `Episode` field-by-field when `seasonNumber == 0`, to backfill the season from the map key. Any field not listed there is silently dropped — and DVR episodes take their season from EPG data, so season 0 is a realistic case. `edlUrl` is now preserved through that rebuild, with a regression test.

**Lazy fallback for Continue Watching.** `_openProgress`'s episode branch holds only a `Progress` and a `Series` — it never loads an `Episode`. Rather than patch that call site, `_initComskip` resolves via `getVodInfo`/`getSeriesInfo` when metadata lacks the field. This covers every current and future play path.

**The fallback is gated on `hasDvrFeature`.** Ungated it would fire on every non-recording movie and episode, and the series branch pulls a full `get_series_info` payload (all seasons, all episodes) on every episode start. That would be a user-visible regression traded for a rare case.

## Behaviour preserved

Fail-open is unchanged: an older server, a non-recording item, or any fetch failure leaves the segment list empty and the player behaves exactly as it does today. Fallback-resolved URLs still go through `_resolveEdlUri`, so the existing loopback-host rewrite applies to them too — both server instances emit loopback URLs, so that workaround remains load-bearing.

`VodItem` deliberately gains no `edlUrl`: `get_vod_streams` doesn't send it (streaming cursor, would be an N+1 server-side), so the field would always be null and would read as a bug. That path is covered by the fallback instead.

## Tests

6 new player tests plus model-parse and season-0 rebuild coverage. Mutation-checked — removing the DVR gate, the season-0 line, or either model's parse each fails the corresponding test. The gate test asserts **no service call is issued**, not merely that no UI appears; a UI-only assertion would pass even if the fetch fired.

`dart format --set-exit-if-changed` clean, `flutter analyze lib test` clean, 156/156 on the targeted files, `test/ui/` green.

Two intermittent failures in `push_token_lifecycle_test` / `media_request_ownership_test` are **pre-existing and unrelated** — confirmed by running them 4x on the clean parent commit with no changes applied, where the same test fails 1-in-4. Worth triaging separately.

## Verification

Confirmed working end-to-end against a real recording: commercial skipping now happens when playing from Movies and from Series, matching the Recordings screen.

## Related

Requires the server change emitting `edl_url` from `get_vod_info` / `get_series_info`: **m3ue/m3u-editor#1425**. That must land first — this degrades silently (no comskip, no errors) against a server without those fields.