### PR TITLE
feat(search): bring EPG show results to the main Search screen (#227)

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1083,6 +1083,8 @@ class AppShellState extends ConsumerState<AppShell>
         onVodSelect: _openVod,
         onSeriesSelect: _openSeries,
         onSidebarActivate: _activateSidebar,
+        onSearchShows: _searchEpgShows,
+        onShowSelect: _openShow,
       ),
       RouteNames.liveTv => LiveTvScreen(
         favoritesService: _appState.favoritesService,

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -19,6 +19,7 @@ import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/dvr_action_dialogs.dart';
+import 'package:m3u_tv/shared/epg_show_search_controller.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/shared/media_category_nav.dart';
 import 'package:m3u_tv/shared/recording_dot.dart';
@@ -212,16 +213,7 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
   // last landed on - not necessarily the row the user was actually just on.
   final GlobalKey<TimelineEpgViewState> _timelineEpgViewKey =
       GlobalKey<TimelineEpgViewState>();
-  Timer? _showSearchDebounce;
-  int _showSearchGeneration = 0;
-  List<EpgShow> _showResults = const <EpgShow>[];
-  bool _showIsLoading = false;
-  String? _showError;
-  // Bumped on each new qualifying search to tell the embedded
-  // ShowSearchResultsView to reset its tab index back to "All". Mirrors
-  // the previous `_searchResultsTabController.index = 0` side effect at
-  // the old :404-407 call site.
-  int _searchSessionId = 0;
+  final _showSearchController = EpgShowSearchController();
 
   @override
   void initState() {
@@ -230,6 +222,11 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
     _attachViewSettingsListener();
     unawaited(_initCategory());
     widget.onBackHandlerReady?.call(_handleBackFromEpg);
+    _showSearchController.addListener(_onShowSearchChanged);
+  }
+
+  void _onShowSearchChanged() {
+    if (mounted) setState(() {});
   }
 
   bool _handleBackFromEpg() {
@@ -263,7 +260,9 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
     _searchResultsFocusNode.dispose();
     _channelColumnFocusNode.dispose();
     _dayControlsFocusNode.dispose();
-    _showSearchDebounce?.cancel();
+    _showSearchController
+      ..removeListener(_onShowSearchChanged)
+      ..dispose();
     super.dispose();
   }
 
@@ -367,77 +366,6 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
     if (mounted) {
       setState(() {
         _favoriteIds = ids;
-      });
-    }
-  }
-
-  // Tracks whether the *previous* keystroke's query already met the 2-char
-  // search threshold, so the results tab only resets to "All" on the
-  // transition into search mode - not on every keystroke while refining an
-  // already-active query, which would otherwise bounce the user off a
-  // deliberately-chosen On Now/Upcoming tab mid-typing.
-  bool _showSearchWasActive = false;
-
-  /// Mirrors `ShowsScreen._onQueryChanged`. Kept independent of the
-  /// synchronous `_query` setState that drives [_filteredChannels] so the
-  /// channel list narrows on every keystroke while the show search waits
-  /// out the debounce + network roundtrip.
-  void _onShowQueryChanged(String value) {
-    final trimmed = value.trim();
-    if (trimmed.length < 2) {
-      _showSearchWasActive = false;
-      _showSearchDebounce?.cancel();
-      _showSearchGeneration++;
-      if (_showResults.isNotEmpty || _showIsLoading || _showError != null) {
-        setState(() {
-          _showResults = const <EpgShow>[];
-          _showIsLoading = false;
-          _showError = null;
-        });
-      }
-      return;
-    }
-    if (!_showSearchWasActive) {
-      _searchSessionId++;
-    }
-    _showSearchWasActive = true;
-    _showSearchDebounce?.cancel();
-    // R2.1: flip to loading synchronously so the results view renders
-    // "Searching shows…" the same frame the qualifying query first
-    // arrives. Without this, the empty view flashes "No shows match your
-    // search" for the 350ms the debounce is waiting before the network
-    // call fires.
-    setState(() {
-      _showIsLoading = true;
-      _showResults = const <EpgShow>[];
-      _showError = null;
-    });
-    _showSearchDebounce = Timer(
-      const Duration(milliseconds: 350),
-      () => _runShowSearch(trimmed),
-    );
-  }
-
-  Future<void> _runShowSearch(String trimmed) async {
-    final search = widget.onSearchShows;
-    if (search == null) return;
-    final generation = ++_showSearchGeneration;
-    setState(() {
-      _showIsLoading = true;
-      _showError = null;
-    });
-    try {
-      final results = await search(trimmed);
-      if (!mounted || generation != _showSearchGeneration) return;
-      setState(() {
-        _showResults = results;
-        _showIsLoading = false;
-      });
-    } on Object catch (error) {
-      if (!mounted || generation != _showSearchGeneration) return;
-      setState(() {
-        _showError = error.toString();
-        _showIsLoading = false;
       });
     }
   }
@@ -764,7 +692,7 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
       query: _query,
       onQueryChanged: (value) {
         setState(() => _query = value);
-        _onShowQueryChanged(value);
+        _showSearchController.onQueryChanged(value, widget.onSearchShows);
       },
       searchHint: l.liveTvSearchHint,
       tabs: _categoryTabs(categories),
@@ -800,16 +728,16 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
               child: FocusScope(
                 node: _searchResultsFocusNode,
                 child: ShowSearchResultsView(
-                  shows: _showResults,
-                  isLoading: _showIsLoading,
-                  error: _showError,
+                  shows: _showSearchController.results,
+                  isLoading: _showSearchController.isLoading,
+                  error: _showSearchController.error,
                   channelsById: channelsById,
                   onChannelSelect: widget.onChannelSelect,
                   onChannelContextChanged: widget.onChannelContextChanged,
                   onShowSelect: widget.onShowSelect,
                   memoryKeyPrefix: 'live-tv/search-results',
                   onEdge: _handleGridLeftEdge,
-                  resetTabsToken: _searchSessionId,
+                  resetTabsToken: _showSearchController.searchSessionId,
                 ),
               ),
             )

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -5,7 +5,6 @@ import 'package:dpad/dpad.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:m3u_tv/features/epg/epg_recording_index.dart';
 import 'package:m3u_tv/features/epg/timeline_epg_view.dart';
 import 'package:m3u_tv/features/live_tv/catchup_shows_dialog.dart';
@@ -19,11 +18,11 @@ import 'package:m3u_tv/services/view_settings_service.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
-import 'package:m3u_tv/shared/dpad_tab_bar.dart';
 import 'package:m3u_tv/shared/dvr_action_dialogs.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/shared/media_category_nav.dart';
 import 'package:m3u_tv/shared/recording_dot.dart';
+import 'package:m3u_tv/shared/show_search_results_view.dart';
 
 enum _ViewMode { list, logoGrid, epgGrid }
 
@@ -218,17 +217,15 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
   List<EpgShow> _showResults = const <EpgShow>[];
   bool _showIsLoading = false;
   String? _showError;
-  late final TabController _searchResultsTabController;
+  // Bumped on each new qualifying search to tell the embedded
+  // ShowSearchResultsView to reset its tab index back to "All". Mirrors
+  // the previous `_searchResultsTabController.index = 0` side effect at
+  // the old :404-407 call site.
+  int _searchSessionId = 0;
 
   @override
   void initState() {
     super.initState();
-    // Constructed eagerly here, not via a lazy `late` initializer, because
-    // it's only read from build() while a search is active - a `late`
-    // initializer would defer construction until dispose() on any screen
-    // instance that never searched, and TabController's AnimationController
-    // needs a live TickerMode ancestor that's already gone by then.
-    _searchResultsTabController = TabController(length: 3, vsync: this);
     widget.favoritesService.addListener(_onFavoritesChanged);
     _attachViewSettingsListener();
     unawaited(_initCategory());
@@ -267,7 +264,6 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
     _channelColumnFocusNode.dispose();
     _dayControlsFocusNode.dispose();
     _showSearchDebounce?.cancel();
-    _searchResultsTabController.dispose();
     super.dispose();
   }
 
@@ -402,7 +398,7 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
       return;
     }
     if (!_showSearchWasActive) {
-      _searchResultsTabController.index = 0;
+      _searchSessionId++;
     }
     _showSearchWasActive = true;
     _showSearchDebounce?.cancel();
@@ -803,18 +799,17 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
             Expanded(
               child: FocusScope(
                 node: _searchResultsFocusNode,
-                child: Column(
-                  children: [
-                    DpadTabBar(
-                      controller: _searchResultsTabController,
-                      tabs: [
-                        l.liveTvSearchFilterAll,
-                        l.liveTvOnNow,
-                        l.liveTvUpcomingAirings,
-                      ],
-                    ),
-                    Expanded(child: _buildSearchResultsTabs(channelsById)),
-                  ],
+                child: ShowSearchResultsView(
+                  shows: _showResults,
+                  isLoading: _showIsLoading,
+                  error: _showError,
+                  channelsById: channelsById,
+                  onChannelSelect: widget.onChannelSelect,
+                  onChannelContextChanged: widget.onChannelContextChanged,
+                  onShowSelect: widget.onShowSelect,
+                  memoryKeyPrefix: 'live-tv/search-results',
+                  onEdge: _handleGridLeftEdge,
+                  resetTabsToken: _searchSessionId,
                 ),
               ),
             )
@@ -862,308 +857,13 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
     );
   }
 
