### PR TITLE
feat(shows-detail): schedule multiple hand-picked airings in one pass (#204)

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -779,7 +779,7 @@ class AppShellState extends ConsumerState<AppShell>
 
   /// Schedules a batch of DVR airings for one Shows-search selection.
   /// Per-item failures land inside the returned list (the screen turns that
-  /// into a single summary SnackBar) — no per-item SnackBars here, mirroring
+  /// into a single summary SnackBar), no per-item SnackBars here, mirroring
   /// the single-item `_scheduleDvrAiring`'s "screen owns feedback" rule.
   Future<List<DvrAiringScheduleResult>> _scheduleDvrAirings(
     List<EpgShowEpisode> episodes,

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -777,6 +777,16 @@ class AppShellState extends ConsumerState<AppShell>
     );
   }
 
+  /// Schedules a batch of DVR airings for one Shows-search selection.
+  /// Per-item failures land inside the returned list (the screen turns that
+  /// into a single summary SnackBar) — no per-item SnackBars here, mirroring
+  /// the single-item `_scheduleDvrAiring`'s "screen owns feedback" rule.
+  Future<List<DvrAiringScheduleResult>> _scheduleDvrAirings(
+    List<EpgShowEpisode> episodes,
+  ) {
+    return _appState.scheduleDvrAirings(episodes);
+  }
+
   /// Calls the foundation-agent-owned `XtreamService.createDvrSeriesRule`
   /// and refreshes the cached series rules list so the DVR screen's new
   /// "Series Rules" section reflects the addition immediately.
@@ -1259,6 +1269,7 @@ class AppShellState extends ConsumerState<AppShell>
       onRecordSeries: _createDvrSeriesRule,
       onDeleteSeriesRule: _deleteDvrSeriesRule,
       onScheduleEpisode: _scheduleDvrAiring,
+      onScheduleEpisodes: _scheduleDvrAirings,
       buildTabScreen: _buildTabScreen,
       child: FocusScope(
         node: _contentFocusNode,

--- a/flutter_client/lib/features/shows/show_detail_screen.dart
+++ b/flutter_client/lib/features/shows/show_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:m3u_tv/features/dvr/dvr_series_rule_options_screen.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/app_button.dart';
@@ -31,6 +32,7 @@ class ShowDetailScreen extends ConsumerStatefulWidget {
     this.onRecordSeries,
     this.onDeleteSeriesRule,
     this.onScheduleEpisode,
+    this.onScheduleEpisodes,
   });
 
   final EpgShow show;
@@ -64,6 +66,16 @@ class ShowDetailScreen extends ConsumerStatefulWidget {
   final Future<DvrRecording?> Function(EpgShowEpisode episode)?
   onScheduleEpisode;
 
+  /// Schedules a batch of DVR airings for the user-selected episodes in
+  /// selection mode. Wired by AppShell against
+  /// `AppStateController.scheduleDvrAirings`. Null means selection mode is
+  /// unavailable entirely (no long-press affordance, no action bar) — a mode
+  /// with no exit would trap the user.
+  final Future<List<DvrAiringScheduleResult>> Function(
+    List<EpgShowEpisode>,
+  )?
+  onScheduleEpisodes;
+
   @override
   ConsumerState<ShowDetailScreen> createState() => _ShowDetailScreenState();
 }
@@ -76,6 +88,17 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
   /// the same channel at different times) are tracked independently. Guards
   /// against double-tap double-scheduling while the request is in flight.
   final Set<String> _submittingEpisodeKeys = {};
+
+  /// True when the user has long-pressed an episode row to enter multi-
+  /// select mode. While true, the per-row Record button is hidden, the
+  /// episode list is tappable (toggle selection), and the action bar shows
+  /// "Record (N)" + "Cancel".
+  bool _selectionMode = false;
+
+  /// Selected episode keys in selection mode. Uses the same
+  /// `channelId|startTime` key as [_submittingEpisodeKeys] / [_episodeRecordKey]
+  /// so the two sets stay disjoint in their semantics.
+  final Set<String> _selectedEpisodeKeys = {};
 
   Future<void> _scheduleEpisode(EpgShowEpisode episode) async {
     final handler = widget.onScheduleEpisode;
@@ -94,6 +117,100 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
         setState(() => _submittingEpisodeKeys.remove(episodeKey));
       }
     }
+  }
+
+  /// Enters selection mode with [episode] as the initially-selected row.
+  /// Caller guards `onScheduleEpisodes != null` (the long-press affordance is
+  /// wired conditionally so this method is never called when the handler is
+  /// missing — but the guard is defensive in case the entry point changes).
+  void _enterSelectionMode(EpgShowEpisode episode) {
+    if (widget.onScheduleEpisodes == null) return;
+    setState(() {
+      _selectionMode = true;
+      _selectedEpisodeKeys
+        ..clear()
+        ..add(_episodeRecordKey(episode));
+    });
+  }
+
+  /// Toggles [episode] in the current selection. Caller is responsible for
+  /// wiring this only when the row is selectable (i.e. not
+  /// already-scheduled).
+  void _toggleSelection(EpgShowEpisode episode) {
+    final key = _episodeRecordKey(episode);
+    setState(() {
+      if (!_selectedEpisodeKeys.add(key)) {
+        _selectedEpisodeKeys.remove(key);
+      }
+    });
+  }
+
+  /// Exits selection mode and clears the selection. Called by the Cancel
+  /// button and by [_scheduleSelected] after the batch handler completes.
+  void _exitSelectionMode() {
+    setState(() {
+      _selectionMode = false;
+      _selectedEpisodeKeys.clear();
+    });
+  }
+
+  /// Runs the batch schedule handler for the user's selected episodes, then
+  /// exits selection mode and surfaces a single summary SnackBar.
+  Future<void> _scheduleSelected() async {
+    final handler = widget.onScheduleEpisodes;
+    if (handler == null || _selectedEpisodeKeys.isEmpty) return;
+    final selectedEpisodes = widget.show.recentEpisodes
+        .where((e) => _selectedEpisodeKeys.contains(_episodeRecordKey(e)))
+        .toList(growable: false);
+
+    // Capture the messenger + l10n BEFORE the await — `context` becomes
+    // invalid if the widget unmounts while the batch is in flight.
+    final messenger = ScaffoldMessenger.of(context);
+    final l10n = AppLocalizations.of(context);
+
+    try {
+      final results = await handler(selectedEpisodes);
+      if (!mounted) return;
+      final scheduled = results.where((r) => r.success).length;
+      final failed = results.length - scheduled;
+      final failureTitles = [
+        for (final r in results)
+          if (!r.success) r.episode.displayTitle,
+      ];
+      messenger.showSnackBar(
+        SnackBar(
+          content: Text(
+            _buildBatchSummary(l10n, scheduled, failed, failureTitles),
+          ),
+        ),
+      );
+    } on Object catch (error) {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text(l10n.appRecordingFailed(error.toString()))),
+      );
+    } finally {
+      if (mounted) _exitSelectionMode();
+    }
+  }
+
+  /// Builds the single summary line for the post-batch SnackBar.
+  ///
+  /// Per the plan's judgment call (state in Worker status), failed-episode
+  /// titles are listed inline only when [failed] is between 1 and 3
+  /// inclusive — beyond that the line would overrun the SnackBar width.
+  /// failed == 0 collapses to the summary alone ("All succeeded.").
+  String _buildBatchSummary(
+    AppLocalizations l10n,
+    int scheduled,
+    int failed,
+    List<String> failureTitles,
+  ) {
+    final summary = l10n.showBatchScheduleSummary(scheduled, failed);
+    if (failed > 0 && failed <= 3 && failureTitles.isNotEmpty) {
+      return '$summary\n${l10n.showBatchScheduleFailures(failureTitles.join(', '))}';
+    }
+    return summary;
   }
 
   DvrSeriesRule? _findExistingRule(List<DvrSeriesRule> rules) {
@@ -229,6 +346,10 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
     final rules = ref.watch(dvrSeriesRulesProvider);
     final existingRule = show.hasSeriesRule ? _findExistingRule(rules) : null;
 
+    // Watching so a freshly-scheduled airing (single tap or batch) flips
+    // the per-row "Scheduled" badge without a full route re-push.
+    final recordings = ref.watch(dvrRecordingsProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.showDetailTitle),
@@ -258,6 +379,9 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
               hasRule: existingRule != null,
               ruleLabel: l10n.showSeriesRuleActive,
               deleteTooltip: l10n.showDeleteRule,
+              // Hide the Record Series controls while in selection mode so
+              // they don't compete for focus with the episode-list action bar.
+              hideActions: _selectionMode,
               onRecordSeries: () => _recordSeries(
                 channelId: nextAiringChannelId(widget.show),
               ),
@@ -277,6 +401,16 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
               ),
             ),
             const SizedBox(height: MediaBrowsingMetrics.itemGap),
