### PR TITLE
fix(linux): keep native video plane transparent

### DIFF
--- a/flutter_client/lib/playback/native_video_surface.dart
+++ b/flutter_client/lib/playback/native_video_surface.dart
@@ -41,12 +41,10 @@ class NativeVideoSurface extends StatelessWidget {
   Widget build(BuildContext context) {
     final plane = nativePlane;
     if (plane != null && plane.usesNativePlane) {
-      return _wrap(
-        Center(
-          child: AspectRatio(
-            aspectRatio: aspectRatio,
-            child: _NativePlaneReporter(plane: plane),
-          ),
+      return Center(
+        child: AspectRatio(
+          aspectRatio: aspectRatio,
+          child: _NativePlaneReporter(plane: plane),
         ),
       );
     }

--- a/flutter_client/linux/my_application.cc
+++ b/flutter_client/linux/my_application.cc
@@ -94,12 +94,12 @@ static void my_application_activate(GApplication* application) {
   // Must run before the window is realized (gtk_widget_show below): GTK
   // visuals can only be set on an unrealized widget.
   enable_video_plane_transparency(window, view);
-  gtk_widget_show(GTK_WIDGET(window));
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
   desktop_libmpv_backend_register(FL_PLUGIN_REGISTRY(view));
+  gtk_widget_show(GTK_WIDGET(window));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }

--- a/flutter_client/test/playback/native_video_surface_test.dart
+++ b/flutter_client/test/playback/native_video_surface_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:m3u_tv/playback/native_video_surface.dart';
+import 'package:m3u_tv/playback/player_adapter.dart';
+
+void main() {
+  testWidgets('active native plane does not paint an opaque black background', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_surface(nativePlane: _ActiveNativePlane()));
+
+    expect(_blackBackgrounds(), findsNothing);
+  });
+
+  testWidgets('texture path retains its opaque black background', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_surface(textureId: 7));
+
+    expect(find.byType(Texture), findsOneWidget);
+    expect(_blackBackgrounds(), findsOneWidget);
+  });
+}
+
+Widget _surface({int? textureId, NativePlaneProvider? nativePlane}) {
+  return MediaQuery(
+    data: const MediaQueryData(),
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: NativeVideoSurface(
+        textureId: textureId,
+        platformView: null,
+        nativePlane: nativePlane,
+        aspectRatio: 16 / 9,
+      ),
+    ),
+  );
+}
+
+Finder _blackBackgrounds() {
+  return find.descendant(
+    of: find.byType(NativeVideoSurface),
+    matching: find.byWidgetPredicate(
+      (widget) => widget is ColoredBox && widget.color == Colors.black,
+    ),
+  );
+}
+
+class _ActiveNativePlane implements NativePlaneProvider {
+  @override
+  bool get usesNativePlane => true;
+
+  @override
+  void reportVideoRect(
+    double x,
+    double y,
+    double width,
+    double height,
+    double devicePixelRatio,
+  ) {}
+}

--- a/flutter_client/test/release/linux_wayland_transparency_contract_test.dart
+++ b/flutter_client/test/release/linux_wayland_transparency_contract_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'Linux attaches the transparent Flutter view before window realization',
+    () {
+      final source = File('linux/my_application.cc').readAsStringSync();
+
+      int statementIndex(String statement) {
+        expect(statement.allMatches(source), hasLength(1), reason: statement);
+        return source.indexOf(statement);
+      }
+
+      final enableTransparency = statementIndex(
+        'enable_video_plane_transparency(window, view);',
+      );
+      final showView = statementIndex(
+        'gtk_widget_show(GTK_WIDGET(view));',
+      );
+      final attachView = statementIndex(
+        'gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));',
+      );
+      final registerFlutterPlugins = statementIndex(
+        'fl_register_plugins(FL_PLUGIN_REGISTRY(view));',
+      );
+      final registerMpvBackend = statementIndex(
+        'desktop_libmpv_backend_register(FL_PLUGIN_REGISTRY(view));',
+      );
+      final showWindow = statementIndex(
+        'gtk_widget_show(GTK_WIDGET(window));',
+      );
+
+      expect(enableTransparency, lessThan(showWindow));
+      expect(showView, lessThan(attachView));
+      expect(
+        attachView,
+        lessThan(showWindow),
+        reason:
+            'The transparent Flutter view must be attached before the '
+            'toplevel window is shown and realized.',
+      );
+      expect(registerFlutterPlugins, lessThan(showWindow));
+      expect(registerMpvBackend, lessThan(showWindow));
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- keep the Linux Wayland native mpv plane transparent in Flutter
- retain the existing black background for texture-based playback
- add a focused regression test for both composition paths

## Root cause

The Linux native plane is stacked below Flutter's compositor and only becomes visible where Flutter paints transparency. `NativeVideoSurface` wrapped the active native-plane reporter in its default opaque black `ColoredBox`, so mpv could render successfully while the player stayed black.

## Verification

- focused regression test against base `8073ada`: native-plane assertion fails while the texture assertion passes
- focused regression test against this candidate: 2 passed
- `dart format --output=show --set-exit-if-changed lib/playback/native_video_surface.dart test/playback/native_video_surface_test.dart`: passed, 0 changed
- `flutter analyze lib test`: no issues found
- `flutter test --concurrency=1`: 1017 passed, 7 skipped
- `./android/gradlew -p android :app:testDebugUnitTest`: BUILD SUCCESSFUL with the tracked CI Firebase stub created temporarily and removed
- `flutter build linux --release`: passed with Flutter 3.44.8
- Linux bundle contract and `ldd`: required files present, no `not found`
- `git diff --check`: passed

## Manual acceptance

A real Linux Wayland playback session was not available in the build environment. Manual Wayland playback acceptance remains required before release promotion.

Closes #242

## Manual Wayland remediation

The first candidate at `6b452d5` passed CI and static review but failed real CachyOS GNOME Wayland acceptance: audio played while the video remained black. Remediation round 1/1 is now included at `40ba49d`.

The remediation preserves the existing native-plane Flutter transparency fix and additionally attaches/registers the transparent `FlView` before showing and realizing the GTK toplevel, matching Flutter's Linux initialization order. A focused Linux source-contract test freezes this ordering.

The PR remains Draft until `40ba49d` passes manual playback on CachyOS GNOME Wayland. Shutdown-only `FlutterEngineRemoveView` and messenger warnings are out of scope.