-  /// Builds the three [DpadTabBarView] pages (All / On Now / Upcoming) that
-  /// replace the channel list while a qualifying show search is active.
-  /// One [_buildShowResultEntries] pass serves all three tabs - each tab is
-  /// just a different filter over the same combined, deduped result set.
-  Widget _buildSearchResultsTabs(Map<int, Channel> channelsById) {
-    final result = _buildShowResultEntries(channelsById);
-    return DpadTabBarView(
-      controller: _searchResultsTabController,
-      children: [
-        _buildSearchResultsList(
-          channelsById,
-          result.all,
-          result.onNowChannels,
-          'all',
-        ),
-        _buildSearchResultsList(
-          channelsById,
-          result.onNow,
-          result.onNowChannels,
-          'on-now',
-        ),
-        _buildSearchResultsList(
-          channelsById,
-          result.upcoming,
-          result.onNowChannels,
-          'upcoming',
-        ),
-      ],
-    );
-  }
-
-  Widget _buildSearchResultsList(
-    Map<int, Channel> channelsById,
-    List<_ShowResultEntry> entries,
-    List<Channel> onNowChannels,
-    String tabKey,
-  ) {
-    final l10n = AppLocalizations.of(context);
-    final localized = Localizations.localeOf(context).toLanguageTag();
-    if (entries.isEmpty) {
-      // Preserve the R2.1 loading UX: when the user types a qualifying
-      // query and the search is still in flight, show the loading label
-      // instead of the no-matches label, so the latter doesn't flash
-      // before the request resolves.
-      final emptyText = _showIsLoading
-          ? l10n.liveTvShowResultsLoading
-          : _showError != null
-          ? l10n.showsSearchError
-          : l10n.showsNoResults;
-      return Center(
-        child: Text(emptyText, style: Theme.of(context).textTheme.bodyLarge),
-      );
-    }
-    return DpadRegion(
-      memoryKey: 'live-tv/search-results/$tabKey',
-      horizontalEdge: DpadEdgeBehavior.stop,
-      onEdge: _handleGridLeftEdge,
-      child: ScrollbarListView(
-        itemCount: entries.length,
-        itemBuilder: (context, index) => Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4),
-          child: _buildSearchResultRow(
-            entries[index],
-            channelsById,
-            onNowChannels,
-            l10n,
-            localized,
-            autofocus: index == 0,
-          ),
-        ),
-      ),
-    );
-  }
-
-  /// Combines `airingNow` and future `recentEpisodes` into one row model
-  /// per (show, channelId), deduped so a show currently airing doesn't also
-  /// render as its own Upcoming row for the same channel - the On Now row
-  /// already covers it. `onNow`/`upcoming` are the same entries split out
-  /// per tab; `all` is On Now first, then Upcoming, matching the previous
-  /// stacking order. `onNowChannels` is the deduped, ordered list of
-  /// channels represented in On Now, used for skip-previous/next context
-  /// when a rider taps an On Now row (those are the only channels reliably
-  /// on screen for that action).
-  ({
-    List<_ShowResultEntry> all,
-    List<_ShowResultEntry> onNow,
-    List<_ShowResultEntry> upcoming,
-    List<Channel> onNowChannels,
-  })
-  _buildShowResultEntries(Map<int, Channel> channelsById) {
-    final now = DateTime.now().toUtc();
-
-    // On Now: one entry per (show, channelId) currently airing. The channel
-    // lookup is built from the **full** channel list, not the
-    // search-filtered list - searching for a show name does not filter
-    // channels by name, so the lookup must include every channel a
-    // programme could be airing on.
-    final onNowKeys = <_ShowResultKey>{};
-    final onNowEntries = <_ShowResultEntry>[];
-    final onNowChannelIds = <int>{};
-    final onNowChannels = <Channel>[];
-    for (final show in _showResults) {
-      for (final episode in show.airingNow) {
-        final channel = channelsById[episode.channelId];
-        if (channel == null) continue;
-        final key = (show: show, channelId: episode.channelId);
-        if (!onNowKeys.add(key)) continue;
-        onNowEntries.add(
-          _ShowResultEntry(
-            show: show,
-            channelId: episode.channelId,
-            episodes: [episode],
-            isOnNow: true,
-          ),
-        );
-        if (onNowChannelIds.add(channel.id)) onNowChannels.add(channel);
-      }
-    }
-
-    // Upcoming: future airings grouped by (show, channelId) - a single show
-    // repeating on one network used to render a wall of identical rows (40
-    // future airings of "Grace and Frankie" on one channel produced 12
-    // identical rows); grouping collapses duplicates into one row that
-    // shows up to 3 airing times plus a "+N more" affordance pointing at
-    // the show detail screen, which already lists every airing. Skips any
-    // (show, channelId) already covered by On Now.
-    final groups = <_ShowResultKey, List<EpgShowEpisode>>{};
-    for (final show in _showResults) {
-      for (final episode in show.recentEpisodes) {
-        if (episode.displayTitle.isEmpty) continue;
-        if (!episode.startTime.isAfter(now)) continue;
-        final key = (show: show, channelId: episode.channelId);
-        if (onNowKeys.contains(key)) continue;
-        groups.putIfAbsent(key, () => <EpgShowEpisode>[]).add(episode);
-      }
-    }
-    final upcomingEntries =
-        groups.entries.map((entry) {
-          final episodes = entry.value
-            ..sort((a, b) => a.startTime.compareTo(b.startTime));
-          return _ShowResultEntry(
-            show: entry.key.show,
-            channelId: entry.key.channelId,
-            episodes: episodes,
-            isOnNow: false,
-          );
-        }).toList()..sort(
-          (a, b) => a.episodes.first.startTime.compareTo(
-            b.episodes.first.startTime,
-          ),
-        );
-
-    return (
-      all: [...onNowEntries, ...upcomingEntries],
-      onNow: onNowEntries,
-      upcoming: upcomingEntries,
-      onNowChannels: onNowChannels,
-    );
-  }
-
-  /// Single row style shared by On Now and Upcoming results so the merged
-  /// "All" tab reads as one consistent list rather than mixed layouts. On
-  /// Now rows tap straight to the channel (skip-previous/next then stays
-  /// within the On Now channel set); Upcoming rows open the show detail
-  /// screen, which has the recording actions.
-  Widget _buildSearchResultRow(
-    _ShowResultEntry entry,
-    Map<int, Channel> channelsById,
-    List<Channel> onNowChannels,
-    AppLocalizations l10n,
-    String languageTag, {
-    bool autofocus = false,
-  }) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final channel = channelsById[entry.channelId];
-    final firstEpisode = entry.episodes.first;
-    final channelName = firstEpisode.channelName;
-    final String? subtitle;
-    final String trailingText;
-    if (entry.isOnNow) {
-      subtitle = _formatOnNowSubtitle(firstEpisode, channelName);
-      trailingText = l10n.liveTvAiringUntil(
-        DateFormat.jm(languageTag).format(firstEpisode.endTime.toLocal()),
-      );
-    } else {
-      subtitle = channelName;
-      final times = <String>[];
-      for (final episode in entry.episodes.take(3)) {
-        times.add(_formatUpcomingTime(episode.startTime, languageTag, l10n));
-      }
-      final remainder = entry.episodes.length - times.length;
-      if (remainder > 0) {
-        times.add(l10n.liveTvMoreAirings(remainder));
-      }
-      trailingText = times.join(' · ');
-    }
-
-    return DpadInkWell(
-      autofocus: autofocus,
-      borderRadius: BorderRadius.circular(8),
-      color: colorScheme.surfaceContainerHigh,
-      onTap: entry.isOnNow
-          ? channel == null
-                ? null
-                : () {
-                    widget.onChannelContextChanged?.call(onNowChannels);
-                    widget.onChannelSelect(channel);
-                  }
-          : () => widget.onShowSelect?.call(entry.show),
-      child: Padding(
-        padding: const EdgeInsets.all(MediaBrowsingMetrics.contentPadding),
-        child: Row(
-          children: [
-            ResilientMediaImage(
-              imageUrl: channel?.logoUrl,
-              fallbackIcon: Icons.tv,
-              width: MediaBrowsingMetrics.logoSize,
-              height: MediaBrowsingMetrics.logoSize,
-              fit: BoxFit.contain,
-              backgroundColor: Colors.transparent,
-            ),
-            const SizedBox(width: MediaBrowsingMetrics.itemGap),
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    entry.show.displayTitle,
-                    style: Theme.of(context).textTheme.bodyMedium,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  if (subtitle != null && subtitle.isNotEmpty) ...[
-                    const SizedBox(height: 2),
-                    Text(
-                      subtitle,
-                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: colorScheme.onSurfaceVariant,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            const SizedBox(width: MediaBrowsingMetrics.itemGap),
-            Flexible(
-              child: Text(
-                trailingText,
-                textAlign: TextAlign.end,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                  color: colorScheme.onSurface,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  /// R6: episode name first (the higher-value token), channel second. Both
-  /// are optional and either may be absent.
-  ///
-  /// Deliberately allowed to ellipsise. Round 4 moved the airing time out
-  /// of the subtitle line precisely so a long value here costs nothing
-  /// important - the time now lives in the trailing time text and is
-  /// immune, and channel identity is carried redundantly by the station
-  /// logo. Do NOT re-add the time here.
-  ///
-  /// Returns null (not empty string) when both are absent - empty string
-  /// would render a phantom 11px row in the result row.
-  String? _formatOnNowSubtitle(EpgShowEpisode episode, String? channelName) {
-    final ep = episode.subtitle;
-    final hasEp = ep != null && ep.trim().isNotEmpty;
-    final hasCh = channelName != null && channelName.trim().isNotEmpty;
-    if (hasEp && hasCh) return '$ep · $channelName';
-    if (hasEp) return ep;
-    if (hasCh) return channelName;
-    return null;
-  }
-
-  String _formatUpcomingTime(
-    DateTime startTime,
-    String languageTag,
-    AppLocalizations l10n,
-  ) {
-    final local = startTime.toLocal();
-    final now = DateTime.now();
-    final tomorrow = DateTime(now.year, now.month, now.day + 1);
-    bool sameDay(DateTime a, DateTime b) =>
-        a.year == b.year && a.month == b.month && a.day == b.day;
-    final time = DateFormat.jm(languageTag).format(local);
-    if (sameDay(local, now)) return time;
-    if (sameDay(local, tomorrow)) return l10n.liveTvAiringTomorrow(time);
-    return DateFormat.MMMd(languageTag).add_jm().format(local);
-  }
+  /// Extracted: the All/On-Now/Upcoming sub-tab rendering, the row widget,
+  /// and the (airingNow + recentEpisodes) -> entries combiner now live in
+  /// `lib/shared/show_search_results_view.dart` and
+  /// `lib/shared/epg_show_results.dart`. Only the parent
+  /// `FocusScope`/`_searchResultsFocusNode` and the `_handleGridLeftEdge`
+  /// binding stay on this screen - both are LiveTvScreen-specific chrome
+  /// for its sidebar-nav integration.
 
   void _handleGridLeftEdge(TraversalDirection direction) {
     if (direction != TraversalDirection.left) return;
@@ -1674,29 +1374,4 @@ class _ChannelGridItem extends StatelessWidget {
       ),
     );
   }
-}
-
-/// Grouping key: `(show, channelId)`. Two airings of the same show on
-/// different channels belong to separate rows; two airings of the same show
-/// on the same channel collapse into one row whose airing list grows.
-/// Keyed on the `EpgShow` instance itself (identity equality, not
-/// `normalizedTitle`) - the server can omit `normalized_title`, and two
-/// distinct shows both falling back to `''` must not merge into one row.
-typedef _ShowResultKey = ({EpgShow show, int channelId});
-
-/// One row in the unified search-results list. On Now rows carry exactly
-/// one episode (the one currently airing); Upcoming rows carry 1+ future
-/// episodes on this show+channel, soonest first.
-class _ShowResultEntry {
-  const _ShowResultEntry({
-    required this.show,
-    required this.channelId,
-    required this.episodes,
-    required this.isOnNow,
-  });
-
-  final EpgShow show;
-  final int channelId;
-  final List<EpgShowEpisode> episodes;
-  final bool isOnNow;
 }

--- a/flutter_client/lib/features/search/search_screen.dart
+++ b/flutter_client/lib/features/search/search_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -5,7 +7,9 @@ import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/dpad_tab_bar.dart';
+import 'package:m3u_tv/shared/epg_show_results.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+import 'package:m3u_tv/shared/show_search_results_view.dart';
 
 /// Search screen with client-side filtering across Live TV, Movies, and Series.
 ///
@@ -21,6 +25,8 @@ class SearchScreen extends ConsumerStatefulWidget {
     required this.onVodSelect,
     required this.onSeriesSelect,
     this.onSidebarActivate,
+    this.onSearchShows,
+    this.onShowSelect,
   });
 
   final void Function(Channel) onChannelSelect;
@@ -33,6 +39,19 @@ class SearchScreen extends ConsumerStatefulWidget {
   final void Function(Series) onSeriesSelect;
   final VoidCallback? onSidebarActivate;
 
+  /// When non-null, a ≥2-character query surfaces EPG show results in
+  /// both the All tab (as On-Now/Upcoming sections above the existing
+  /// channel-name section) and the Live TV tab (which fully replaces its
+  /// content with the All/On-Now/Upcoming sub-tab view). The same
+  /// nullable convention `LiveTvScreen` uses - hides the affordance
+  /// entirely when the host app hasn't wired it.
+  final Future<List<EpgShow>> Function(String)? onSearchShows;
+
+  /// Tapping an Upcoming row in either tab calls this. On Now rows still
+  /// go through [onChannelSelect] (today's player skip-previous/next
+  /// semantics depend on that channel-first path).
+  final void Function(EpgShow)? onShowSelect;
+
   @override
   ConsumerState<SearchScreen> createState() => _SearchScreenState();
 }
@@ -41,6 +60,19 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
   String _query = '';
+
+  // EPG show-search state machine. Mirrors `live_tv_screen.dart:216-220`
+  // minus the tab-reset side effect (which lives on the embedded
+  // ShowSearchResultsView via its `resetTabsToken` prop instead). The
+  // LiveTvScreen version's tab-reset side effect doesn't generalize
+  // cleanly, so ~50 duplicated lines is the accepted trade.
+  Timer? _showSearchDebounce;
+  int _showSearchGeneration = 0;
+  List<EpgShow> _showResults = const <EpgShow>[];
+  bool _showIsLoading = false;
+  String? _showError;
+  bool _showSearchWasActive = false;
+  int _searchSessionId = 0;
 
   @override
   void initState() {
@@ -51,6 +83,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   @override
   void dispose() {
     _tabController.dispose();
+    _showSearchDebounce?.cancel();
     super.dispose();
   }
 
@@ -81,6 +114,76 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             .toList(growable: false)
       : const [];
 
+  /// Mirrors `LiveTvScreen._onShowQueryChanged`. Kept independent of the
+  /// synchronous `_query` setState that drives channel/VOD/series
+  /// filtering so those lists narrow on every keystroke while the show
+  /// search waits out the debounce + network roundtrip.
+  void _onShowQueryChanged(String value) {
+    final trimmed = value.trim();
+    if (trimmed.length < 2) {
+      _showSearchWasActive = false;
+      _showSearchDebounce?.cancel();
+      _showSearchGeneration++;
+      if (_showResults.isNotEmpty || _showIsLoading || _showError != null) {
+        setState(() {
+          _showResults = const <EpgShow>[];
+          _showIsLoading = false;
+          _showError = null;
+        });
+      }
+      return;
+    }
+    if (!_showSearchWasActive) {
+      _searchSessionId++;
+    }
+    _showSearchWasActive = true;
+    _showSearchDebounce?.cancel();
+    // Flip to loading synchronously so the show-results view renders
+    // "Searching shows…" the same frame the qualifying query first
+    // arrives. Without this, the empty view flashes "No shows match
+    // your search" for the 350ms the debounce is waiting before the
+    // network call fires.
+    setState(() {
+      _showIsLoading = true;
+      _showResults = const <EpgShow>[];
+      _showError = null;
+    });
+    _showSearchDebounce = Timer(
+      const Duration(milliseconds: 350),
+      () => _runShowSearch(trimmed),
+    );
+  }
+
+  Future<void> _runShowSearch(String trimmed) async {
+    final search = widget.onSearchShows;
+    if (search == null) return;
+    final generation = ++_showSearchGeneration;
+    setState(() {
+      _showIsLoading = true;
+      _showError = null;
+    });
+    try {
+      final results = await search(trimmed);
+      if (!mounted || generation != _showSearchGeneration) return;
+      setState(() {
+        _showResults = results;
+        _showIsLoading = false;
+      });
+    } on Object catch (error) {
+      if (!mounted || generation != _showSearchGeneration) return;
+      setState(() {
+        _showError = error.toString();
+        _showIsLoading = false;
+      });
+    }
+  }
+
+  /// Active when the EPG show search should render in place of (Live TV
+  /// tab) or alongside (All tab) the synchronous channel-name filter.
+  /// Mirrors `live_tv_screen.dart:764`'s `showSearchActive` condition.
+  bool get _showSearchActive =>
+      widget.onSearchShows != null && _normalizedQuery.length >= 2;
+
   @override
   Widget build(BuildContext context) {
     final isBootstrapping = ref.watch(isBootstrappingProvider);
@@ -107,6 +210,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     final filteredChannels = _filterChannels(channels);
     final filteredVodItems = _filterVodItems(vodItems);
     final filteredSeries = _filterSeriesList(seriesList);
+    // Build from the FULL channel list (not the filtered one) - EPG
+    // show-result channel lookups must work even when the show's
+    // channel name doesn't match the current query.
+    final channelsById = {for (final c in channels) c.id: c};
 
     return Scaffold(
       body: Column(
@@ -116,7 +223,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             child: InlineMediaSearchField(
               query: _query,
               hintText: AppLocalizations.of(context).searchHint,
-              onChanged: (value) => setState(() => _query = value),
+              onChanged: (value) {
+                setState(() => _query = value);
+                _onShowQueryChanged(value);
+              },
             ),
           ),
           DpadTabBar(
@@ -136,8 +246,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
                   filteredChannels,
                   filteredVodItems,
                   filteredSeries,
+                  channelsById,
                 ),
-                _buildLiveTvTab(filteredChannels),
+                _buildLiveTvTab(filteredChannels, channelsById),
                 _buildMoviesTab(filteredVodItems),
                 _buildSeriesTab(filteredSeries),
               ],
@@ -152,9 +263,22 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     List<Channel> channels,
     List<VodItem> vodItems,
     List<Series> seriesList,
+    Map<int, Channel> channelsById,
   ) {
     if (!_hasQuery) return _buildPromptState();
-    if (channels.isEmpty && vodItems.isEmpty && seriesList.isEmpty) {
+    final languageTag = Localizations.localeOf(context).toLanguageTag();
+    final showResult = buildShowResultEntries(_showResults, channelsById);
+    final onNowEntries = showResult.onNow;
+    final upcomingEntries = showResult.upcoming;
+    // Empty-state-guard: a query can match a show name that doesn't match
+    // any channel/VOD/series name (e.g. "Bear" matching no channel called
+    // "Bear" but airing on some channel). Without this check, the EPG
+    // results would never render.
+    if (channels.isEmpty &&
+        vodItems.isEmpty &&
+        seriesList.isEmpty &&
+        onNowEntries.isEmpty &&
+        upcomingEntries.isEmpty) {
       return _buildEmptyState('No results found');
     }
 
@@ -168,6 +292,36 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
       },
       child: ListView(
         children: [
+          if (onNowEntries.isNotEmpty) ...[
+            _SectionHeader(title: AppLocalizations.of(context).liveTvOnNow),
+            ...onNowEntries.map(
+              (entry) => ShowResultRow(
+                entry: entry,
+                channel: channelsById[entry.channelId],
+                onNowChannels: showResult.onNowChannels,
+                onChannelSelect: widget.onChannelSelect,
+                onChannelContextChanged: widget.onChannelContextChanged,
+                onShowSelect: widget.onShowSelect,
+                languageTag: languageTag,
+              ),
+            ),
+          ],
+          if (upcomingEntries.isNotEmpty) ...[
+            _SectionHeader(
+              title: AppLocalizations.of(context).liveTvUpcomingAirings,
+            ),
+            ...upcomingEntries.map(
+              (entry) => ShowResultRow(
+                entry: entry,
+                channel: channelsById[entry.channelId],
+                onNowChannels: showResult.onNowChannels,
+                onChannelSelect: widget.onChannelSelect,
+                onChannelContextChanged: widget.onChannelContextChanged,
+                onShowSelect: widget.onShowSelect,
+                languageTag: languageTag,
+              ),
+            ),
+          ],
           if (channels.isNotEmpty) ...[
             _SectionHeader(
               title: AppLocalizations.of(context).searchSectionLiveTv,
@@ -206,8 +360,33 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     );
   }
 
-  Widget _buildLiveTvTab(List<Channel> channels) {
+  Widget _buildLiveTvTab(
+    List<Channel> channels,
+    Map<int, Channel> channelsById,
+  ) {
     if (!_hasQuery) return _buildPromptState();
+    // When the EPG show search is active, fully replace the channel-tile
+    // list with the same All/On-Now/Upcoming sub-tab view LiveTvScreen
+    // uses - mirrors LiveTvScreen exactly because (like Live TV) this tab
+    // has nothing else to show once a show search fires.
+    if (_showSearchActive) {
+      return ShowSearchResultsView(
+        shows: _showResults,
+        isLoading: _showIsLoading,
+        error: _showError,
+        channelsById: channelsById,
+        onChannelSelect: widget.onChannelSelect,
+        onChannelContextChanged: widget.onChannelContextChanged,
+        onShowSelect: widget.onShowSelect,
+        memoryKeyPrefix: 'search/live-tv/search-results',
+        onEdge: (direction) {
+          if (direction == TraversalDirection.left) {
+            widget.onSidebarActivate?.call();
+          }
+        },
+        resetTabsToken: _searchSessionId,
+      );
+    }
     if (channels.isEmpty) return _buildEmptyState('No results found');
     return DpadRegion(
       memoryKey: 'search/live-tv',

--- a/flutter_client/lib/features/search/search_screen.dart
+++ b/flutter_client/lib/features/search/search_screen.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,6 +6,7 @@ import 'package:m3u_tv/providers/app_providers.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/dpad_tab_bar.dart';
 import 'package:m3u_tv/shared/epg_show_results.dart';
+import 'package:m3u_tv/shared/epg_show_search_controller.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/shared/show_search_results_view.dart';
 
@@ -61,29 +60,25 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   late TabController _tabController;
   String _query = '';
 
-  // EPG show-search state machine. Mirrors `live_tv_screen.dart:216-220`
-  // minus the tab-reset side effect (which lives on the embedded
-  // ShowSearchResultsView via its `resetTabsToken` prop instead). The
-  // LiveTvScreen version's tab-reset side effect doesn't generalize
-  // cleanly, so ~50 duplicated lines is the accepted trade.
-  Timer? _showSearchDebounce;
-  int _showSearchGeneration = 0;
-  List<EpgShow> _showResults = const <EpgShow>[];
-  bool _showIsLoading = false;
-  String? _showError;
-  bool _showSearchWasActive = false;
-  int _searchSessionId = 0;
+  final _showSearchController = EpgShowSearchController();
 
   @override
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _showSearchController.addListener(_onShowSearchChanged);
+  }
+
+  void _onShowSearchChanged() {
+    if (mounted) setState(() {});
   }
 
   @override
   void dispose() {
     _tabController.dispose();
-    _showSearchDebounce?.cancel();
+    _showSearchController
+      ..removeListener(_onShowSearchChanged)
+      ..dispose();
     super.dispose();
   }
 
@@ -113,70 +108,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             )
             .toList(growable: false)
       : const [];
-
-  /// Mirrors `LiveTvScreen._onShowQueryChanged`. Kept independent of the
-  /// synchronous `_query` setState that drives channel/VOD/series
-  /// filtering so those lists narrow on every keystroke while the show
-  /// search waits out the debounce + network roundtrip.
-  void _onShowQueryChanged(String value) {
-    final trimmed = value.trim();
-    if (trimmed.length < 2) {
-      _showSearchWasActive = false;
-      _showSearchDebounce?.cancel();
-      _showSearchGeneration++;
-      if (_showResults.isNotEmpty || _showIsLoading || _showError != null) {
-        setState(() {
-          _showResults = const <EpgShow>[];
-          _showIsLoading = false;
-          _showError = null;
-        });
-      }
-      return;
-    }
-    if (!_showSearchWasActive) {
-      _searchSessionId++;
-    }
-    _showSearchWasActive = true;
-    _showSearchDebounce?.cancel();
-    // Flip to loading synchronously so the show-results view renders
-    // "Searching shows…" the same frame the qualifying query first
-    // arrives. Without this, the empty view flashes "No shows match
-    // your search" for the 350ms the debounce is waiting before the
-    // network call fires.
-    setState(() {
-      _showIsLoading = true;
-      _showResults = const <EpgShow>[];
-      _showError = null;
-    });
-    _showSearchDebounce = Timer(
-      const Duration(milliseconds: 350),
-      () => _runShowSearch(trimmed),
-    );
-  }
-
-  Future<void> _runShowSearch(String trimmed) async {
-    final search = widget.onSearchShows;
-    if (search == null) return;
-    final generation = ++_showSearchGeneration;
-    setState(() {
-      _showIsLoading = true;
-      _showError = null;
-    });
-    try {
-      final results = await search(trimmed);
-      if (!mounted || generation != _showSearchGeneration) return;
-      setState(() {
-        _showResults = results;
-        _showIsLoading = false;
-      });
-    } on Object catch (error) {
-      if (!mounted || generation != _showSearchGeneration) return;
-      setState(() {
-        _showError = error.toString();
-        _showIsLoading = false;
-      });
-    }
-  }
 
   /// Active when the EPG show search should render in place of (Live TV
   /// tab) or alongside (All tab) the synchronous channel-name filter.
@@ -214,6 +145,13 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     // show-result channel lookups must work even when the show's
     // channel name doesn't match the current query.
     final channelsById = {for (final c in channels) c.id: c};
+    // Computed once per build and threaded through to both the All tab and
+    // the Live TV tab's ShowSearchResultsView - both are built eagerly by
+    // TabBarView on every keystroke, so without sharing this the On-Now/
+    // Upcoming grouping work ran twice per build.
+    final showResult = _showSearchActive
+        ? buildShowResultEntries(_showSearchController.results, channelsById)
+        : null;
 
     return Scaffold(
       body: Column(
@@ -225,7 +163,10 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
               hintText: AppLocalizations.of(context).searchHint,
               onChanged: (value) {
                 setState(() => _query = value);
-                _onShowQueryChanged(value);
+                _showSearchController.onQueryChanged(
+                  value,
+                  widget.onSearchShows,
+                );
               },
             ),
           ),
@@ -247,8 +188,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
                   filteredVodItems,
                   filteredSeries,
                   channelsById,
+                  showResult,
                 ),
-                _buildLiveTvTab(filteredChannels, channelsById),
+                _buildLiveTvTab(filteredChannels, channelsById, showResult),
                 _buildMoviesTab(filteredVodItems),
                 _buildSeriesTab(filteredSeries),
               ],
@@ -264,12 +206,13 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     List<VodItem> vodItems,
     List<Series> seriesList,
     Map<int, Channel> channelsById,
+    ShowResultEntries? showResult,
   ) {
     if (!_hasQuery) return _buildPromptState();
     final languageTag = Localizations.localeOf(context).toLanguageTag();
-    final showResult = buildShowResultEntries(_showResults, channelsById);
-    final onNowEntries = showResult.onNow;
-    final upcomingEntries = showResult.upcoming;
+    final onNowEntries = showResult?.onNow ?? const <ShowResultEntry>[];
+    final upcomingEntries = showResult?.upcoming ?? const <ShowResultEntry>[];
+    final onNowChannels = showResult?.onNowChannels ?? const <Channel>[];
     // Empty-state-guard: a query can match a show name that doesn't match
     // any channel/VOD/series name (e.g. "Bear" matching no channel called
     // "Bear" but airing on some channel). Without this check, the EPG
@@ -298,7 +241,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
               (entry) => ShowResultRow(
                 entry: entry,
                 channel: channelsById[entry.channelId],
-                onNowChannels: showResult.onNowChannels,
+                onNowChannels: onNowChannels,
                 onChannelSelect: widget.onChannelSelect,
                 onChannelContextChanged: widget.onChannelContextChanged,
                 onShowSelect: widget.onShowSelect,
@@ -314,7 +257,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
               (entry) => ShowResultRow(
                 entry: entry,
                 channel: channelsById[entry.channelId],
-                onNowChannels: showResult.onNowChannels,
+                onNowChannels: onNowChannels,
                 onChannelSelect: widget.onChannelSelect,
                 onChannelContextChanged: widget.onChannelContextChanged,
                 onShowSelect: widget.onShowSelect,
@@ -363,6 +306,7 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
   Widget _buildLiveTvTab(
     List<Channel> channels,
     Map<int, Channel> channelsById,
+    ShowResultEntries? showResult,
   ) {
     if (!_hasQuery) return _buildPromptState();
     // When the EPG show search is active, fully replace the channel-tile
@@ -371,9 +315,9 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
     // has nothing else to show once a show search fires.
     if (_showSearchActive) {
       return ShowSearchResultsView(
-        shows: _showResults,
-        isLoading: _showIsLoading,
-        error: _showError,
+        shows: _showSearchController.results,
+        isLoading: _showSearchController.isLoading,
+        error: _showSearchController.error,
         channelsById: channelsById,
         onChannelSelect: widget.onChannelSelect,
         onChannelContextChanged: widget.onChannelContextChanged,
@@ -384,7 +328,8 @@ class _SearchScreenState extends ConsumerState<SearchScreen>
             widget.onSidebarActivate?.call();
           }
         },
-        resetTabsToken: _searchSessionId,
+        resetTabsToken: _showSearchController.searchSessionId,
+        precomputedResult: showResult,
       );
     }
     if (channels.isEmpty) return _buildEmptyState('No results found');

--- a/flutter_client/lib/shared/epg_show_results.dart
+++ b/flutter_client/lib/shared/epg_show_results.dart
@@ -31,6 +31,16 @@ class ShowResultEntry {
   final bool isOnNow;
 }
 
+/// Return shape of [buildShowResultEntries], named so callers can hold onto
+/// a precomputed result (e.g. to share it between two widgets in the same
+/// build instead of recomputing) without repeating the record shape.
+typedef ShowResultEntries = ({
+  List<ShowResultEntry> all,
+  List<ShowResultEntry> onNow,
+  List<ShowResultEntry> upcoming,
+  List<Channel> onNowChannels,
+});
+
 /// Combines the `airingNow` and `recentEpisodes` of each show into a single
 /// deduped list of result rows, partitioned by On Now vs Upcoming and grouped
 /// by (show, channelId) - keeps the same shape LiveTvScreen has rendered
@@ -40,13 +50,7 @@ class ShowResultEntry {
 /// search-filtered channel list - searching for a show name does not filter
 /// channels by name, so the lookup must include every channel a programme
 /// could be airing on.
-({
-  List<ShowResultEntry> all,
-  List<ShowResultEntry> onNow,
-  List<ShowResultEntry> upcoming,
-  List<Channel> onNowChannels,
-})
-buildShowResultEntries(
+ShowResultEntries buildShowResultEntries(
   List<EpgShow> shows,
   Map<int, Channel> channelsById,
 ) {

--- a/flutter_client/lib/shared/epg_show_results.dart
+++ b/flutter_client/lib/shared/epg_show_results.dart
@@ -1,0 +1,289 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+/// Key for grouping EPG show search results. One row per (show, channelId)
+/// pair: two airings of the same show on different channels belong to separate
+/// rows; two airings of the same show on the same channel collapse into one
+/// row whose airing list grows. Keyed on the `EpgShow` instance itself
+/// (identity equality, not `normalizedTitle`) - the server can omit
+/// `normalized_title`, and two distinct shows both falling back to `''` must
+/// not merge into one row.
+typedef ShowResultKey = ({EpgShow show, int channelId});
+
+/// One row in the unified search-results list. On Now rows carry exactly
+/// one episode (the one currently airing); Upcoming rows carry 1+ future
+/// episodes on this show+channel, soonest first.
+class ShowResultEntry {
+  const ShowResultEntry({
+    required this.show,
+    required this.channelId,
+    required this.episodes,
+    required this.isOnNow,
+  });
+
+  final EpgShow show;
+  final int channelId;
+  final List<EpgShowEpisode> episodes;
+  final bool isOnNow;
+}
+
+/// Combines the `airingNow` and `recentEpisodes` of each show into a single
+/// deduped list of result rows, partitioned by On Now vs Upcoming and grouped
+/// by (show, channelId) - keeps the same shape LiveTvScreen has rendered
+/// since #212.
+///
+/// The `channels` lookup must be built from the **full** channel list, not a
+/// search-filtered channel list - searching for a show name does not filter
+/// channels by name, so the lookup must include every channel a programme
+/// could be airing on.
+({
+  List<ShowResultEntry> all,
+  List<ShowResultEntry> onNow,
+  List<ShowResultEntry> upcoming,
+  List<Channel> onNowChannels,
+})
+buildShowResultEntries(
+  List<EpgShow> shows,
+  Map<int, Channel> channelsById,
+) {
+  final now = DateTime.now().toUtc();
+
+  // On Now: one entry per (show, channelId) currently airing. The channel
+  // lookup is built from the **full** channel list, not the
+  // search-filtered list - searching for a show name does not filter
+  // channels by name, so the lookup must include every channel a
+  // programme could be airing on.
+  final onNowKeys = <ShowResultKey>{};
+  final onNowEntries = <ShowResultEntry>[];
+  final onNowChannelIds = <int>{};
+  final onNowChannels = <Channel>[];
+  for (final show in shows) {
+    for (final episode in show.airingNow) {
+      final channel = channelsById[episode.channelId];
+      if (channel == null) continue;
+      final key = (show: show, channelId: episode.channelId);
+      if (!onNowKeys.add(key)) continue;
+      onNowEntries.add(
+        ShowResultEntry(
+          show: show,
+          channelId: episode.channelId,
+          episodes: [episode],
+          isOnNow: true,
+        ),
+      );
+      if (onNowChannelIds.add(channel.id)) onNowChannels.add(channel);
+    }
+  }
+
+  // Upcoming: future airings grouped by (show, channelId) - a single show
+  // repeating on one network used to render a wall of identical rows (40
+  // future airings of "Grace and Frankie" on one channel produced 12
+  // identical rows); grouping collapses duplicates into one row that
+  // shows up to 3 airing times plus a "+N more" affordance pointing at
+  // the show detail screen, which already lists every airing. Skips any
+  // (show, channelId) already covered by On Now.
+  final groups = <ShowResultKey, List<EpgShowEpisode>>{};
+  for (final show in shows) {
+    for (final episode in show.recentEpisodes) {
+      if (episode.displayTitle.isEmpty) continue;
+      if (!episode.startTime.isAfter(now)) continue;
+      final key = (show: show, channelId: episode.channelId);
+      if (onNowKeys.contains(key)) continue;
+      groups.putIfAbsent(key, () => <EpgShowEpisode>[]).add(episode);
+    }
+  }
+  final upcomingEntries =
+      groups.entries.map((entry) {
+        final episodes = entry.value
+          ..sort((a, b) => a.startTime.compareTo(b.startTime));
+        return ShowResultEntry(
+          show: entry.key.show,
+          channelId: entry.key.channelId,
+          episodes: episodes,
+          isOnNow: false,
+        );
+      }).toList()..sort(
+        (a, b) => a.episodes.first.startTime.compareTo(
+          b.episodes.first.startTime,
+        ),
+      );
+
+  return (
+    all: [...onNowEntries, ...upcomingEntries],
+    onNow: onNowEntries,
+    upcoming: upcomingEntries,
+    onNowChannels: onNowChannels,
+  );
+}
+
+/// Single row style shared by On Now and Upcoming results so the merged
+/// "All" tab reads as one consistent list rather than mixed layouts. On
+/// Now rows tap straight to the channel (skip-previous/next then stays
+/// within the On Now channel set); Upcoming rows open the show detail
+/// screen, which has the recording actions.
+class ShowResultRow extends StatelessWidget {
+  const ShowResultRow({
+    super.key,
+    required this.entry,
+    required this.channel,
+    required this.onNowChannels,
+    required this.onChannelSelect,
+    this.onChannelContextChanged,
+    this.onShowSelect,
+    required this.languageTag,
+    this.autofocus = false,
+  });
+
+  final ShowResultEntry entry;
+  final Channel? channel;
+  final List<Channel> onNowChannels;
+  final void Function(Channel) onChannelSelect;
+  final void Function(List<Channel>)? onChannelContextChanged;
+  final void Function(EpgShow)? onShowSelect;
+  final String languageTag;
+  final bool autofocus;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final l10n = AppLocalizations.of(context);
+    final firstEpisode = entry.episodes.first;
+    final channelName = firstEpisode.channelName;
+    final String? subtitle;
+    final String trailingText;
+    if (entry.isOnNow) {
+      subtitle = _formatOnNowSubtitle(firstEpisode, channelName);
+      trailingText = l10n.liveTvAiringUntil(
+        DateFormat.jm(languageTag).format(firstEpisode.endTime.toLocal()),
+      );
+    } else {
+      subtitle = channelName;
+      final times = <String>[];
+      for (final episode in entry.episodes.take(3)) {
+        times.add(_formatUpcomingTime(episode.startTime, languageTag, l10n));
+      }
+      final remainder = entry.episodes.length - times.length;
+      if (remainder > 0) {
+        times.add(l10n.liveTvMoreAirings(remainder));
+      }
+      trailingText = times.join(' · ');
+    }
+
+    // Capture a non-nullable local so the tap closure can call
+    // onChannelSelect without a flow-analysis-into-closure issue. On Now
+    // rows whose channel wasn't in the channel list stay non-focusable
+    // (DpadInkWell with `onTap: null` is disabled) - preserves the
+    // pre-extraction behavior from live_tv_screen.dart exactly.
+    final onNowChannel = channel;
+    final onTap = entry.isOnNow
+        ? (onNowChannel == null
+              ? null
+              : () {
+                  onChannelContextChanged?.call(onNowChannels);
+                  onChannelSelect(onNowChannel);
+                })
+        : () => onShowSelect?.call(entry.show);
+
+    return DpadInkWell(
+      autofocus: autofocus,
+      borderRadius: BorderRadius.circular(8),
+      color: colorScheme.surfaceContainerHigh,
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.all(MediaBrowsingMetrics.contentPadding),
+        child: Row(
+          children: [
+            ResilientMediaImage(
+              imageUrl: channel?.logoUrl,
+              fallbackIcon: Icons.tv,
+              width: MediaBrowsingMetrics.logoSize,
+              height: MediaBrowsingMetrics.logoSize,
+              fit: BoxFit.contain,
+              backgroundColor: Colors.transparent,
+            ),
+            const SizedBox(width: MediaBrowsingMetrics.itemGap),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    entry.show.displayTitle,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (subtitle != null && subtitle.isNotEmpty) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(width: MediaBrowsingMetrics.itemGap),
+            Flexible(
+              child: Text(
+                trailingText,
+                textAlign: TextAlign.end,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                  color: colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// R6: episode name first (the higher-value token), channel second. Both
+/// are optional and either may be absent.
+///
+/// Deliberately allowed to ellipsise. Round 4 moved the airing time out
+/// of the subtitle line precisely so a long value here costs nothing
+/// important - the time now lives in the trailing time text and is
+/// immune, and channel identity is carried redundantly by the station
+/// logo. Do NOT re-add the time here.
+///
+/// Returns null (not empty string) when both are absent - empty string
+/// would render a phantom 11px row in the result row.
+String? _formatOnNowSubtitle(EpgShowEpisode episode, String? channelName) {
+  final ep = episode.subtitle;
+  final hasEp = ep != null && ep.trim().isNotEmpty;
+  final hasCh = channelName != null && channelName.trim().isNotEmpty;
+  if (hasEp && hasCh) return '$ep · $channelName';
+  if (hasEp) return ep;
+  if (hasCh) return channelName;
+  return null;
+}
+
+String _formatUpcomingTime(
+  DateTime startTime,
+  String languageTag,
+  AppLocalizations l10n,
+) {
+  final local = startTime.toLocal();
+  final now = DateTime.now();
+  final tomorrow = DateTime(now.year, now.month, now.day + 1);
+  bool sameDay(DateTime a, DateTime b) =>
+      a.year == b.year && a.month == b.month && a.day == b.day;
+  final time = DateFormat.jm(languageTag).format(local);
+  if (sameDay(local, now)) return time;
+  if (sameDay(local, tomorrow)) return l10n.liveTvAiringTomorrow(time);
+  return DateFormat.MMMd(languageTag).add_jm().format(local);
+}

--- a/flutter_client/lib/shared/epg_show_search_controller.dart
+++ b/flutter_client/lib/shared/epg_show_search_controller.dart
@@ -1,0 +1,99 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+/// Debounced EPG show-search state machine shared by `LiveTvScreen` and
+/// `SearchScreen`. Owns the 350ms debounce and the generation counter that
+/// guards against an out-of-order network response clobbering a later
+/// query's result, plus the "just became active" edge used to bump
+/// [searchSessionId] (consumed by `ShowSearchResultsView` to reset its tab
+/// index back to "All") only on the transition into search mode - not on
+/// every keystroke of an already-active query, which would otherwise bounce
+/// the user off a deliberately-chosen On Now/Upcoming tab mid-typing.
+class EpgShowSearchController extends ChangeNotifier {
+  Timer? _debounce;
+  int _generation = 0;
+  bool _wasActive = false;
+  bool _disposed = false;
+
+  List<EpgShow> results = const <EpgShow>[];
+  bool isLoading = false;
+  String? error;
+  int searchSessionId = 0;
+
+  /// Call on every keystroke of the search field, passing the host's
+  /// current `onSearchShows` callback (may be null to hide the affordance
+  /// entirely).
+  void onQueryChanged(
+    String value,
+    Future<List<EpgShow>> Function(String)? search,
+  ) {
+    final trimmed = value.trim();
+    if (trimmed.length < 2) {
+      _wasActive = false;
+      _debounce?.cancel();
+      _generation++;
+      if (results.isNotEmpty || isLoading || error != null) {
+        results = const <EpgShow>[];
+        isLoading = false;
+        error = null;
+        notifyListeners();
+      }
+      return;
+    }
+    if (!_wasActive) {
+      searchSessionId++;
+    }
+    _wasActive = true;
+    _debounce?.cancel();
+    // Flip to loading synchronously so the results view renders "Searching
+    // shows..." the same frame the qualifying query first arrives. Without
+    // this, the empty view flashes "No shows match your search" for the
+    // 350ms the debounce is waiting before the network call fires.
+    isLoading = true;
+    results = const <EpgShow>[];
+    error = null;
+    notifyListeners();
+    _debounce = Timer(
+      const Duration(milliseconds: 350),
+      () => _runSearch(trimmed, search),
+    );
+  }
+
+  Future<void> _runSearch(
+    String trimmed,
+    Future<List<EpgShow>> Function(String)? search,
+  ) async {
+    if (search == null) {
+      if (isLoading) {
+        isLoading = false;
+        notifyListeners();
+      }
+      return;
+    }
+    final generation = ++_generation;
+    isLoading = true;
+    error = null;
+    notifyListeners();
+    try {
+      final searchResults = await search(trimmed);
+      if (_disposed || generation != _generation) return;
+      results = searchResults;
+      isLoading = false;
+      notifyListeners();
+    } on Object catch (e) {
+      if (_disposed || generation != _generation) return;
+      error = e.toString();
+      isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _debounce?.cancel();
+    super.dispose();
+  }
+}

--- a/flutter_client/lib/shared/show_search_results_view.dart
+++ b/flutter_client/lib/shared/show_search_results_view.dart
@@ -1,0 +1,166 @@
+import 'package:dpad/dpad.dart';
+import 'package:flutter/material.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/dpad_tab_bar.dart';
+import 'package:m3u_tv/shared/epg_show_results.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+/// Renders the All / On Now / Upcoming sub-tab view used by both
+/// LiveTvScreen and SearchScreen when a qualifying EPG show search is
+/// active. Owns its own `TabController` so callers don't need a second
+/// `TickerProvider` slot, and emits a dedicated `DpadRegion` per tab so
+/// focus memory doesn't collide between screens (each screen passes a
+/// distinct `memoryKeyPrefix`).
+class ShowSearchResultsView extends StatefulWidget {
+  const ShowSearchResultsView({
+    super.key,
+    required this.shows,
+    required this.isLoading,
+    this.error,
+    required this.channelsById,
+    required this.onChannelSelect,
+    this.onChannelContextChanged,
+    this.onShowSelect,
+    required this.memoryKeyPrefix,
+    this.onEdge,
+    this.resetTabsToken,
+  });
+
+  final List<EpgShow> shows;
+  final bool isLoading;
+  final String? error;
+  final Map<int, Channel> channelsById;
+  final void Function(Channel) onChannelSelect;
+  final void Function(List<Channel>)? onChannelContextChanged;
+  final void Function(EpgShow)? onShowSelect;
+
+  /// Prefix for each tab's `DpadRegion` memoryKey (e.g. `live-tv/search-results`
+  /// or `search/live-tv/search-results`) - must be distinct per screen so
+  /// D-pad focus memory doesn't collide between LiveTvScreen and SearchScreen.
+  final String memoryKeyPrefix;
+  final void Function(TraversalDirection)? onEdge;
+
+  /// Bump this (e.g. a counter) when a *new* search starts (not on every
+  /// keystroke of an already-active one) to reset the internal tab index
+  /// back to "All". Mirrors `live_tv_screen.dart:404-407`'s
+  /// `_searchResultsTabController.index = 0` side effect, which becomes
+  /// unreachable from the parent once the TabController moves in here.
+  final Object? resetTabsToken;
+
+  @override
+  State<ShowSearchResultsView> createState() => _ShowSearchResultsViewState();
+}
+
+class _ShowSearchResultsViewState extends State<ShowSearchResultsView>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void didUpdateWidget(covariant ShowSearchResultsView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.resetTabsToken != oldWidget.resetTabsToken) {
+      _tabController.index = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+    final languageTag = Localizations.localeOf(context).toLanguageTag();
+    final result = buildShowResultEntries(widget.shows, widget.channelsById);
+    return Column(
+      children: [
+        DpadTabBar(
+          controller: _tabController,
+          tabs: [
+            l10n.liveTvSearchFilterAll,
+            l10n.liveTvOnNow,
+            l10n.liveTvUpcomingAirings,
+          ],
+        ),
+        Expanded(
+          child: DpadTabBarView(
+            controller: _tabController,
+            children: [
+              _buildResultsList(
+                result.all,
+                result.onNowChannels,
+                languageTag,
+                'all',
+              ),
+              _buildResultsList(
+                result.onNow,
+                result.onNowChannels,
+                languageTag,
+                'on-now',
+              ),
+              _buildResultsList(
+                result.upcoming,
+                result.onNowChannels,
+                languageTag,
+                'upcoming',
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildResultsList(
+    List<ShowResultEntry> entries,
+    List<Channel> onNowChannels,
+    String languageTag,
+    String tabKey,
+  ) {
+    if (entries.isEmpty) {
+      // Preserve the R2.1 loading UX: when the user types a qualifying
+      // query and the search is still in flight, show the loading label
+      // instead of the no-matches label, so the latter doesn't flash
+      // before the request resolves.
+      final l10n = AppLocalizations.of(context);
+      final emptyText = widget.isLoading
+          ? l10n.liveTvShowResultsLoading
+          : widget.error != null
+          ? l10n.showsSearchError
+          : l10n.showsNoResults;
+      return Center(
+        child: Text(emptyText, style: Theme.of(context).textTheme.bodyLarge),
+      );
+    }
+    return DpadRegion(
+      memoryKey: '${widget.memoryKeyPrefix}/$tabKey',
+      horizontalEdge: DpadEdgeBehavior.stop,
+      onEdge: widget.onEdge,
+      child: ScrollbarListView(
+        itemCount: entries.length,
+        itemBuilder: (context, index) => Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: ShowResultRow(
+            entry: entries[index],
+            channel: widget.channelsById[entries[index].channelId],
+            onNowChannels: onNowChannels,
+            onChannelSelect: widget.onChannelSelect,
+            onChannelContextChanged: widget.onChannelContextChanged,
+            onShowSelect: widget.onShowSelect,
+            languageTag: languageTag,
+            autofocus: index == 0,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/shared/show_search_results_view.dart
+++ b/flutter_client/lib/shared/show_search_results_view.dart
@@ -25,6 +25,7 @@ class ShowSearchResultsView extends StatefulWidget {
     required this.memoryKeyPrefix,
     this.onEdge,
     this.resetTabsToken,
+    this.precomputedResult,
   });
 
   final List<EpgShow> shows;
@@ -47,6 +48,12 @@ class ShowSearchResultsView extends StatefulWidget {
   /// `_searchResultsTabController.index = 0` side effect, which becomes
   /// unreachable from the parent once the TabController moves in here.
   final Object? resetTabsToken;
+
+  /// Skips the internal `buildShowResultEntries` call when the caller has
+  /// already computed it this build (e.g. `SearchScreen`'s All tab needs the
+  /// same result) - avoids doing the On-Now/Upcoming grouping work twice per
+  /// keystroke.
+  final ShowResultEntries? precomputedResult;
 
   @override
   State<ShowSearchResultsView> createState() => _ShowSearchResultsViewState();
@@ -80,7 +87,9 @@ class _ShowSearchResultsViewState extends State<ShowSearchResultsView>
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
     final languageTag = Localizations.localeOf(context).toLanguageTag();
-    final result = buildShowResultEntries(widget.shows, widget.channelsById);
+    final result =
+        widget.precomputedResult ??
+        buildShowResultEntries(widget.shows, widget.channelsById);
     return Column(
       children: [
         DpadTabBar(

--- a/flutter_client/test/ui/features/search_screen_test.dart
+++ b/flutter_client/test/ui/features/search_screen_test.dart
@@ -321,6 +321,339 @@ void main() {
         findsOneWidget,
       );
     });
+
+    // --- EPG show search wiring (#227) ---
+
+    group('EPG show search', () {
+      // Now/future-relative fixtures: `airingNow` must be within [start,
+      // end]; `recentEpisodes` for the Upcoming row must be in the future.
+      final now = DateTime.now();
+      final pastStart = now.subtract(const Duration(minutes: 5));
+      final pastEnd = now.add(const Duration(minutes: 30));
+      final futureStart = now.add(const Duration(hours: 1));
+      final futureEnd = futureStart.add(const Duration(minutes: 30));
+
+      final onNowShow = EpgShow(
+        normalizedTitle: 'nightly-report',
+        displayTitle: 'Nightly Report',
+        channelCount: 1,
+        channels: const [],
+        episodeCount: 1,
+        recentEpisodes: const [],
+        airingNow: [
+          EpgShowEpisode(
+            channelId: 1,
+            channelName: 'BBC News',
+            title: 'Nightly Report Episode',
+            startTime: pastStart,
+            endTime: pastEnd,
+          ),
+        ],
+      );
+      final upcomingShow = EpgShow(
+        normalizedTitle: 'bear',
+        displayTitle: 'Bear',
+        channelCount: 1,
+        channels: const [],
+        episodeCount: 1,
+        recentEpisodes: [
+          EpgShowEpisode(
+            channelId: 2,
+            channelName: 'CNN International',
+            title: 'Bear Episode',
+            startTime: futureStart,
+            endTime: futureEnd,
+          ),
+        ],
+      );
+      final showResults = [onNowShow, upcomingShow];
+
+      Future<List<EpgShow>> Function(String) staticShows(
+        List<EpgShow> results,
+      ) {
+        return (query) async => results;
+      }
+
+      testWidgets(
+        'Live TV tab replaces channel list with On Now/Upcoming sub-tabs on '
+        'qualifying query',
+        (tester) async {
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              onSearchShows: staticShows(showResults),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'be');
+          // Cross the 350ms debounce + the future async resolution.
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          // On the Live TV tab, the channel-name-filter list is gone,
+          // replaced by the All/On Now/Upcoming sub-tab view.
+          await tester.tap(
+            find.descendant(
+              of: find.byType(DpadTabBar),
+              matching: find.text('Live TV'),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // The outer SearchScreen DpadTabBar still has its 4 tabs
+          // (All / Live TV / Movies / Series); ShowSearchResultsView
+          // contributes a nested DpadTabBar for the sub-tabs.
+          expect(find.byType(DpadTabBar), findsNWidgets(2));
+          expect(find.text('All'), findsWidgets);
+          expect(find.text('On Now'), findsOneWidget);
+          expect(find.text('Upcoming'), findsOneWidget);
+          // The channel-tile list is gone (ShowSearchResultsView replaced
+          // it). ScrollbarListView is the new view's scroll container;
+          // the old Live TV tab used a plain ListView.builder.
+          expect(find.byType(ScrollbarListView), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Live TV tab renders EPG sub-tabs even when no channel name matches '
+        'the query (regression guard for channel-list-source bug)',
+        (tester) async {
+          // Query "bear" matches no channel name (BBC News, CNN), no VOD
+          // (Matrix…), no series (Breaking Bad…). Only the EPG show
+          // "Bear" matches. Without the full-channels lookup, this test
+          // would silently render the empty-state.
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              onSearchShows: (query) async {
+                return query == 'bear' ? showResults : const [];
+              },
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'bear');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          await tester.tap(
+            find.descendant(
+              of: find.byType(DpadTabBar),
+              matching: find.text('Live TV'),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // ShowSearchResultsView's nested DpadTabBar must be present.
+          expect(find.text('On Now'), findsOneWidget);
+          expect(find.text('Upcoming'), findsOneWidget);
+          // The "Bear" show still appears in the upcoming results.
+          expect(find.text('Bear'), findsOneWidget);
+          // Empty-state must NOT be shown.
+          expect(find.text('No results found'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'All tab renders On Now + Upcoming sections above the Live TV '
+        'channel-match section for a qualifying query',
+        (tester) async {
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              onSearchShows: staticShows(showResults),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'be');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          // We're on All by default.
+          expect(find.text('Nightly Report'), findsOneWidget);
+          expect(find.text('Bear'), findsOneWidget);
+          // Channel-name matches still appear below the EPG sections.
+          expect(find.text('BBC News'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'All tab renders EPG sections when query matches no '
+        'channel/VOD/series name but matches a show (regression guard '
+        'for empty-state-guard bug)',
+        (tester) async {
+          // Query "bear" matches only the EPG show "Bear"; no channel
+          // name, VOD name, or series name contains "bear". Without the
+          // empty-state-guard fix, the EPG sections would be hidden by
+          // the "all empty -> show empty state" early-return.
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              onSearchShows: (query) async {
+                return query == 'bear' ? showResults : const [];
+              },
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'bear');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          expect(find.text('Bear'), findsOneWidget);
+          // Empty-state must NOT be shown.
+          expect(find.text('No results found'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'tapping an On Now row calls onChannelContextChanged then '
+        'onChannelSelect with the right channel',
+        (tester) async {
+          List<Channel>? reportedContext;
+          Channel? selectedChannel;
+
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              onSearchShows: staticShows(showResults),
+              onChannelSelect: (channel) => selectedChannel = channel,
+              onChannelContextChanged: (channels) => reportedContext = channels,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'be');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Nightly Report'));
+          await tester.pumpAndSettle();
+
+          expect(reportedContext, isNotNull);
+          expect(reportedContext!.map((c) => c.id), [1]);
+          expect(selectedChannel?.id, 1);
+        },
+      );
+
+      testWidgets(
+        'tapping an Upcoming row calls onShowSelect with the parent show',
+        (tester) async {
+          EpgShow? selectedShow;
+
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              onSearchShows: staticShows(showResults),
+              onShowSelect: (show) => selectedShow = show,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'be');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Bear'));
+          await tester.pumpAndSettle();
+
+          expect(selectedShow, isNotNull);
+          expect(selectedShow!.normalizedTitle, 'bear');
+        },
+      );
+
+      testWidgets(
+        'null onSearchShows keeps the channel-name results; no EPG '
+        'sections/sub-tabs anywhere',
+        (tester) async {
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              // No onSearchShows callback - the screen should behave
+              // exactly like pre-#227.
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(find.byType(TextField), 'bbc');
+          await tester.pumpAndSettle();
+
+          // Only one DpadTabBar (the screen's outer one) - no nested
+          // sub-tabs from ShowSearchResultsView.
+          expect(find.byType(DpadTabBar), findsOneWidget);
+          // No EPG section headers rendered.
+          expect(find.text('On Now'), findsNothing);
+          expect(find.text('Upcoming'), findsNothing);
+          // Channel-name filter still works.
+          expect(find.text('BBC News'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'Movies and Series tabs are unaffected by EPG show search wiring',
+        (tester) async {
+          await tester.pumpWidget(
+            _TestApp(
+              channels: testChannels,
+              vodItems: testVodItems,
+              seriesList: testSeriesList,
+              onSearchShows: staticShows(showResults),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Movies tab: a query matching VOD items only.
+          await tester.enterText(find.byType(TextField), 'matrix');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          await tester.tap(
+            find.descendant(
+              of: find.byType(DpadTabBar),
+              matching: find.text('Movies'),
+            ),
+          );
+          await tester.pumpAndSettle();
+          // The Movies tab still shows the VOD matches; the EPG show
+          // search results are scoped to All/Live TV only.
+          expect(find.text('The Matrix'), findsOneWidget);
+          expect(find.text('Nightly Report'), findsNothing);
+          expect(find.text('Bear'), findsNothing);
+
+          // Series tab: a different query matching series.
+          await tester.enterText(find.byType(TextField), 'bad');
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pumpAndSettle();
+
+          await tester.tap(
+            find.descendant(
+              of: find.byType(DpadTabBar),
+              matching: find.text('Series'),
+            ),
+          );
+          await tester.pumpAndSettle();
+          expect(find.text('Breaking Bad'), findsOneWidget);
+          expect(find.text('Nightly Report'), findsNothing);
+          expect(find.text('Bear'), findsNothing);
+        },
+      );
+    });
   });
 }
 
@@ -334,6 +667,8 @@ class _TestApp extends StatelessWidget {
     this.onChannelContextChanged,
     this.onVodSelect,
     this.onSeriesSelect,
+    this.onSearchShows,
+    this.onShowSelect,
   });
 
   final List<Channel> channels;
@@ -344,6 +679,8 @@ class _TestApp extends StatelessWidget {
   final void Function(List<Channel>)? onChannelContextChanged;
   final void Function(VodItem)? onVodSelect;
   final void Function(Series)? onSeriesSelect;
+  final Future<List<EpgShow>> Function(String)? onSearchShows;
+  final void Function(EpgShow)? onShowSelect;
 
   @override
   Widget build(BuildContext context) {
@@ -363,6 +700,8 @@ class _TestApp extends StatelessWidget {
           onChannelContextChanged: onChannelContextChanged,
           onVodSelect: onVodSelect ?? (_) {},
           onSeriesSelect: onSeriesSelect ?? (_) {},
+          onSearchShows: onSearchShows,
+          onShowSelect: onShowSelect,
         ),
       ),
     );


### PR DESCRIPTION
Closes #227.

## Problem

The main Search screen's Live TV tab (and All tab) only matched channel names — searching a programme title there returned nothing under Live TV, while the same query on the dedicated Live TV screen already returns On Now, Upcoming results (#211/#212). The more discoverable screen was the weaker one.

## What this does

This is an extraction, not a reimplementation — the On Now/Upcoming logic has already produced several separately-diagnosed bugs (wrong channel-lookup source, wrong `displayTitle`, a `RenderFlex` overflow) across #211/#212, and a copy in `SearchScreen` would drift from those fixes.

- **`lib/shared/epg_show_results.dart`** (new): `ShowResultKey`/`ShowResultEntry` and `buildShowResultEntries()`, extracted verbatim from `LiveTvScreen._buildShowResultEntries`; `ShowResultRow`, extracted verbatim from `LiveTvScreen._buildSearchResultRow` (including its "don't re-add time to the subtitle" constraint).
- **`lib/shared/show_search_results_view.dart`** (new): `ShowSearchResultsView`, a self-contained All/On-Now/Upcoming sub-tab widget (owns its own `TabController`/ticker) used identically by `LiveTvScreen` and the new `SearchScreen` wiring. A `resetTabsToken` prop replaces the tab-reset side effect that used to live directly on `LiveTvScreen`'s own `TabController`.
- **`LiveTvScreen`** rewritten to consume both shared pieces in place of its private duplicates. Behavior-preserving by construction: its existing test suite (`live_tv_screen_test.dart`) passes **unmodified**, which was the explicit gate for this step.
- **`SearchScreen`**:
  - **Live TV tab** fully replaces its content with the same sub-tab view `LiveTvScreen` uses, once a qualifying (2+ char) show search is active — mirrors `LiveTvScreen` exactly, since that tab has nothing else to show once a show search fires.
  - **All tab** keeps its existing sectioned list and gains On Now / Upcoming as two more sections above the channel-match section, since it must keep showing VOD/Series matches simultaneously (a full sub-tab replacement there would hide them).
  - `channelsById` is built from the **full** channel list, not the name-filtered one — a show's channel resolves even when the channel name itself doesn't match the query (this is the issue's first cited bug, guarded against directly).
  - The All tab's empty-state guard now also checks for EPG entries, so a query matching no channel/VOD/series name but matching a show still renders results, instead of silently hiding them.

## Explicitly out of scope

- No Movies & Series rail added to `SearchScreen` — it already has dedicated tabs for those.
- `shows_screen.dart`'s own (third, non-identical) copy of a similar debounce pattern is untouched — unifying all three screens' search state machines is a separate effort.
- No server changes.

## Testing

- `dart format --set-exit-if-changed lib test` — clean
- `flutter analyze lib test` — no issues
- `flutter test test/ui/features/live_tv_screen_test.dart` — 50/50, **file unmodified** (the hard gate for the extraction step)
- `flutter test test/ui/features/search_screen_test.dart` — 20/20 (12 pre-existing + 8 new, covering the sub-tab swap, the channel-list-source regression guard, the All-tab empty-state-guard regression guard, tap dispatching in both tabs, the unwired-screen no-op case, and Movies/Series being unaffected)
- `flutter test test/ui/live_tv/` — 5/5
- `flutter test test/ui/` — 402 passed, 7 skipped, 0 failed