+            if (_selectionMode) ...[
+              _SelectionActionsBar(
+                selectedCount: _selectedEpisodeKeys.length,
+                onRecord: _selectedEpisodeKeys.isEmpty
+                    ? null
+                    : _scheduleSelected,
+                onCancel: _exitSelectionMode,
+              ),
+              const SizedBox(height: MediaBrowsingMetrics.itemGap),
+            ],
             if (show.recentEpisodes.isEmpty)
               Center(
                 child: Text(
@@ -286,21 +420,48 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
               )
             else
               ...show.recentEpisodes.map(
-                (episode) => Padding(
-                  padding: const EdgeInsets.only(
-                    bottom: MediaBrowsingMetrics.itemGap,
-                  ),
-                  child: _EpisodeRow(
-                    episode: episode,
-                    localeTag: localized,
-                    onScheduleEpisode: widget.onScheduleEpisode == null
-                        ? null
-                        : _scheduleEpisode,
-                    isScheduling: _submittingEpisodeKeys.contains(
-                      _episodeRecordKey(episode),
+                (episode) {
+                  final alreadyScheduled = _isAlreadyScheduled(
+                    episode,
+                    recordings,
+                  );
+                  final episodeKey = _episodeRecordKey(episode);
+                  final rowSelectable = !alreadyScheduled;
+                  return Padding(
+                    padding: const EdgeInsets.only(
+                      bottom: MediaBrowsingMetrics.itemGap,
                     ),
-                  ),
-                ),
+                    child: _EpisodeRow(
+                      episode: episode,
+                      localeTag: localized,
+                      alreadyScheduled: alreadyScheduled,
+                      selectionMode: _selectionMode,
+                      selected: _selectedEpisodeKeys.contains(episodeKey),
+                      // Long-press: enter mode (normal mode) or toggle (in mode).
+                      // Only available when selection mode is reachable AND
+                      // this row is selectable.
+                      onLongTap:
+                          (widget.onScheduleEpisodes != null &&
+                              !_selectionMode &&
+                              rowSelectable)
+                          ? () => _enterSelectionMode(episode)
+                          : (_selectionMode && rowSelectable
+                                ? () => _toggleSelection(episode)
+                                : null),
+                      // Tap: only meaningful in selection mode (toggle).
+                      onTap: _selectionMode && rowSelectable
+                          ? () => _toggleSelection(episode)
+                          : null,
+                      onScheduleEpisode:
+                          !_selectionMode &&
+                              widget.onScheduleEpisode != null &&
+                              rowSelectable
+                          ? _scheduleEpisode
+                          : null,
+                      isScheduling: _submittingEpisodeKeys.contains(episodeKey),
+                    ),
+                  );
+                },
               ),
           ],
         ),
@@ -323,6 +484,7 @@ class _Header extends StatelessWidget {
     required this.onRecordSeries,
     required this.onOpenOptions,
     required this.onDeleteRule,
+    this.hideActions = false,
   });
 
   final String title;
@@ -338,12 +500,17 @@ class _Header extends StatelessWidget {
   final VoidCallback onOpenOptions;
   final VoidCallback? onDeleteRule;
 
+  /// When true, suppresses the trailing action area entirely so it doesn't
+  /// compete for focus with the episode-list selection-mode action bar.
+  final bool hideActions;
+
   // Below this width the title + action buttons no longer fit on one row
   // (on a phone, forcing them into a Row starves the title's Expanded column
   // down to a sliver, wrapping every word onto its own line).
   static const double _narrowBreakpoint = 420;
 
   Widget? _buildActions(AppLocalizations l10n) {
+    if (hideActions) return null;
     if (hasRule) {
       return Wrap(
         crossAxisAlignment: WrapCrossAlignment.center,
@@ -454,16 +621,43 @@ class _EpisodeRow extends StatefulWidget {
   const _EpisodeRow({
     required this.episode,
     required this.localeTag,
+    this.alreadyScheduled = false,
+    this.selectionMode = false,
+    this.selected = false,
     this.onScheduleEpisode,
+    this.onTap,
+    this.onLongTap,
     this.isScheduling = false,
   });
 
   final EpgShowEpisode episode;
   final String localeTag;
 
+  /// True when an existing DVR recording already covers this airing (by
+  /// channel + time-window overlap). Renders a "Scheduled" badge on the
+  /// row and excludes it from selection in batch mode.
+  final bool alreadyScheduled;
+
+  /// True when the screen is in multi-select mode. Replaces the per-row
+  /// Record `AppIconButton` with a checkbox indicator via [LeadingTile]'s
+  /// `selectMode` prop.
+  final bool selectionMode;
+
+  /// True when this row is among the user's selected episodes. Only
+  /// meaningful when [selectionMode] is true.
+  final bool selected;
+
   /// One-shot Record action for this single airing. Null hides the
   /// affordance (screen not wired); airings already over hide it too.
   final Future<void> Function(EpgShowEpisode episode)? onScheduleEpisode;
+
+  /// Row tap handler. In selection mode, toggles this row's selection. In
+  /// normal mode, null (rows aren't tappable — the Record icon is).
+  final VoidCallback? onTap;
+
+  /// Row long-press handler. In normal mode, enters selection mode (with
+  /// this row as the seed). In selection mode, also toggles this row.
+  final VoidCallback? onLongTap;
 
   /// True while this row's schedule request is in flight (disables the
   /// Record button so a double-tap can't schedule the same airing twice).
@@ -527,6 +721,8 @@ class _EpisodeRowState extends State<_EpisodeRow> {
     return DpadInkWell(
       borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
       color: theme.colorScheme.surfaceContainerHigh,
+      onTap: widget.onTap,
+      onLongTap: widget.onLongTap,
       child: Padding(
         padding: const EdgeInsets.all(MediaBrowsingMetrics.contentPadding),
         child: Row(
@@ -534,6 +730,8 @@ class _EpisodeRowState extends State<_EpisodeRow> {
             LeadingTile(
               icon: Icons.play_arrow,
               tileColor: theme.colorScheme.tertiary,
+              selectMode: widget.selectionMode,
+              selected: widget.selected,
             ),
             const SizedBox(width: MediaBrowsingMetrics.contentPadding),
             Expanded(
@@ -566,7 +764,11 @@ class _EpisodeRowState extends State<_EpisodeRow> {
                 ],
               ),
             ),
-            if (canSchedule) ...[
+            if (widget.alreadyScheduled) ...[
+              const SizedBox(width: MediaBrowsingMetrics.chipGap),
+              AppBadge(label: l10n.showScheduled),
+            ],
+            if (!widget.selectionMode && canSchedule) ...[
               const SizedBox(width: MediaBrowsingMetrics.chipGap),
               // Direct AppIconButton rather than RowActionMenu: record is the
               // only action on episode rows, so the "more" overflow that
@@ -593,8 +795,73 @@ class _EpisodeRowState extends State<_EpisodeRow> {
   }
 }
 
+/// Action bar shown above the episode list while the user is in multi-
+/// select mode. Provides "Record (N)" (disabled at N=0) and "Cancel". Both
+/// buttons are D-pad focusable so the user can navigate to the bar with
+/// up-arrow from the episode list and back with down-arrow.
+class _SelectionActionsBar extends StatelessWidget {
+  const _SelectionActionsBar({
+    required this.selectedCount,
+    required this.onRecord,
+    required this.onCancel,
+  });
+
+  final int selectedCount;
+  final VoidCallback? onRecord;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final l10n = AppLocalizations.of(context);
+    return Container(
+      padding: const EdgeInsets.all(MediaBrowsingMetrics.contentPadding),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          AppButton(
+            label: l10n.showBatchRecord(selectedCount),
+            icon: Icons.fiber_manual_record,
+            variant: AppButtonVariant.primaryInverted,
+            onPressed: onRecord,
+          ),
+          const SizedBox(width: MediaBrowsingMetrics.contentPadding),
+          AppButton(label: l10n.cancel, onPressed: onCancel),
+        ],
+      ),
+    );
+  }
+}
+
 /// Unique per-airing key for the in-flight guard: `channelId|startTime`
 /// stays distinct even when the same title airs on another channel or at a
 /// different time.
 String _episodeRecordKey(EpgShowEpisode episode) =>
     '${episode.channelId}|${episode.startTime.toIso8601String()}';
+
+/// True when [episode] is already covered by an existing DVR recording.
+///
+/// Uses time-window overlap rather than start-time equality so it still
+/// matches recordings whose `scheduledStart` has been padded backward by
+/// the server's `start_early_seconds` (which commonly exceeds the 60s
+/// tolerance the single-row `scheduleDvrAiring` uses for its return match).
+///
+/// Null `scheduledStart`/`scheduledEnd` on the recording means "can't
+/// confirm" — such rows aren't marked as duplicates, so a recording still
+/// being seeded server-side isn't prematurely locked out of rescheduling.
+bool _isAlreadyScheduled(
+  EpgShowEpisode episode,
+  List<DvrRecording> recordings,
+) {
+  return recordings.any((recording) {
+    if (recording.channelId != episode.channelId) return false;
+    final start = recording.scheduledStart;
+    final end = recording.scheduledEnd;
+    if (start == null || end == null) return false;
+    return !start.isAfter(episode.endTime) && !end.isBefore(episode.startTime);
+  });
+}

--- a/flutter_client/lib/features/shows/show_detail_screen.dart
+++ b/flutter_client/lib/features/shows/show_detail_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:m3u_tv/features/dvr/dvr_series_rule_options_screen.dart';
+import 'package:m3u_tv/features/epg/epg_recording_index.dart';
+import 'package:m3u_tv/features/epg/epg_recording_state.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/app_state_controller.dart';
@@ -69,8 +71,8 @@ class ShowDetailScreen extends ConsumerStatefulWidget {
   /// Schedules a batch of DVR airings for the user-selected episodes in
   /// selection mode. Wired by AppShell against
   /// `AppStateController.scheduleDvrAirings`. Null means selection mode is
-  /// unavailable entirely (no long-press affordance, no action bar) — a mode
-  /// with no exit would trap the user.
+  /// unavailable entirely (no long-press affordance, no action bar), since a
+  /// mode with no exit would trap the user.
   final Future<List<DvrAiringScheduleResult>> Function(
     List<EpgShowEpisode>,
   )?
@@ -100,6 +102,11 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
   /// so the two sets stay disjoint in their semantics.
   final Set<String> _selectedEpisodeKeys = {};
 
+  /// True while a batch schedule request is in flight. Guards "Record (N)"
+  /// against a double-tap firing two concurrent batch submissions of the
+  /// same selection (mirrors [_submittingEpisodeKeys]'s per-row guard).
+  bool _batchSubmitting = false;
+
   Future<void> _scheduleEpisode(EpgShowEpisode episode) async {
     final handler = widget.onScheduleEpisode;
     if (handler == null) return;
@@ -122,7 +129,7 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
   /// Enters selection mode with [episode] as the initially-selected row.
   /// Caller guards `onScheduleEpisodes != null` (the long-press affordance is
   /// wired conditionally so this method is never called when the handler is
-  /// missing — but the guard is defensive in case the entry point changes).
+  /// missing, but the guard is defensive in case the entry point changes).
   void _enterSelectionMode(EpgShowEpisode episode) {
     if (widget.onScheduleEpisodes == null) return;
     setState(() {
@@ -156,41 +163,53 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
 
   /// Runs the batch schedule handler for the user's selected episodes, then
   /// exits selection mode and surfaces a single summary SnackBar.
+  ///
+  /// Re-entrancy is guarded by [_batchSubmitting] (mirrors
+  /// [_submittingEpisodeKeys] for the single-row path) so a double-tap on
+  /// "Record (N)" can't fire two concurrent batches for the same selection.
+  /// Selected episodes that became already-scheduled since the user picked
+  /// them (e.g. scheduled from another device, or by a series rule, while
+  /// selection mode was open) are dropped before submitting rather than
+  /// resubmitted.
   Future<void> _scheduleSelected() async {
     final handler = widget.onScheduleEpisodes;
-    if (handler == null || _selectedEpisodeKeys.isEmpty) return;
-    final selectedEpisodes = widget.show.recentEpisodes
-        .where((e) => _selectedEpisodeKeys.contains(_episodeRecordKey(e)))
-        .toList(growable: false);
+    if (handler == null || _selectedEpisodeKeys.isEmpty || _batchSubmitting) {
+      return;
+    }
+    final recordingIndex = EpgRecordingIndex.fromRecordings(
+      ref.read(dvrRecordingsProvider),
+    );
+    final selectedEpisodes = [
+      for (final episode in widget.show.recentEpisodes)
+        if (_selectedEpisodeKeys.contains(_episodeRecordKey(episode)) &&
+            !_isAlreadyScheduled(episode, recordingIndex))
+          episode,
+    ];
+    if (selectedEpisodes.isEmpty) {
+      _exitSelectionMode();
+      return;
+    }
 
-    // Capture the messenger + l10n BEFORE the await — `context` becomes
-    // invalid if the widget unmounts while the batch is in flight.
-    final messenger = ScaffoldMessenger.of(context);
-    final l10n = AppLocalizations.of(context);
-
+    setState(() => _batchSubmitting = true);
     try {
-      final results = await handler(selectedEpisodes);
-      if (!mounted) return;
-      final scheduled = results.where((r) => r.success).length;
-      final failed = results.length - scheduled;
-      final failureTitles = [
-        for (final r in results)
-          if (!r.success) r.episode.displayTitle,
-      ];
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            _buildBatchSummary(l10n, scheduled, failed, failureTitles),
-          ),
-        ),
-      );
-    } on Object catch (error) {
-      if (!mounted) return;
-      messenger.showSnackBar(
-        SnackBar(content: Text(l10n.appRecordingFailed(error.toString()))),
+      await scheduleDvrWithFeedback<List<DvrAiringScheduleResult>>(
+        context,
+        schedule: () => handler(selectedEpisodes),
+        successMessage: (results, l10n) {
+          final scheduled = results.where((r) => r.success).length;
+          final failed = results.length - scheduled;
+          final failureTitles = [
+            for (final r in results)
+              if (!r.success) r.episode.displayTitle,
+          ];
+          return _buildBatchSummary(l10n, scheduled, failed, failureTitles);
+        },
       );
     } finally {
-      if (mounted) _exitSelectionMode();
+      if (mounted) {
+        setState(() => _batchSubmitting = false);
+        _exitSelectionMode();
+      }
     }
   }
 
@@ -198,7 +217,7 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
   ///
   /// Per the plan's judgment call (state in Worker status), failed-episode
   /// titles are listed inline only when [failed] is between 1 and 3
-  /// inclusive — beyond that the line would overrun the SnackBar width.
+  /// inclusive (beyond that the line would overrun the SnackBar width).
   /// failed == 0 collapses to the summary alone ("All succeeded.").
   String _buildBatchSummary(
     AppLocalizations l10n,
@@ -207,7 +226,7 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
     List<String> failureTitles,
   ) {
     final summary = l10n.showBatchScheduleSummary(scheduled, failed);
-    if (failed > 0 && failed <= 3 && failureTitles.isNotEmpty) {
+    if (failed > 0 && failed <= 3) {
       return '$summary\n${l10n.showBatchScheduleFailures(failureTitles.join(', '))}';
     }
     return summary;
@@ -349,6 +368,7 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
     // Watching so a freshly-scheduled airing (single tap or batch) flips
     // the per-row "Scheduled" badge without a full route re-push.
     final recordings = ref.watch(dvrRecordingsProvider);
+    final recordingIndex = EpgRecordingIndex.fromRecordings(recordings);
 
     return Scaffold(
       appBar: AppBar(
@@ -404,7 +424,8 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
             if (_selectionMode) ...[
               _SelectionActionsBar(
                 selectedCount: _selectedEpisodeKeys.length,
-                onRecord: _selectedEpisodeKeys.isEmpty
+                onRecord:
+                    _selectedEpisodeKeys.isEmpty || _batchSubmitting
                     ? null
                     : _scheduleSelected,
                 onCancel: _exitSelectionMode,
@@ -423,10 +444,18 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
                 (episode) {
                   final alreadyScheduled = _isAlreadyScheduled(
                     episode,
-                    recordings,
+                    recordingIndex,
                   );
                   final episodeKey = _episodeRecordKey(episode);
-                  final rowSelectable = !alreadyScheduled;
+                  // Matches the single-row `canSchedule` gate in
+                  // _EpisodeRowState: an airing that has already ended can't
+                  // be recorded, in batch mode any more than single-row mode.
+                  final rowSelectable =
+                      !alreadyScheduled &&
+                      episode.endTime.isAfter(DateTime.now());
+                  final toggleSelection = _selectionMode && rowSelectable
+                      ? () => _toggleSelection(episode)
+                      : null;
                   return Padding(
                     padding: const EdgeInsets.only(
                       bottom: MediaBrowsingMetrics.itemGap,
@@ -437,21 +466,17 @@ class _ShowDetailScreenState extends ConsumerState<ShowDetailScreen> {
                       alreadyScheduled: alreadyScheduled,
                       selectionMode: _selectionMode,
                       selected: _selectedEpisodeKeys.contains(episodeKey),
-                      // Long-press: enter mode (normal mode) or toggle (in mode).
-                      // Only available when selection mode is reachable AND
-                      // this row is selectable.
+                      // Long-press: enter mode (normal mode) or toggle (in
+                      // mode). Only available when selection mode is
+                      // reachable AND this row is selectable.
                       onLongTap:
                           (widget.onScheduleEpisodes != null &&
                               !_selectionMode &&
                               rowSelectable)
                           ? () => _enterSelectionMode(episode)
-                          : (_selectionMode && rowSelectable
-                                ? () => _toggleSelection(episode)
-                                : null),
+                          : toggleSelection,
                       // Tap: only meaningful in selection mode (toggle).
-                      onTap: _selectionMode && rowSelectable
-                          ? () => _toggleSelection(episode)
-                          : null,
+                      onTap: toggleSelection,
                       onScheduleEpisode:
                           !_selectionMode &&
                               widget.onScheduleEpisode != null &&
@@ -652,7 +677,7 @@ class _EpisodeRow extends StatefulWidget {
   final Future<void> Function(EpgShowEpisode episode)? onScheduleEpisode;
 
   /// Row tap handler. In selection mode, toggles this row's selection. In
-  /// normal mode, null (rows aren't tappable — the Record icon is).
+  /// normal mode, null (rows aren't tappable; the Record icon is).
   final VoidCallback? onTap;
 
   /// Row long-press handler. In normal mode, enters selection mode (with
@@ -845,23 +870,16 @@ String _episodeRecordKey(EpgShowEpisode episode) =>
 
 /// True when [episode] is already covered by an existing DVR recording.
 ///
-/// Uses time-window overlap rather than start-time equality so it still
-/// matches recordings whose `scheduledStart` has been padded backward by
-/// the server's `start_early_seconds` (which commonly exceeds the 60s
-/// tolerance the single-row `scheduleDvrAiring` uses for its return match).
-///
-/// Null `scheduledStart`/`scheduledEnd` on the recording means "can't
-/// confirm" — such rows aren't marked as duplicates, so a recording still
-/// being seeded server-side isn't prematurely locked out of rescheduling.
-bool _isAlreadyScheduled(
-  EpgShowEpisode episode,
-  List<DvrRecording> recordings,
-) {
-  return recordings.any((recording) {
-    if (recording.channelId != episode.channelId) return false;
-    final start = recording.scheduledStart;
-    final end = recording.scheduledEnd;
-    if (start == null || end == null) return false;
-    return !start.isAfter(episode.endTime) && !end.isBefore(episode.startTime);
-  });
+/// Delegates to [EpgRecordingIndex], which the EPG timeline grid also uses
+/// for the same "does this programme have a recording" question: coverage-
+/// based overlap (not naive boundary overlap, which false-matches adjacent
+/// back-to-back airings on the same channel) plus channel-bucketed lookup
+/// and terminal-status filtering.
+bool _isAlreadyScheduled(EpgShowEpisode episode, EpgRecordingIndex index) {
+  return index.stateFor(
+        channelId: episode.channelId,
+        programStart: episode.startTime,
+        programEnd: episode.endTime,
+      ) !=
+      EpgRecordingState.none;
 }

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -559,6 +559,34 @@
     }
   },
   "showSeriesRuleActive": "Serien-Regel aktiv",
+  "showScheduled": "Geplant",
+  "showBatchRecord": "Aufnehmen ({count})",
+  "@showBatchRecord": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleSummary": "{scheduled, plural, =1{1 Folge aufgenommen} other{{scheduled} Folgen aufgenommen}}. {failed, plural, =0{Alle erfolgreich.} =1{1 fehlgeschlagen.} other{{failed} fehlgeschlagen.}}",
+  "@showBatchScheduleSummary": {
+    "placeholders": {
+      "scheduled": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleFailures": "Fehlgeschlagen: {titles}",
+  "@showBatchScheduleFailures": {
+    "placeholders": {
+      "titles": {
+        "type": "String"
+      }
+    }
+  },
   "showDetailTitle": "Show-Details",
   "showEpisodesCount": "{count, plural, =1{1 Folge} other{{count} Folgen}}",
   "@showEpisodesCount": {

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -560,6 +560,34 @@
     }
   },
   "showSeriesRuleActive": "Series rule active",
+  "showScheduled": "Scheduled",
+  "showBatchRecord": "Record ({count})",
+  "@showBatchRecord": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleSummary": "{scheduled, plural, =1{Recorded 1 episode} other{Recorded {scheduled} episodes}}. {failed, plural, =0{All succeeded.} =1{1 failed.} other{{failed} failed.}}",
+  "@showBatchScheduleSummary": {
+    "placeholders": {
+      "scheduled": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleFailures": "Failed: {titles}",
+  "@showBatchScheduleFailures": {
+    "placeholders": {
+      "titles": {
+        "type": "String"
+      }
+    }
+  },
   "showDetailTitle": "Show details",
   "showEpisodesCount": "{count, plural, =1{1 episode} other{{count} episodes}}",
   "@showEpisodesCount": {

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -559,6 +559,34 @@
     }
   },
   "showSeriesRuleActive": "Regla de serie activa",
+  "showScheduled": "Programada",
+  "showBatchRecord": "Grabar ({count})",
+  "@showBatchRecord": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleSummary": "{scheduled, plural, =1{Se programó 1 episodio} other{Se programaron {scheduled} episodios}}. {failed, plural, =0{Todos exitosos.} =1{Falló 1.} other{Fallaron {failed}.}}",
+  "@showBatchScheduleSummary": {
+    "placeholders": {
+      "scheduled": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleFailures": "Fallaron: {titles}",
+  "@showBatchScheduleFailures": {
+    "placeholders": {
+      "titles": {
+        "type": "String"
+      }
+    }
+  },
   "showDetailTitle": "Detalles del show",
   "showEpisodesCount": "{count, plural, =1{1 episodio} other{{count} episodios}}",
   "@showEpisodesCount": {

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -559,6 +559,34 @@
     }
   },
   "showSeriesRuleActive": "Règle de série active",
+  "showScheduled": "Programmé",
+  "showBatchRecord": "Enregistrer ({count})",
+  "@showBatchRecord": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleSummary": "{scheduled, plural, =1{1 épisode programmé} other{{scheduled} épisodes programmés}}. {failed, plural, =0{Tous réussis.} =1{1 échec.} other{{failed} échecs.}}",
+  "@showBatchScheduleSummary": {
+    "placeholders": {
+      "scheduled": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleFailures": "Échecs : {titles}",
+  "@showBatchScheduleFailures": {
+    "placeholders": {
+      "titles": {
+        "type": "String"
+      }
+    }
+  },
   "showDetailTitle": "Détails du show",
   "showEpisodesCount": "{count, plural, =1{1 épisode} other{{count} épisodes}}",
   "@showEpisodesCount": {

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -2060,6 +2060,30 @@ abstract class AppLocalizations {
   /// **'Series rule active'**
   String get showSeriesRuleActive;
 
+  /// No description provided for @showScheduled.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled'**
+  String get showScheduled;
+
+  /// No description provided for @showBatchRecord.
+  ///
+  /// In en, this message translates to:
+  /// **'Record ({count})'**
+  String showBatchRecord(int count);
+
+  /// No description provided for @showBatchScheduleSummary.
+  ///
+  /// In en, this message translates to:
+  /// **'{scheduled, plural, =1{Recorded 1 episode} other{Recorded {scheduled} episodes}}. {failed, plural, =0{All succeeded.} =1{1 failed.} other{{failed} failed.}}'**
+  String showBatchScheduleSummary(int scheduled, int failed);
+
+  /// No description provided for @showBatchScheduleFailures.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed: {titles}'**
+  String showBatchScheduleFailures(String titles);
+
   /// No description provided for @showDetailTitle.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -1106,6 +1106,37 @@ class AppLocalizationsDe extends AppLocalizations {
   String get showSeriesRuleActive => 'Serien-Regel aktiv';
 
   @override
+  String get showScheduled => 'Geplant';
+
+  @override
+  String showBatchRecord(int count) {
+    return 'Aufnehmen ($count)';
+  }
+
+  @override
+  String showBatchScheduleSummary(int scheduled, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      scheduled,
+      locale: localeName,
+      other: '$scheduled Folgen aufgenommen',
+      one: '1 Folge aufgenommen',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed fehlgeschlagen.',
+      one: '1 fehlgeschlagen.',
+      zero: 'Alle erfolgreich.',
+    );
+    return '$_temp0. $_temp1';
+  }
+
+  @override
+  String showBatchScheduleFailures(String titles) {
+    return 'Fehlgeschlagen: $titles';
+  }
+
+  @override
   String get showDetailTitle => 'Show-Details';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -1099,6 +1099,37 @@ class AppLocalizationsEn extends AppLocalizations {
   String get showSeriesRuleActive => 'Series rule active';
 
   @override
+  String get showScheduled => 'Scheduled';
+
+  @override
+  String showBatchRecord(int count) {
+    return 'Record ($count)';
+  }
+
+  @override
+  String showBatchScheduleSummary(int scheduled, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      scheduled,
+      locale: localeName,
+      other: 'Recorded $scheduled episodes',
+      one: 'Recorded 1 episode',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed failed.',
+      one: '1 failed.',
+      zero: 'All succeeded.',
+    );
+    return '$_temp0. $_temp1';
+  }
+
+  @override
+  String showBatchScheduleFailures(String titles) {
+    return 'Failed: $titles';
+  }
+
+  @override
   String get showDetailTitle => 'Show details';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -1108,6 +1108,37 @@ class AppLocalizationsEs extends AppLocalizations {
   String get showSeriesRuleActive => 'Regla de serie activa';
 
   @override
+  String get showScheduled => 'Programada';
+
+  @override
+  String showBatchRecord(int count) {
+    return 'Grabar ($count)';
+  }
+
+  @override
+  String showBatchScheduleSummary(int scheduled, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      scheduled,
+      locale: localeName,
+      other: 'Se programaron $scheduled episodios',
+      one: 'Se programó 1 episodio',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: 'Fallaron $failed.',
+      one: 'Falló 1.',
+      zero: 'Todos exitosos.',
+    );
+    return '$_temp0. $_temp1';
+  }
+
+  @override
+  String showBatchScheduleFailures(String titles) {
+    return 'Fallaron: $titles';
+  }
+
+  @override
   String get showDetailTitle => 'Detalles del show';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -1110,6 +1110,37 @@ class AppLocalizationsFr extends AppLocalizations {
   String get showSeriesRuleActive => 'Règle de série active';
 
   @override
+  String get showScheduled => 'Programmé';
+
+  @override
+  String showBatchRecord(int count) {
+    return 'Enregistrer ($count)';
+  }
+
+  @override
+  String showBatchScheduleSummary(int scheduled, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      scheduled,
+      locale: localeName,
+      other: '$scheduled épisodes programmés',
+      one: '1 épisode programmé',
+    );
+    String _temp1 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '$failed échecs.',
+      one: '1 échec.',
+      zero: 'Tous réussis.',
+    );
+    return '$_temp0. $_temp1';
+  }
+
+  @override
+  String showBatchScheduleFailures(String titles) {
+    return 'Échecs : $titles';
+  }
+
+  @override
   String get showDetailTitle => 'Détails du show';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -1073,6 +1073,31 @@ class AppLocalizationsZh extends AppLocalizations {
   String get showSeriesRuleActive => '剧集规则已启用';
 
   @override
+  String get showScheduled => '已计划';
+
+  @override
+  String showBatchRecord(int count) {
+    return '录制 ($count)';
+  }
+
+  @override
+  String showBatchScheduleSummary(int scheduled, int failed) {
+    String _temp0 = intl.Intl.pluralLogic(
+      failed,
+      locale: localeName,
+      other: '失败 $failed 个。',
+      one: '失败 1 个。',
+      zero: '全部成功。',
+    );
+    return '已安排 $scheduled 个录制。$_temp0';
+  }
+
+  @override
+  String showBatchScheduleFailures(String titles) {
+    return '失败: $titles';
+  }
+
+  @override
   String get showDetailTitle => '节目详情';
 
   @override

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -559,6 +559,34 @@
     }
   },
   "showSeriesRuleActive": "剧集规则已启用",
+  "showScheduled": "已计划",
+  "showBatchRecord": "录制 ({count})",
+  "@showBatchRecord": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleSummary": "已安排 {scheduled} 个录制。{failed, plural, =0{全部成功。} =1{失败 1 个。} other{失败 {failed} 个。}}",
+  "@showBatchScheduleSummary": {
+    "placeholders": {
+      "scheduled": {
+        "type": "int"
+      },
+      "failed": {
+        "type": "int"
+      }
+    }
+  },
+  "showBatchScheduleFailures": "失败: {titles}",
+  "@showBatchScheduleFailures": {
+    "placeholders": {
+      "titles": {
+        "type": "String"
+      }
+    }
+  },
   "showDetailTitle": "节目详情",
   "showEpisodesCount": "{count, plural, =1{1 集} other{{count} 集}}",
   "@showEpisodesCount": {

--- a/flutter_client/lib/navigation/content_actions.dart
+++ b/flutter_client/lib/navigation/content_actions.dart
@@ -22,6 +22,7 @@ class ContentActions extends InheritedWidget {
     required this.onRecordSeries,
     required this.onDeleteSeriesRule,
     this.onScheduleEpisode,
+    this.onScheduleEpisodes,
     required this.buildTabScreen,
     required super.child,
   });
@@ -76,6 +77,16 @@ class ContentActions extends InheritedWidget {
   /// persistent rule is created). Returns the matching recording if the
   /// post-schedule refresh surfaced one, else null.
   final Future<DvrRecording?> Function(EpgShowEpisode)? onScheduleEpisode;
+
+  /// Schedules a batch of DVR airings for the user-selected episodes in
+  /// selection mode. Wired by AppShell against
+  /// `AppStateController.scheduleDvrAirings`. Null means the selection-mode
+  /// entry affordance is hidden on the route (same null-hides-affordance
+  /// convention as [onScheduleEpisode]).
+  final Future<List<DvrAiringScheduleResult>> Function(
+    List<EpgShowEpisode>,
+  )?
+  onScheduleEpisodes;
 
   /// Builds the full tab screen for the given routeName.
   /// Provided by AppShell so go_router branch builders don't need to import

--- a/flutter_client/lib/navigation/go_router_config.dart
+++ b/flutter_client/lib/navigation/go_router_config.dart
@@ -308,6 +308,7 @@ GoRouter createGoRouter({
                           onRecordSeries: actions.onRecordSeries,
                           onDeleteSeriesRule: actions.onDeleteSeriesRule,
                           onScheduleEpisode: actions.onScheduleEpisode,
+                          onScheduleEpisodes: actions.onScheduleEpisodes,
                         ),
                       );
                     },

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -1917,16 +1917,16 @@ class AppStateController extends ChangeNotifier {
 
   /// Schedules a batch of one-shot DVR recordings and refreshes the local
   /// list once, after the whole loop completes. The single-item
-  /// [scheduleDvrAiring] does this per call — applying it per item in a
+  /// [scheduleDvrAiring] does this per call (applying it per item in a
   /// batch would mean N `getDvrRecordingsFor` round-trips, N
-  /// `notifyListeners()` rebuilds, and N `refreshDvrStorage()` calls.
+  /// `notifyListeners()` rebuilds, and N `refreshDvrStorage()` calls).
   ///
   /// Per-item failures (e.g. `XtreamDvrScheduleException` for the 422
   /// concurrent recording limit case) are captured into each
   /// [DvrAiringScheduleResult] rather than aborting the rest of the batch.
   ///
-  /// Throws [StateError] when credentials are not configured — a wholesale
-  /// precondition fail, not a per-item failure. Matches [scheduleDvrAiring].
+  /// Throws [StateError] when credentials are not configured (a wholesale
+  /// precondition fail, not a per-item failure). Matches [scheduleDvrAiring].
   Future<List<DvrAiringScheduleResult>> scheduleDvrAirings(
     List<EpgShowEpisode> episodes,
   ) async {
@@ -1939,7 +1939,7 @@ class AppStateController extends ChangeNotifier {
 
     final results = <DvrAiringScheduleResult>[];
     for (final episode in episodes) {
-      if (!ownsWork()) return results;
+      if (!ownsWork()) break;
       try {
         await xtreamService.scheduleDvrFor(
           credentials,
@@ -1968,6 +1968,19 @@ class AppStateController extends ChangeNotifier {
           ),
         );
       }
+    }
+
+    // Ownership was lost partway through the loop above: report the
+    // untried episodes as failed instead of silently dropping them from
+    // the caller's success/failure count.
+    for (final episode in episodes.skip(results.length)) {
+      results.add(
+        DvrAiringScheduleResult(
+          episode: episode,
+          success: false,
+          errorMessage: 'Cancelled: DVR ownership changed mid-batch',
+        ),
+      );
     }
 
     if (!ownsWork()) return results;

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -44,6 +44,24 @@ typedef MediaRequestOwner = ({
   UserCredentials? credentials,
 });
 
+/// Per-episode outcome from [AppStateController.scheduleDvrAirings]. One
+/// entry per input episode, in input order. Per-item failures (e.g.
+/// `XtreamDvrScheduleException` for the 422 concurrent recording limit case)
+/// land here instead of aborting the rest of the batch.
+class DvrAiringScheduleResult {
+  const DvrAiringScheduleResult({
+    required this.episode,
+    required this.success,
+    this.errorMessage,
+  });
+
+  final EpgShowEpisode episode;
+  final bool success;
+
+  /// Server-side error message when [success] is false. Null on success.
+  final String? errorMessage;
+}
+
 class AppStateController extends ChangeNotifier {
   factory AppStateController({
     AuthNotifier? authNotifier,
@@ -1895,6 +1913,78 @@ class AppStateController extends ChangeNotifier {
       }
     }
     return null;
+  }
+
+  /// Schedules a batch of one-shot DVR recordings and refreshes the local
+  /// list once, after the whole loop completes. The single-item
+  /// [scheduleDvrAiring] does this per call — applying it per item in a
+  /// batch would mean N `getDvrRecordingsFor` round-trips, N
+  /// `notifyListeners()` rebuilds, and N `refreshDvrStorage()` calls.
+  ///
+  /// Per-item failures (e.g. `XtreamDvrScheduleException` for the 422
+  /// concurrent recording limit case) are captured into each
+  /// [DvrAiringScheduleResult] rather than aborting the rest of the batch.
+  ///
+  /// Throws [StateError] when credentials are not configured — a wholesale
+  /// precondition fail, not a per-item failure. Matches [scheduleDvrAiring].
+  Future<List<DvrAiringScheduleResult>> scheduleDvrAirings(
+    List<EpgShowEpisode> episodes,
+  ) async {
+    final credentials = authNotifier.credentials;
+    if (credentials == null) {
+      throw StateError('Xtream credentials not configured');
+    }
+    final ownsWork = _captureDvrOwnership(credentials);
+    if (!ownsWork()) return const <DvrAiringScheduleResult>[];
+
+    final results = <DvrAiringScheduleResult>[];
+    for (final episode in episodes) {
+      if (!ownsWork()) return results;
+      try {
+        await xtreamService.scheduleDvrFor(
+          credentials,
+          channelId: episode.channelId,
+          title: episode.displayTitle,
+          startTime: episode.startTime,
+          endTime: episode.endTime,
+        );
+        results.add(DvrAiringScheduleResult(episode: episode, success: true));
+      } on XtreamDvrScheduleException catch (error) {
+        results.add(
+          DvrAiringScheduleResult(
+            episode: episode,
+            success: false,
+            errorMessage: error.message,
+          ),
+        );
+      } on Object catch (error, stackTrace) {
+        debugPrint('DVR: batch schedule item failed: $error');
+        debugPrintStack(stackTrace: stackTrace);
+        results.add(
+          DvrAiringScheduleResult(
+            episode: episode,
+            success: false,
+            errorMessage: error.toString(),
+          ),
+        );
+      }
+    }
+
+    if (!ownsWork()) return results;
+    try {
+      final recordings = await xtreamService.getDvrRecordingsFor(credentials);
+      if (!ownsWork()) return results;
+      _dvrRecordings = recordings;
+      _recordingChannelIds = _extractRecordingChannelIds(recordings);
+    } on Object catch (error, stackTrace) {
+      if (!ownsWork()) return results;
+      debugPrint('DVR: refresh after batch schedule failed: $error');
+      debugPrintStack(stackTrace: stackTrace);
+    }
+    if (!ownsWork()) return results;
+    notifyListeners();
+    unawaited(refreshDvrStorage());
+    return results;
   }
 
   static Set<int> _extractRecordingChannelIds(List<DvrRecording> recordings) {

--- a/flutter_client/lib/shared/dvr_schedule_feedback.dart
+++ b/flutter_client/lib/shared/dvr_schedule_feedback.dart
@@ -7,19 +7,31 @@ import 'package:m3u_tv/l10n/app_localizations.dart';
 /// (`ShowDetailScreen._scheduleEpisode`) so both surfaces report the same
 /// way. Returns the scheduled result, or null if scheduling failed or the
 /// context was unmounted by the time the call completed.
+///
+/// [title] drives the default single-item success message
+/// (`l10n.appRecordingScheduled(title)`). Pass [successMessage] instead when
+/// the caller needs a different success message shape (e.g. a batch
+/// summary) — it receives the captured [AppLocalizations] so it can be
+/// built after the same mounted-check this helper already does.
 Future<T?> scheduleDvrWithFeedback<T>(
   BuildContext context, {
   required Future<T> Function() schedule,
-  required String title,
+  String? title,
+  String Function(T result, AppLocalizations l10n)? successMessage,
 }) async {
+  assert(
+    title != null || successMessage != null,
+    'scheduleDvrWithFeedback requires either title or successMessage',
+  );
   final messenger = ScaffoldMessenger.of(context);
   final l10n = AppLocalizations.of(context);
   try {
     final result = await schedule();
     if (!context.mounted) return null;
-    messenger.showSnackBar(
-      SnackBar(content: Text(l10n.appRecordingScheduled(title))),
-    );
+    final message = successMessage != null
+        ? successMessage(result, l10n)
+        : l10n.appRecordingScheduled(title!);
+    messenger.showSnackBar(SnackBar(content: Text(message)));
     return result;
   } on Object catch (error) {
     if (!context.mounted) return null;

--- a/flutter_client/test/features/shows/test_episode_record_action_test.dart
+++ b/flutter_client/test/features/shows/test_episode_record_action_test.dart
@@ -43,7 +43,10 @@ void main() {
   }) async {
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [dvrSeriesRulesProvider.overrideWith((_) => const [])],
+        overrides: [
+          dvrSeriesRulesProvider.overrideWith((_) => const []),
+          dvrRecordingsProvider.overrideWith((_) => const []),
+        ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/flutter_client/test/features/shows/test_episode_scheduled_badge_test.dart
+++ b/flutter_client/test/features/shows/test_episode_scheduled_badge_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/shows/show_detail_screen.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  // Fixed future window so the per-row end-timer never fires during a test.
+  // Anywhere later than now() + a few minutes is fine; an hour keeps the
+  // 1-hour-future end safely beyond the typical widget-test runtime.
+  final episode = EpgShowEpisode(
+    channelId: 8,
+    channelName: 'Channel Eight',
+    title: 'Future Ep',
+    startTime: DateTime.now().add(const Duration(hours: 1)),
+    endTime: DateTime.now().add(const Duration(hours: 2)),
+  );
+
+  EpgShow testShow({List<EpgShowEpisode> episodes = const []}) => EpgShow(
+    normalizedTitle: 'scheduled-show',
+    displayTitle: 'Scheduled Show',
+    channelCount: 1,
+    channels: const [
+      EpgShowChannel(channelId: 8, channelName: 'Channel Eight'),
+    ],
+    episodeCount: episodes.length,
+    recentEpisodes: episodes,
+  );
+
+  DvrRecording recording({
+    int? channelId = 8,
+    required DateTime? scheduledStart,
+    required DateTime? scheduledEnd,
+  }) => DvrRecording(
+    uuid:
+        'uuid-${channelId ?? 'null'}-${scheduledStart?.millisecondsSinceEpoch ?? 0}',
+    title: 'Existing Recording',
+    status: DvrRecordingStatus.scheduled,
+    channelId: channelId,
+    channelName: 'Channel Eight',
+    scheduledStart: scheduledStart,
+    scheduledEnd: scheduledEnd,
+  );
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    required EpgShow show,
+    List<DvrRecording> recordings = const [],
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dvrSeriesRulesProvider.overrideWith((_) => const []),
+          dvrRecordingsProvider.overrideWith((_) => recordings),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ShowDetailScreen(show: show),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  Finder scheduledBadge(WidgetTester tester) {
+    final l10n = AppLocalizations.of(
+      tester.element(find.byType(ShowDetailScreen)),
+    );
+    return find.text(l10n.showScheduled);
+  }
+
+  testWidgets(
+    'shows Scheduled badge when a recording window overlaps the episode',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [episode]),
+        recordings: [
+          recording(
+            scheduledStart: episode.startTime,
+            scheduledEnd: episode.endTime,
+          ),
+        ],
+      );
+
+      expect(scheduledBadge(tester), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'shows Scheduled badge when the recording is padded backward by '
+    'start_early_seconds beyond the 1-minute singular tolerance',
+    (tester) async {
+      // 5 minutes of padding — the singular `scheduleDvrAiring` return-match
+      // only tolerates 1 minute, so this case would have been missed by any
+      // helper built on near-exact start-time equality. The new overlap
+      // helper must still match.
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [episode]),
+        recordings: [
+          recording(
+            scheduledStart: episode.startTime.subtract(
+              const Duration(minutes: 5),
+            ),
+            scheduledEnd: episode.endTime,
+          ),
+        ],
+      );
+
+      expect(scheduledBadge(tester), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'does NOT show Scheduled badge when the recording is on a different '
+    'channel, even at the same time',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [episode]),
+        recordings: [
+          recording(
+            channelId: 9,
+            scheduledStart: episode.startTime,
+            scheduledEnd: episode.endTime,
+          ),
+        ],
+      );
+
+      expect(scheduledBadge(tester), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'does NOT show Scheduled badge when the recording has null '
+    'scheduledStart/End ("cannot confirm" semantics)',
+    (tester) async {
+      // The provider yields a recording whose window can't be checked
+      // (both timestamps null). Overlap match must return false rather than
+      // locking out a still-seeding recording from being scheduled.
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [episode]),
+        recordings: [
+          recording(scheduledStart: null, scheduledEnd: null),
+        ],
+      );
+
+      expect(scheduledBadge(tester), findsNothing);
+    },
+  );
+}

--- a/flutter_client/test/features/shows/test_episode_subtitle_test.dart
+++ b/flutter_client/test/features/shows/test_episode_subtitle_test.dart
@@ -30,7 +30,10 @@ void main() {
   Future<void> pumpScreen(WidgetTester tester, EpgShow show) async {
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [dvrSeriesRulesProvider.overrideWith((_) => const [])],
+        overrides: [
+          dvrSeriesRulesProvider.overrideWith((_) => const []),
+          dvrRecordingsProvider.overrideWith((_) => const []),
+        ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,

--- a/flutter_client/test/features/shows/test_header_narrow_layout_test.dart
+++ b/flutter_client/test/features/shows/test_header_narrow_layout_test.dart
@@ -34,7 +34,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [dvrSeriesRulesProvider.overrideWith((_) => const [])],
+          overrides: [
+            dvrSeriesRulesProvider.overrideWith((_) => const []),
+            dvrRecordingsProvider.overrideWith((_) => const []),
+          ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,

--- a/flutter_client/test/features/shows/test_record_button_wiring_test.dart
+++ b/flutter_client/test/features/shows/test_record_button_wiring_test.dart
@@ -44,7 +44,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [dvrSeriesRulesProvider.overrideWith((_) => const [])],
+          overrides: [
+            dvrSeriesRulesProvider.overrideWith((_) => const []),
+            dvrRecordingsProvider.overrideWith((_) => const []),
+          ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
@@ -116,7 +119,10 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          overrides: [dvrSeriesRulesProvider.overrideWith((_) => const [])],
+          overrides: [
+            dvrSeriesRulesProvider.overrideWith((_) => const []),
+            dvrRecordingsProvider.overrideWith((_) => const []),
+          ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,

--- a/flutter_client/test/features/shows/test_selection_mode_test.dart
+++ b/flutter_client/test/features/shows/test_selection_mode_test.dart
@@ -1,0 +1,393 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/shows/show_detail_screen.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/app_button.dart';
+
+void main() {
+  // Each episode starts 1 hour apart in the future so the per-row end-timer
+  // (rebuilds the row when the airing ends) never fires during a test.
+  EpgShowEpisode ep(int n) => EpgShowEpisode(
+    channelId: 8,
+    channelName: 'Channel Eight',
+    title: 'Ep $n',
+    startTime: DateTime.now().add(Duration(hours: n)),
+    endTime: DateTime.now().add(Duration(hours: n + 1)),
+  );
+
+  EpgShow testShow({List<EpgShowEpisode> episodes = const []}) => EpgShow(
+    normalizedTitle: 'selectable-show',
+    displayTitle: 'Selectable Show',
+    channelCount: 1,
+    channels: const [
+      EpgShowChannel(channelId: 8, channelName: 'Channel Eight'),
+    ],
+    episodeCount: episodes.length,
+    recentEpisodes: episodes,
+  );
+
+  Future<void> pumpScreen(
+    WidgetTester tester, {
+    required EpgShow show,
+    List<DvrRecording> recordings = const [],
+    Future<List<DvrAiringScheduleResult>> Function(List<EpgShowEpisode>)?
+    onScheduleEpisodes,
+  }) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          dvrSeriesRulesProvider.overrideWith((_) => const []),
+          dvrRecordingsProvider.overrideWith((_) => recordings),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: ShowDetailScreen(
+            show: show,
+            onScheduleEpisodes: onScheduleEpisodes,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  AppLocalizations l10n(WidgetTester tester) =>
+      AppLocalizations.of(tester.element(find.byType(ShowDetailScreen)));
+
+  Finder cancelButton(WidgetTester tester) => find.text(l10n(tester).cancel);
+
+  Finder recordButtonLabel(WidgetTester tester, int count) =>
+      find.text(l10n(tester).showBatchRecord(count));
+
+  // Returns the [_SelectionActionsBar]'s Record button widget so a test can
+  // assert its onPressed state without scraping semantics.
+  AppButton recordButtonWidget(WidgetTester tester, int count) {
+    final labelFinder = recordButtonLabel(tester, count);
+    final buttonFinder = find.ancestor(
+      of: labelFinder,
+      matching: find.byType(AppButton),
+    );
+    return tester.widget<AppButton>(buttonFinder);
+  }
+
+  testWidgets(
+    'long-pressing a row enters selection mode and surfaces the action bar',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2)]),
+        onScheduleEpisodes: (_) async => [],
+      );
+
+      // Initially no action bar — the user is in normal mode.
+      expect(cancelButton(tester), findsNothing);
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+
+      // Action bar now visible, Record button label reflects the seed row.
+      expect(cancelButton(tester), findsOneWidget);
+      expect(recordButtonLabel(tester, 1), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'in selection mode, tapping a row toggles its selection',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2), ep(3)]),
+        onScheduleEpisodes: (_) async => [],
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      expect(recordButtonLabel(tester, 1), findsOneWidget);
+
+      // Tap Ep 2 → 2 selected.
+      await tester.tap(find.text('Ep 2'));
+      await tester.pumpAndSettle();
+      expect(recordButtonLabel(tester, 2), findsOneWidget);
+
+      // Tap Ep 1 (the seed row) → 1 selected (only Ep 2 remains).
+      await tester.tap(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      expect(recordButtonLabel(tester, 1), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'Record button is disabled when the selection is empty (count = 0)',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1)]),
+        onScheduleEpisodes: (_) async => [],
+      );
+
+      // Enter mode with Ep 1 selected.
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+
+      // Deselect Ep 1 by tapping it.
+      await tester.tap(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+
+      // Label shows "Record (0)" but the button itself is disabled.
+      expect(recordButtonLabel(tester, 0), findsOneWidget);
+      expect(recordButtonWidget(tester, 0).onPressed, isNull);
+    },
+  );
+
+  testWidgets(
+    'Cancel exits selection mode and clears the action bar',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2)]),
+        onScheduleEpisodes: (_) async => [],
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      expect(cancelButton(tester), findsOneWidget);
+
+      await tester.tap(cancelButton(tester));
+      await tester.pumpAndSettle();
+
+      expect(cancelButton(tester), findsNothing);
+      expect(recordButtonLabel(tester, 0), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'null onScheduleEpisodes: long-press does NOT enter selection mode',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1)]),
+        // onScheduleEpisodes left null — selection mode is unavailable.
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+
+      // No action bar should ever surface.
+      expect(cancelButton(tester), findsNothing);
+      expect(recordButtonLabel(tester, 1), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'already-scheduled rows are excluded from selection (long-press is a no-op)',
+    (tester) async {
+      // A recording that covers Ep 1's window — Ep 1 should be excluded.
+      final recording = DvrRecording(
+        uuid: 'uuid-scheduled',
+        title: 'Ep 1',
+        status: DvrRecordingStatus.scheduled,
+        channelId: 8,
+        channelName: 'Channel Eight',
+        scheduledStart: ep(1).startTime,
+        scheduledEnd: ep(1).endTime,
+      );
+
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2)]),
+        recordings: [recording],
+        onScheduleEpisodes: (_) async => [],
+      );
+
+      // Long-press Ep 1 (already-scheduled) — should not enter mode.
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      expect(cancelButton(tester), findsNothing);
+
+      // Long-press Ep 2 (selectable) — should enter mode.
+      await tester.longPress(find.text('Ep 2'));
+      await tester.pumpAndSettle();
+      expect(cancelButton(tester), findsOneWidget);
+      expect(recordButtonLabel(tester, 1), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping Record (N) fires onScheduleEpisodes with the selected episodes '
+    'and exits selection mode',
+    (tester) async {
+      List<EpgShowEpisode>? captured;
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2), ep(3)]),
+        onScheduleEpisodes: (eps) async {
+          captured = eps;
+          return [
+            for (final e in eps)
+              DvrAiringScheduleResult(episode: e, success: true),
+          ];
+        },
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Ep 2'));
+      await tester.pumpAndSettle();
+      expect(recordButtonLabel(tester, 2), findsOneWidget);
+
+      await tester.tap(recordButtonLabel(tester, 2));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.map((e) => e.title).toSet(), {'Ep 1', 'Ep 2'});
+
+      // Handler completed → selection mode cleared.
+      expect(cancelButton(tester), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'all-success batch shows a summary SnackBar ("All succeeded.")',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2)]),
+        onScheduleEpisodes: (eps) async => [
+          for (final e in eps)
+            DvrAiringScheduleResult(episode: e, success: true),
+        ],
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Ep 2'));
+      await tester.pumpAndSettle();
+      await tester.tap(recordButtonLabel(tester, 2));
+      await tester.pumpAndSettle();
+
+      // Summary appears as a SnackBar text. failed == 0 → no failure line.
+      expect(
+        find.text(l10n(tester).showBatchScheduleSummary(2, 0)),
+        findsOneWidget,
+      );
+      expect(
+        find.text(l10n(tester).showBatchScheduleFailures('Ep 1, Ep 2')),
+        findsNothing,
+        reason: 'failed == 0 should suppress the failure-list line',
+      );
+    },
+  );
+
+  testWidgets(
+    'mixed batch lists per-failure titles inline when failed ≤ 3',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2), ep(3)]),
+        onScheduleEpisodes: (eps) async => [
+          DvrAiringScheduleResult(episode: eps[0], success: true),
+          DvrAiringScheduleResult(
+            episode: eps[1],
+            success: false,
+            errorMessage: 'limit reached',
+          ),
+          DvrAiringScheduleResult(
+            episode: eps[2],
+            success: false,
+            errorMessage: 'limit reached',
+          ),
+        ],
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Ep 2'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Ep 3'));
+      await tester.pumpAndSettle();
+      await tester.tap(recordButtonLabel(tester, 3));
+      await tester.pumpAndSettle();
+
+      // 1 scheduled + 2 failed (≤ 3) → failure titles listed inline.
+      // The SnackBar text is summary + "\n" + failure-line, so use
+      // `find.textContaining` — `find.text` is an exact-match against
+      // the full multi-line string.
+      expect(
+        find.textContaining(
+          l10n(tester).showBatchScheduleFailures('Ep 2, Ep 3'),
+        ),
+        findsOneWidget,
+        reason: 'failed (2) ≤ 3 → failure-line appended; substring matches',
+      );
+    },
+  );
+
+  testWidgets(
+    'large-failure batch omits per-failure titles when failed > 3',
+    (tester) async {
+      // List.generate is 0-indexed, so shift by 1 to get titles Ep 1..Ep 5.
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: List.generate(5, (i) => ep(i + 1))),
+        onScheduleEpisodes: (eps) async => [
+          DvrAiringScheduleResult(episode: eps[0], success: true),
+          for (final e in eps.skip(1))
+            DvrAiringScheduleResult(
+              episode: e,
+              success: false,
+              errorMessage: 'x',
+            ),
+        ],
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      for (var i = 2; i <= 5; i++) {
+        await tester.tap(find.text('Ep $i'));
+        await tester.pumpAndSettle();
+      }
+      await tester.tap(recordButtonLabel(tester, 5));
+      await tester.pumpAndSettle();
+
+      // 1 scheduled + 4 failed (> 3) → failure list is suppressed.
+      expect(
+        find.text(l10n(tester).showBatchScheduleSummary(1, 4)),
+        findsOneWidget,
+      );
+      expect(
+        find.textContaining('Failed:'),
+        findsNothing,
+        reason: 'failed > 3 should suppress the failure-list line entirely',
+      );
+    },
+  );
+
+  testWidgets(
+    'wholesale handler failure surfaces appRecordingFailed',
+    (tester) async {
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1)]),
+        onScheduleEpisodes: (_) async {
+          throw StateError('server down');
+        },
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      await tester.tap(recordButtonLabel(tester, 1));
+      await tester.pumpAndSettle();
+
+      // Wholesale-fail path uses the existing appRecordingFailed key.
+      expect(
+        find.text(l10n(tester).appRecordingFailed('Bad state: server down')),
+        findsOneWidget,
+      );
+    },
+  );
+}

--- a/flutter_client/test/features/shows/test_selection_mode_test.dart
+++ b/flutter_client/test/features/shows/test_selection_mode_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -84,7 +86,7 @@ void main() {
         onScheduleEpisodes: (_) async => [],
       );
 
-      // Initially no action bar — the user is in normal mode.
+      // Initially no action bar; the user is in normal mode.
       expect(cancelButton(tester), findsNothing);
 
       await tester.longPress(find.text('Ep 1'));
@@ -171,7 +173,7 @@ void main() {
       await pumpScreen(
         tester,
         show: testShow(episodes: [ep(1)]),
-        // onScheduleEpisodes left null — selection mode is unavailable.
+        // onScheduleEpisodes left null; selection mode is unavailable.
       );
 
       await tester.longPress(find.text('Ep 1'));
@@ -186,7 +188,7 @@ void main() {
   testWidgets(
     'already-scheduled rows are excluded from selection (long-press is a no-op)',
     (tester) async {
-      // A recording that covers Ep 1's window — Ep 1 should be excluded.
+      // A recording that covers Ep 1's window: Ep 1 should be excluded.
       final recording = DvrRecording(
         uuid: 'uuid-scheduled',
         title: 'Ep 1',
@@ -204,16 +206,108 @@ void main() {
         onScheduleEpisodes: (_) async => [],
       );
 
-      // Long-press Ep 1 (already-scheduled) — should not enter mode.
+      // Long-press Ep 1 (already-scheduled): should not enter mode.
       await tester.longPress(find.text('Ep 1'));
       await tester.pumpAndSettle();
       expect(cancelButton(tester), findsNothing);
 
-      // Long-press Ep 2 (selectable) — should enter mode.
+      // Long-press Ep 2 (selectable): should enter mode.
       await tester.longPress(find.text('Ep 2'));
       await tester.pumpAndSettle();
       expect(cancelButton(tester), findsOneWidget);
       expect(recordButtonLabel(tester, 1), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'an already-ended episode cannot be long-pressed into selection mode',
+    (tester) async {
+      final endedEpisode = EpgShowEpisode(
+        channelId: 8,
+        channelName: 'Channel Eight',
+        title: 'Ep Past',
+        startTime: DateTime.now().subtract(const Duration(hours: 2)),
+        endTime: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [endedEpisode, ep(1)]),
+        onScheduleEpisodes: (_) async => [],
+      );
+
+      // The single-item Record button already hides for ended episodes; this
+      // asserts the batch entry point (long-press) respects the same rule.
+      await tester.longPress(find.text('Ep Past'));
+      await tester.pumpAndSettle();
+      expect(cancelButton(tester), findsNothing);
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+      expect(cancelButton(tester), findsOneWidget);
+      expect(recordButtonLabel(tester, 1), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'a recording that only touches (does not overlap) an episode does not '
+    'mark it already-scheduled',
+    (tester) async {
+      // Recording for Ep 1 ends exactly when Ep 2 starts (back-to-back
+      // airings on the same channel). Ep 2 must remain selectable.
+      final recording = DvrRecording(
+        uuid: 'uuid-back-to-back',
+        title: 'Ep 1',
+        status: DvrRecordingStatus.scheduled,
+        channelId: 8,
+        channelName: 'Channel Eight',
+        scheduledStart: ep(1).startTime,
+        scheduledEnd: ep(2).startTime,
+      );
+
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1), ep(2)]),
+        recordings: [recording],
+        onScheduleEpisodes: (_) async => [],
+      );
+
+      await tester.longPress(find.text('Ep 2'));
+      await tester.pumpAndSettle();
+      expect(cancelButton(tester), findsOneWidget);
+      expect(recordButtonLabel(tester, 1), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'double-tapping Record (N) only fires onScheduleEpisodes once',
+    (tester) async {
+      var callCount = 0;
+      final completer = Completer<List<DvrAiringScheduleResult>>();
+      await pumpScreen(
+        tester,
+        show: testShow(episodes: [ep(1)]),
+        onScheduleEpisodes: (eps) {
+          callCount++;
+          return completer.future;
+        },
+      );
+
+      await tester.longPress(find.text('Ep 1'));
+      await tester.pumpAndSettle();
+
+      // Tap twice before the handler resolves.
+      await tester.tap(recordButtonLabel(tester, 1));
+      await tester.pump();
+      await tester.tap(recordButtonLabel(tester, 1));
+      await tester.pump();
+
+      expect(callCount, 1);
+
+      completer.complete([
+        DvrAiringScheduleResult(episode: ep(1), success: true),
+      ]);
+      await tester.pumpAndSettle();
     },
   );
 
@@ -315,7 +409,7 @@ void main() {
 
       // 1 scheduled + 2 failed (≤ 3) → failure titles listed inline.
       // The SnackBar text is summary + "\n" + failure-line, so use
-      // `find.textContaining` — `find.text` is an exact-match against
+      // `find.textContaining`; `find.text` is an exact-match against
       // the full multi-line string.
       expect(
         find.textContaining(

--- a/flutter_client/test/features/shows/test_toggle_state_test.dart
+++ b/flutter_client/test/features/shows/test_toggle_state_test.dart
@@ -49,6 +49,7 @@ void main() {
             // Override dvrSeriesRulesProvider directly so we don't need a
             // full AppStateController mock.
             dvrSeriesRulesProvider.overrideWith((_) => [matchingRule]),
+            dvrRecordingsProvider.overrideWith((_) => const []),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -118,6 +119,7 @@ void main() {
         ProviderScope(
           overrides: [
             dvrSeriesRulesProvider.overrideWith((_) => const []),
+            dvrRecordingsProvider.overrideWith((_) => const []),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
Phase 2 of #204. Phase 1 (single-airing Record button) shipped in #208.

## What this does

Adds a multi-select mode to the Shows-DVR detail screen so several hand-picked airings can be scheduled in one pass, without creating a series rule.

- `AppStateController.scheduleDvrAirings(List<EpgShowEpisode>)` — new bulk primitive alongside the existing single-item `scheduleDvrAiring`. Runs requests sequentially, refreshes the DVR recordings list **once** after the whole batch (not once per item), and returns a `DvrAiringScheduleResult` per episode so a per-item failure (e.g. a 422 concurrent-recording-limit response partway through a large batch) doesn't abort the rest.
- **Duplicate marking is derived client-side**, not from a server 409: an episode already covered by an existing recording is detected via channel + time-window overlap against `AppStateController.dvrRecordings`, and excluded from selection with a "Scheduled" badge. Overlap matching (not near-exact start-time equality) because the server pads `DvrRecording.scheduled_start` backward by the rule's `start_early_seconds`, which commonly exceeds a minute.
- Long-press a row to enter selection mode (the existing `DpadInkWell.onLongTap`, already used for D-pad hold + touch long-press elsewhere); tapping toggles selection. A "Record (N)" / Cancel action bar appears above the episode list, reusing `LeadingTile`'s existing checkbox rendering (already used by the DVR recordings screen) for the selected-state indicator.
- Wired through `ContentActions` → go_router → `AppShell` the same way the existing single-airing `onScheduleEpisode` already is.
- A single summary SnackBar after a batch completes ("N scheduled, N failed"), with failed episode titles listed inline only when the failure count is 1-3 (beyond that it would overrun the SnackBar).

## Related

`schedule_dvr` has no server-side duplicate check at all — found while scoping this work, filed separately as m3ue/m3u-editor#1432 (not a blocker here; this PR works entirely from client-side data). m3ue/m3u-editor#1412 (already merged) raised `search_epg_shows`'s `recent_episodes` cap from 5 to 40; selection is still bounded to that preview list, not the show's full airing history — no "select all" wording implies otherwise.

## Testing

- `dart format --set-exit-if-changed lib test` — clean
- `flutter analyze lib test` — no issues
- `flutter test test/features/shows/` — 42/42 (27 pre-existing + 4 new duplicate-marking tests + 11 new selection-mode/batch-summary tests)
- `flutter test test/ui/` — 393 passed, 7 skipped, 2 failed; both failures are in `timeline_epg_view_test.dart` and confirmed pre-existing and unrelated (reproduced identically on the clean base commit with zero changes applied)