### PR TITLE
fix(linux): expose Wayland native video planes

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -146,6 +146,8 @@ class AppShellState extends ConsumerState<AppShell>
 
   PlayerArgs? _playerArgs;
   PlaybackOrchestrator? _playerOrchestrator;
+  StreamSubscription<bool>? _playerNativePlaneSub;
+  bool _playerNativePlaneActive = false;
   bool _playerHasFailed = false;
   // True while any root-navigator modal dialog opened from within the
   // player is on screen (track selector, stop/delete-recording confirm),
@@ -329,6 +331,7 @@ class AppShellState extends ConsumerState<AppShell>
     _desktopNotificationDispatcher.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _playerOrchestrator?.dispose().ignore();
+    _playerNativePlaneSub?.cancel().ignore();
     for (final node in _sidebarFocusNodes) {
       node.dispose();
     }
@@ -539,7 +542,15 @@ class AppShellState extends ConsumerState<AppShell>
     setState(() {
       _playerArgs = args;
       _playerOrchestrator = newOrch;
+      _playerNativePlaneActive = newOrch.isNativePlaneActive;
       _playerHasFailed = false;
+    });
+    _playerNativePlaneSub = newOrch.onNativePlaneCompositionChanged.listen((
+      active,
+    ) {
+      if (!mounted || !identical(_playerOrchestrator, newOrch)) return;
+      if (_playerNativePlaneActive == active) return;
+      setState(() => _playerNativePlaneActive = active);
     });
   }
 
@@ -555,6 +566,7 @@ class AppShellState extends ConsumerState<AppShell>
   Future<void> _closePlayer() async {
     ref.read(playerOverlayActiveProvider.notifier).state = false;
     final orch = _playerOrchestrator;
+    final nativePlaneSub = _playerNativePlaneSub;
     final savedFocus = _focusBeforePlayer;
     _focusBeforePlayer = null;
     unawaited(_systemUiPolicy.applyBrowsing());
@@ -574,10 +586,13 @@ class AppShellState extends ConsumerState<AppShell>
       // Fall through and close anyway -- better to leak a not-fully-disposed
       // adapter than leave the user stuck on a dead player screen.
     }
+    nativePlaneSub?.cancel().ignore();
     if (!mounted) return;
     setState(() {
       _playerArgs = null;
       _playerOrchestrator = null;
+      _playerNativePlaneSub = null;
+      _playerNativePlaneActive = false;
       _playerHasFailed = false;
       _playerModalDialogVisible = false;
     });
@@ -1340,7 +1355,16 @@ class AppShellState extends ConsumerState<AppShell>
       key: _toastKey,
       child: Stack(
         children: [
-          backAwareShell,
+          IgnorePointer(
+            ignoring: _playerNativePlaneActive,
+            child: ExcludeSemantics(
+              excluding: _playerNativePlaneActive,
+              child: Opacity(
+                opacity: _playerNativePlaneActive ? 0 : 1,
+                child: backAwareShell,
+              ),
+            ),
+          ),
           Positioned.fill(
             child:
                 widget.playerRouteBuilder?.call(args) ??

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1350,17 +1350,19 @@ class AppShellState extends ConsumerState<AppShell>
 
     final viewerId = _appState.activeViewer?.ulid ?? '';
     final recordingChannelIds = ref.watch(recordingChannelIdsProvider);
+    final suppressBrowsingComposition =
+        _playerNativePlaneActive && !_playerHasFailed;
 
     return NotificationToastOverlay(
       key: _toastKey,
       child: Stack(
         children: [
           IgnorePointer(
-            ignoring: _playerNativePlaneActive,
+            ignoring: suppressBrowsingComposition,
             child: ExcludeSemantics(
-              excluding: _playerNativePlaneActive,
+              excluding: suppressBrowsingComposition,
               child: Opacity(
-                opacity: _playerNativePlaneActive ? 0 : 1,
+                opacity: suppressBrowsingComposition ? 0 : 1,
                 child: backAwareShell,
               ),
             ),
@@ -1512,7 +1514,7 @@ class AppShellState extends ConsumerState<AppShell>
                   },
                   traktService: _appState.traktService,
                   onPlaybackFailure: () {
-                    _playerHasFailed = true;
+                    setState(() => _playerHasFailed = true);
                     unawaited(_systemUiPolicy.applyBrowsing());
                   },
                   onClose: _closePlayer,

--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -531,6 +531,7 @@ class AppShellState extends ConsumerState<AppShell>
       setState(() {
         _playerArgs = args;
         _playerHasFailed = false;
+        _playerNativePlaneActive = _playerOrchestrator!.isNativePlaneActive;
       });
       return;
     }
@@ -1514,6 +1515,7 @@ class AppShellState extends ConsumerState<AppShell>
                   },
                   traktService: _appState.traktService,
                   onPlaybackFailure: () {
+                    if (!mounted) return;
                     setState(() => _playerHasFailed = true);
                     unawaited(_systemUiPolicy.applyBrowsing());
                   },

--- a/flutter_client/lib/features/multiview/multiview_screen.dart
+++ b/flutter_client/lib/features/multiview/multiview_screen.dart
@@ -531,7 +531,8 @@ class _MultiviewScreenState extends ConsumerState<MultiviewScreen> {
     final state = tile.state;
     final isFocused = _focusedIndex == index;
     final isReordering = _reorderingIndex == index;
-    final nativePlaneActive = _nativePlaneFor(tile)?.usesNativePlane ?? false;
+    final nativePlaneActive =
+        !tile.hasError && (_nativePlaneFor(tile)?.usesNativePlane ?? false);
     return DpadFocusable(
       focusNode: tile.focusNode,
       autofocus: index == 0,
@@ -576,7 +577,7 @@ class _MultiviewScreenState extends ConsumerState<MultiviewScreen> {
                 nativePlane: _nativePlaneFor(tile),
                 aspectRatio: state?.videoAspectRatio ?? 16 / 9,
                 wrapInBlackBackground: false,
-                clearAncestorPaintForNativePlane: true,
+                clearAncestorPaintForNativePlane: nativePlaneActive,
               ),
               if (tile.hasError)
                 Center(

--- a/flutter_client/lib/features/multiview/multiview_screen.dart
+++ b/flutter_client/lib/features/multiview/multiview_screen.dart
@@ -531,6 +531,7 @@ class _MultiviewScreenState extends ConsumerState<MultiviewScreen> {
     final state = tile.state;
     final isFocused = _focusedIndex == index;
     final isReordering = _reorderingIndex == index;
+    final nativePlaneActive = _nativePlaneFor(tile)?.usesNativePlane ?? false;
     return DpadFocusable(
       focusNode: tile.focusNode,
       autofocus: index == 0,
@@ -557,7 +558,7 @@ class _MultiviewScreenState extends ConsumerState<MultiviewScreen> {
       child: ClipRRect(
         borderRadius: const BorderRadius.all(Radius.circular(8)),
         child: ColoredBox(
-          color: Colors.black,
+          color: nativePlaneActive ? Colors.transparent : Colors.black,
           child: Stack(
             fit: StackFit.expand,
             children: [
@@ -575,6 +576,7 @@ class _MultiviewScreenState extends ConsumerState<MultiviewScreen> {
                 nativePlane: _nativePlaneFor(tile),
                 aspectRatio: state?.videoAspectRatio ?? 16 / 9,
                 wrapInBlackBackground: false,
+                clearAncestorPaintForNativePlane: true,
               ),
               if (tile.hasError)
                 Center(

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -193,6 +193,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
   bool get _isLive => widget.args.type == 'live';
   bool get _canSeek => !_isLive && _duration > Duration.zero;
   bool get _isSeries => widget.args.type == 'series';
+  bool get _isNativePlaneActive => widget.orchestrator.isNativePlaneActive;
 
   String _nowPlayingBadgeLabel(BuildContext context) {
     final l10n = AppLocalizations.of(context);
@@ -1198,7 +1199,9 @@ class _PlayerScreenState extends State<PlayerScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: _isNativePlaneActive && _errorMessage == null
+          ? Colors.transparent
+          : Colors.black,
       body: Shortcuts(
         shortcuts: <LogicalKeySet, Intent>{
           LogicalKeySet(LogicalKeyboardKey.escape): const _BackIntent(),

--- a/flutter_client/lib/features/player/player_screen.dart
+++ b/flutter_client/lib/features/player/player_screen.dart
@@ -184,6 +184,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
 
   StreamSubscription<PlaybackState>? _stateSubscription;
   StreamSubscription<PlaybackError>? _errorSubscription;
+  StreamSubscription<bool>? _nativePlaneSubscription;
 
   bool _disposed = false;
   bool _traktScrobbleActive = false;
@@ -255,6 +256,18 @@ class _PlayerScreenState extends State<PlayerScreen> {
     });
     _stateSubscription = widget.orchestrator.onState.listen(_handleState);
     _errorSubscription = widget.orchestrator.onError.listen(_handleError);
+    // `_isNativePlaneActive` reads the orchestrator directly rather than
+    // caching its value, so nothing otherwise triggers a rebuild when it
+    // flips -- without this, AppShell's own onNativePlaneCompositionChanged
+    // listener (app_shell.dart) could un-suppress the opaque browsing shell
+    // behind this screen before this screen's own backgroundColor toggle
+    // (which only updates via _handleState/_handleError) catches up.
+    _nativePlaneSubscription = widget
+        .orchestrator
+        .onNativePlaneCompositionChanged
+        .listen((_) {
+          if (mounted) setState(() {});
+        });
     _openSource(widget.args);
     _startLoadingTimeout();
     _scheduleOverlayHide();
@@ -764,6 +777,7 @@ class _PlayerScreenState extends State<PlayerScreen> {
     _errorButtonFocusNode.dispose();
     unawaited(_stateSubscription?.cancel());
     unawaited(_errorSubscription?.cancel());
+    unawaited(_nativePlaneSubscription?.cancel());
     unawaited(widget.wakelockController.disable());
     unawaited(widget.orchestrator.stop());
     super.dispose();

--- a/flutter_client/lib/playback/desktop_libmpv_backend.dart
+++ b/flutter_client/lib/playback/desktop_libmpv_backend.dart
@@ -188,7 +188,6 @@ class DesktopLibmpvBackend
 
       _handle = handle;
       _textureId = textureId;
-      _usesNativePlane = usesNativePlane;
       _lastSequence = -1;
       _errorEmitted = false;
 
@@ -214,6 +213,12 @@ class DesktopLibmpvBackend
       if (!_isActiveLoad(generation)) return;
       _clearLoading(ready);
       if (failure != null) throw failure;
+      // Flipped only once FILE_LOADED is actually confirmed -- setting this
+      // earlier let a buffered pre-load event drained above emit a state
+      // update while the Wayland subsurface had no frame yet, which could
+      // make a listener (e.g. NativeVideoSurface) hole-punch the widget
+      // before there was anything for the native plane to show through.
+      _usesNativePlane = usesNativePlane;
     } on PlaybackException {
       _clearLoading(ready);
       rethrow;

--- a/flutter_client/lib/playback/native_video_surface.dart
+++ b/flutter_client/lib/playback/native_video_surface.dart
@@ -196,7 +196,13 @@ class _NativePlaneReporterState extends State<_NativePlaneReporter> {
 
   void _reportRect(Duration _) {
     if (!mounted) return;
-    if (_routeAnimation?.status != AnimationStatus.completed) {
+    // A null route animation means there's no enclosing ModalRoute to gate
+    // on (e.g. this surface isn't hosted inside a pushed route) -- report
+    // the real rect rather than treating "no route" the same as "route
+    // mid-transition", which would otherwise hide the plane permanently.
+    final routeAnimation = _routeAnimation;
+    if (routeAnimation != null &&
+        routeAnimation.status != AnimationStatus.completed) {
       _reportHiddenRect();
       return;
     }

--- a/flutter_client/lib/playback/native_video_surface.dart
+++ b/flutter_client/lib/playback/native_video_surface.dart
@@ -158,10 +158,10 @@ class _NativePlaneHolePainter extends CustomPainter {
   bool shouldRepaint(_NativePlaneHolePainter oldDelegate) => false;
 }
 
-/// Reports this widget's on-screen rect to [plane] on every layout, and
-/// paints fully transparent -- the actual video is a native surface (e.g. a
-/// Wayland `wl_subsurface`) stacked outside Flutter's own compositor, which
-/// only shows through where Flutter itself paints nothing.
+/// Reports this widget's on-screen rect to [plane], and paints fully
+/// transparent -- the actual video is a native surface (e.g. a Wayland
+/// `wl_subsurface`) stacked outside Flutter's own compositor, which only
+/// shows through where Flutter itself paints nothing.
 class _NativePlaneReporter extends StatefulWidget {
   const _NativePlaneReporter({required this.plane});
 
@@ -173,9 +173,33 @@ class _NativePlaneReporter extends StatefulWidget {
 
 class _NativePlaneReporterState extends State<_NativePlaneReporter> {
   final GlobalKey _key = GlobalKey();
+  Animation<double>? _routeAnimation;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final routeAnimation = ModalRoute.of(context)?.animation;
+    if (_routeAnimation == routeAnimation) return;
+    _routeAnimation?.removeStatusListener(_handleRouteStatusChanged);
+    _routeAnimation = routeAnimation;
+    _routeAnimation?.addStatusListener(_handleRouteStatusChanged);
+  }
+
+  void _handleRouteStatusChanged(AnimationStatus status) {
+    if (!mounted) return;
+    if (status != AnimationStatus.completed) {
+      _reportHiddenRect();
+      return;
+    }
+    WidgetsBinding.instance.addPostFrameCallback(_reportRect);
+  }
 
   void _reportRect(Duration _) {
     if (!mounted) return;
+    if (_routeAnimation?.status != AnimationStatus.completed) {
+      _reportHiddenRect();
+      return;
+    }
     final renderObject = _key.currentContext?.findRenderObject();
     if (renderObject is! RenderBox || !renderObject.hasSize) return;
     final topLeft = renderObject.localToGlobal(Offset.zero);
@@ -190,6 +214,11 @@ class _NativePlaneReporterState extends State<_NativePlaneReporter> {
     );
   }
 
+  void _reportHiddenRect() {
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+    widget.plane.reportVideoRect(0, 0, 0, 0, devicePixelRatio);
+  }
+
   @override
   Widget build(BuildContext context) {
     WidgetsBinding.instance.addPostFrameCallback(_reportRect);
@@ -197,5 +226,11 @@ class _NativePlaneReporterState extends State<_NativePlaneReporter> {
       key: _key,
       child: const ColoredBox(color: Colors.transparent),
     );
+  }
+
+  @override
+  void dispose() {
+    _routeAnimation?.removeStatusListener(_handleRouteStatusChanged);
+    super.dispose();
   }
 }

--- a/flutter_client/lib/playback/native_video_surface.dart
+++ b/flutter_client/lib/playback/native_video_surface.dart
@@ -24,6 +24,7 @@ class NativeVideoSurface extends StatelessWidget {
     required this.aspectRatio,
     this.nativePlane,
     this.wrapInBlackBackground = true,
+    this.clearAncestorPaintForNativePlane = false,
   });
 
   final int? textureId;
@@ -37,15 +38,26 @@ class NativeVideoSurface extends StatelessWidget {
   /// `false` to avoid an extra, redundant paint layer.
   final bool wrapInBlackBackground;
 
+  /// Clears Flutter paint already present behind an active native plane.
+  /// Multiview needs this because its below-parent planes sit inside an
+  /// otherwise opaque browsing route; full-screen playback instead makes
+  /// those ancestors transparent directly.
+  final bool clearAncestorPaintForNativePlane;
+
   @override
   Widget build(BuildContext context) {
     final plane = nativePlane;
     if (plane != null && plane.usesNativePlane) {
-      return _wrap(
-        Center(
-          child: AspectRatio(
-            aspectRatio: aspectRatio,
-            child: _NativePlaneReporter(plane: plane),
+      return Center(
+        child: AspectRatio(
+          aspectRatio: aspectRatio,
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              if (clearAncestorPaintForNativePlane)
+                const CustomPaint(painter: _NativePlaneHolePainter()),
+              _NativePlaneReporter(plane: plane),
+            ],
           ),
         ),
       );
@@ -129,6 +141,21 @@ class NativeVideoSurface extends StatelessWidget {
       },
     );
   }
+}
+
+class _NativePlaneHolePainter extends CustomPainter {
+  const _NativePlaneHolePainter();
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawRect(
+      Offset.zero & size,
+      Paint()..blendMode = BlendMode.clear,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_NativePlaneHolePainter oldDelegate) => false;
 }
 
 /// Reports this widget's on-screen rect to [plane] on every layout, and

--- a/flutter_client/lib/playback/playback_orchestrator.dart
+++ b/flutter_client/lib/playback/playback_orchestrator.dart
@@ -57,6 +57,8 @@ class PlaybackOrchestrator {
       StreamController<PlaybackState>.broadcast();
   final StreamController<PlaybackError> _errorController =
       StreamController<PlaybackError>.broadcast();
+  final StreamController<bool> _nativePlaneController =
+      StreamController<bool>.broadcast();
   final List<String> _diagnostics = <String>[];
   final List<StreamSubscription<Object?>> _subscriptions =
       <StreamSubscription<Object?>>[];
@@ -72,10 +74,19 @@ class PlaybackOrchestrator {
   int _playbackGeneration = 0;
   bool _recovering = false;
   bool _disposed = false;
+  bool _nativePlaneActive = false;
 
   Stream<PlaybackState> get onState => _stateController.stream;
   Stream<PlaybackError> get onError => _errorController.stream;
+  Stream<bool> get onNativePlaneCompositionChanged =>
+      _nativePlaneController.stream;
   PlaybackBackend? get activeBackend => _activeBackend;
+  bool get isNativePlaneActive {
+    final adapter = _activeAdapter;
+    return adapter is NativePlaneProvider &&
+        (adapter! as NativePlaneProvider).usesNativePlane;
+  }
+
   int? get activeTextureId {
     final adapter = _activeAdapter;
     if (adapter is! VideoTextureProvider) return null;
@@ -121,6 +132,7 @@ class PlaybackOrchestrator {
     _activeAdapter = null;
     _activeBackend = null;
     _activeSource = null;
+    _syncNativePlaneComposition();
 
     PlaybackException? lastRecoverableFailure;
     PlaybackBackend? previousBackend;
@@ -190,6 +202,7 @@ class PlaybackOrchestrator {
     }
     await _stateController.close();
     await _errorController.close();
+    await _nativePlaneController.close();
   }
 
   Iterable<PlaybackBackend> _nativeBackends() sync* {
@@ -215,6 +228,7 @@ class PlaybackOrchestrator {
     _activeAdapter = adapter;
     _activeBackend = backend;
     _activeSource = source;
+    _syncNativePlaneComposition();
     if (adapter is PlatformViewProvider) {
       // A PlatformView-backed adapter's native side can't finish load()
       // until Flutter actually creates its platform view and the native
@@ -237,6 +251,7 @@ class PlaybackOrchestrator {
     while (true) {
       try {
         await adapter.load(source);
+        _syncNativePlaneComposition();
         break;
       } on PlaybackException catch (error) {
         final isStreamUnavailable =
@@ -267,6 +282,7 @@ class PlaybackOrchestrator {
           _activeAdapter = null;
           _activeBackend = null;
           _activeSource = null;
+          _syncNativePlaneComposition();
         }
         if (adapter is PlatformViewProvider) {
           // This adapter's platform view is about to be unmounted (the
@@ -318,6 +334,7 @@ class PlaybackOrchestrator {
         _activeAdapter = null;
         _activeBackend = null;
         _activeSource = null;
+        _syncNativePlaneComposition();
       }
       if (adapter is PlatformViewProvider) {
         // Same use-after-free reasoning as the PlaybackException branch
@@ -468,6 +485,7 @@ class PlaybackOrchestrator {
     _activeAdapter = adapter;
     _activeBackend = PlaybackBackend.serverTranscode;
     _activeSource = transcodedSource;
+    _syncNativePlaneComposition();
     try {
       await adapter.load(transcodedSource);
       if (!_isCurrentGeneration(generation)) {
@@ -481,6 +499,7 @@ class PlaybackOrchestrator {
           _activeAdapter = null;
           _activeBackend = null;
           _activeSource = null;
+          _syncNativePlaneComposition();
         }
         await adapter.stop();
         if (identical(_activeBroadcast, broadcast) && broadcast != null) {
@@ -500,6 +519,7 @@ class PlaybackOrchestrator {
         _activeAdapter = null;
         _activeBackend = null;
         _activeSource = null;
+        _syncNativePlaneComposition();
       }
       await _cleanupSessions();
       _emitError(PlaybackError.fromException(error));
@@ -558,6 +578,7 @@ class PlaybackOrchestrator {
     _activeAdapter = null;
     _activeBackend = null;
     _activeSource = null;
+    _syncNativePlaneComposition();
     await adapter.stop();
   }
 
@@ -605,6 +626,7 @@ class PlaybackOrchestrator {
 
   void _handleAdapterState(PlaybackState state) {
     if (_disposed) return;
+    _syncNativePlaneComposition();
     _stateController.add(state);
     if (state.status == PlaybackStatus.buffering &&
         state.backend == _activeBackend) {
@@ -706,6 +728,15 @@ class PlaybackOrchestrator {
   void _cancelBufferingTimer() {
     _bufferingTimer?.cancel();
     _bufferingTimer = null;
+  }
+
+  void _syncNativePlaneComposition() {
+    final active = isNativePlaneActive;
+    if (_nativePlaneActive == active) return;
+    _nativePlaneActive = active;
+    if (!_disposed && !_nativePlaneController.isClosed) {
+      _nativePlaneController.add(active);
+    }
   }
 
   PlayerAdapter _requireActiveAdapter() {

--- a/flutter_client/lib/playback/playback_orchestrator.dart
+++ b/flutter_client/lib/playback/playback_orchestrator.dart
@@ -129,10 +129,7 @@ class PlaybackOrchestrator {
     if (!_isCurrentGeneration(generation)) return;
     await _cleanupSessions();
     if (!_isCurrentGeneration(generation)) return;
-    _activeAdapter = null;
-    _activeBackend = null;
-    _activeSource = null;
-    _syncNativePlaneComposition();
+    _clearActiveAdapter();
 
     PlaybackException? lastRecoverableFailure;
     PlaybackBackend? previousBackend;
@@ -225,10 +222,7 @@ class PlaybackOrchestrator {
     final adapter = _adapters[backend];
     if (adapter == null) return null;
     _bind(adapter);
-    _activeAdapter = adapter;
-    _activeBackend = backend;
-    _activeSource = source;
-    _syncNativePlaneComposition();
+    _setActiveAdapter(adapter, backend, source);
     if (adapter is PlatformViewProvider) {
       // A PlatformView-backed adapter's native side can't finish load()
       // until Flutter actually creates its platform view and the native
@@ -279,10 +273,7 @@ class PlaybackOrchestrator {
         if (identical(_activeAdapter, adapter) &&
             _activeBackend == backend &&
             identical(_activeSource, source)) {
-          _activeAdapter = null;
-          _activeBackend = null;
-          _activeSource = null;
-          _syncNativePlaneComposition();
+          _clearActiveAdapter();
         }
         if (adapter is PlatformViewProvider) {
           // This adapter's platform view is about to be unmounted (the
@@ -331,10 +322,7 @@ class PlaybackOrchestrator {
       if (identical(_activeAdapter, adapter) &&
           _activeBackend == backend &&
           identical(_activeSource, source)) {
-        _activeAdapter = null;
-        _activeBackend = null;
-        _activeSource = null;
-        _syncNativePlaneComposition();
+        _clearActiveAdapter();
       }
       if (adapter is PlatformViewProvider) {
         // Same use-after-free reasoning as the PlaybackException branch
@@ -482,10 +470,11 @@ class PlaybackOrchestrator {
     );
 
     _bind(adapter);
-    _activeAdapter = adapter;
-    _activeBackend = PlaybackBackend.serverTranscode;
-    _activeSource = transcodedSource;
-    _syncNativePlaneComposition();
+    _setActiveAdapter(
+      adapter,
+      PlaybackBackend.serverTranscode,
+      transcodedSource,
+    );
     try {
       await adapter.load(transcodedSource);
       if (!_isCurrentGeneration(generation)) {
@@ -496,10 +485,7 @@ class PlaybackOrchestrator {
         if (identical(_activeAdapter, adapter) &&
             _activeBackend == PlaybackBackend.serverTranscode &&
             identical(_activeSource, transcodedSource)) {
-          _activeAdapter = null;
-          _activeBackend = null;
-          _activeSource = null;
-          _syncNativePlaneComposition();
+          _clearActiveAdapter();
         }
         await adapter.stop();
         if (identical(_activeBroadcast, broadcast) && broadcast != null) {
@@ -516,10 +502,7 @@ class PlaybackOrchestrator {
       if (identical(_activeAdapter, adapter) &&
           _activeBackend == PlaybackBackend.serverTranscode &&
           identical(_activeSource, transcodedSource)) {
-        _activeAdapter = null;
-        _activeBackend = null;
-        _activeSource = null;
-        _syncNativePlaneComposition();
+        _clearActiveAdapter();
       }
       await _cleanupSessions();
       _emitError(PlaybackError.fromException(error));
@@ -575,10 +558,7 @@ class PlaybackOrchestrator {
     _cancelBufferingTimer();
     final adapter = _activeAdapter;
     if (adapter == null) return;
-    _activeAdapter = null;
-    _activeBackend = null;
-    _activeSource = null;
-    _syncNativePlaneComposition();
+    _clearActiveAdapter();
     await adapter.stop();
   }
 
@@ -728,6 +708,28 @@ class PlaybackOrchestrator {
   void _cancelBufferingTimer() {
     _bufferingTimer?.cancel();
     _bufferingTimer = null;
+  }
+
+  // Every assignment to _activeAdapter/_activeBackend/_activeSource must be
+  // followed by _syncNativePlaneComposition() -- funneling the trio through
+  // these two setters means a future call site can't set the fields and
+  // forget the sync.
+  void _setActiveAdapter(
+    PlayerAdapter adapter,
+    PlaybackBackend backend,
+    PlaybackSource source,
+  ) {
+    _activeAdapter = adapter;
+    _activeBackend = backend;
+    _activeSource = source;
+    _syncNativePlaneComposition();
+  }
+
+  void _clearActiveAdapter() {
+    _activeAdapter = null;
+    _activeBackend = null;
+    _activeSource = null;
+    _syncNativePlaneComposition();
   }
 
   void _syncNativePlaneComposition() {

--- a/flutter_client/test/features/multiview/multiview_native_plane_test.dart
+++ b/flutter_client/test/features/multiview/multiview_native_plane_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -152,5 +153,12 @@ void main() {
       await tester.pump();
     },
     variant: TargetPlatformVariant.only(TargetPlatform.linux),
+    // `buildMultiviewTilePlayer` picks Linux's DesktopLibmpvBackend vs.
+    // macOS's MacMpvNativeBackend by checking the real `Platform.isMacOS`,
+    // not this test's TargetPlatformVariant override -- so on a macOS host
+    // this always resolves to MacMpvNativeBackend (not a NativePlaneProvider)
+    // and the native-plane assertions below can never pass. CI's flutter
+    // test job runs on ubuntu-latest, where this exercises the real path.
+    skip: !Platform.isLinux,
   );
 }

--- a/flutter_client/test/features/multiview/multiview_native_plane_test.dart
+++ b/flutter_client/test/features/multiview/multiview_native_plane_test.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/features/multiview/multiview_screen.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/playback/native_video_surface.dart';
+import 'package:m3u_tv/providers/app_providers.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'active Linux native-plane tile punches through instead of painting black',
+    (tester) async {
+      const methodChannel = MethodChannel('m3u_tv/desktop_libmpv');
+      const eventChannel = EventChannel('m3u_tv/desktop_libmpv/events');
+      final eventListenerReady = Completer<void>();
+      final events = StreamController<Map<String, Object?>>.broadcast(
+        onListen: eventListenerReady.complete,
+      );
+      addTearDown(() async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(methodChannel, null);
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockStreamHandler(eventChannel, null);
+        await events.close();
+      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockStreamHandler(
+            eventChannel,
+            MockStreamHandler.inline(
+              onListen: (arguments, eventSink) {
+                events.stream.listen(eventSink.success);
+              },
+            ),
+          );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(methodChannel, (call) async {
+            if (call.method == 'load') {
+              await eventListenerReady.future;
+              scheduleMicrotask(() {
+                events.add(<String, Object?>{
+                  'schemaVersion': 1,
+                  'handle': 1,
+                  'sequence': 0,
+                  'kind': 'FILE_LOADED',
+                });
+              });
+              return <String, Object?>{
+                'ok': true,
+                'handle': 1,
+                'usesNativePlane': true,
+              };
+            }
+            return null;
+          });
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            multiviewChannelsProvider.overrideWith(
+              (_) => const <Channel>[
+                Channel(
+                  id: 1,
+                  name: 'Native Plane Channel',
+                  streamUrl: 'https://example.com/live.m3u8',
+                ),
+              ],
+            ),
+          ],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MultiviewScreen(),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+      await tester.pump();
+
+      final surface = find.byType(NativeVideoSurface);
+      expect(surface, findsOneWidget);
+      expect(
+        tester.widget<NativeVideoSurface>(surface).nativePlane?.usesNativePlane,
+        isTrue,
+      );
+      expect(
+        tester
+            .widgetList<ColoredBox>(
+              find.ancestor(of: surface, matching: find.byType(ColoredBox)),
+            )
+            .where((box) => box.color == Colors.black),
+        isEmpty,
+      );
+      expect(
+        find.descendant(of: surface, matching: find.byType(CustomPaint)),
+        findsOneWidget,
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.linux),
+  );
+}

--- a/flutter_client/test/features/multiview/multiview_native_plane_test.dart
+++ b/flutter_client/test/features/multiview/multiview_native_plane_test.dart
@@ -14,7 +14,7 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'active Linux native-plane tile punches through instead of painting black',
+    'Linux native-plane tile clears while healthy and paints black on error',
     (tester) async {
       const methodChannel = MethodChannel('m3u_tv/desktop_libmpv');
       const eventChannel = EventChannel('m3u_tv/desktop_libmpv/events');
@@ -89,17 +89,63 @@ void main() {
         tester.widget<NativeVideoSurface>(surface).nativePlane?.usesNativePlane,
         isTrue,
       );
+      final clippedTile = find
+          .ancestor(
+            of: surface,
+            matching: find.byType(ClipRRect),
+          )
+          .first;
+
+      List<RecordedInvocation> recordedTilePaint() {
+        final canvas = TestRecordingCanvas();
+        final context = TestRecordingPaintingContext(canvas);
+        tester.renderObject<RenderBox>(clippedTile).paint(context, Offset.zero);
+        context.dispose();
+        return canvas.invocations;
+      }
+
+      bool paintsWithBlendMode(
+        List<RecordedInvocation> invocations,
+        BlendMode blendMode,
+      ) {
+        return invocations.any(
+          (record) =>
+              record.invocation.memberName == #drawRect &&
+              (record.invocation.positionalArguments[1] as Paint).blendMode ==
+                  blendMode,
+        );
+      }
+
+      final healthyPaint = recordedTilePaint();
       expect(
-        tester
-            .widgetList<ColoredBox>(
-              find.ancestor(of: surface, matching: find.byType(ColoredBox)),
-            )
-            .where((box) => box.color == Colors.black),
-        isEmpty,
+        healthyPaint.any(
+          (record) => record.invocation.memberName == #clipRRect,
+        ),
+        isTrue,
       );
+      expect(paintsWithBlendMode(healthyPaint, BlendMode.clear), isTrue);
+
+      events.add(<String, Object?>{
+        'schemaVersion': 1,
+        'handle': 1,
+        'sequence': 1,
+        'kind': 'ERROR',
+        'message': 'Playback failed',
+        'code': 'playback_failed',
+      });
+      await tester.pump();
+
+      expect(find.text("Couldn't play - select to retry"), findsOneWidget);
+      final errorPaint = recordedTilePaint();
+      expect(paintsWithBlendMode(errorPaint, BlendMode.clear), isFalse);
       expect(
-        find.descendant(of: surface, matching: find.byType(CustomPaint)),
-        findsOneWidget,
+        errorPaint.any(
+          (record) =>
+              record.invocation.memberName == #drawRect &&
+              (record.invocation.positionalArguments[1] as Paint).color ==
+                  Colors.black,
+        ),
+        isTrue,
       );
 
       await tester.pumpWidget(const SizedBox.shrink());

--- a/flutter_client/test/playback/native_video_surface_test.dart
+++ b/flutter_client/test/playback/native_video_surface_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/playback/native_video_surface.dart';
@@ -64,6 +66,80 @@ void main() {
       isNotEmpty,
     );
   });
+
+  testWidgets('native plane hides while its route is transitioning', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    final stablePlane = _RecordingNativePlane();
+    final transitioningPlane = _RecordingNativePlane();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        home: NativeVideoSurface(
+          textureId: null,
+          platformView: null,
+          nativePlane: stablePlane,
+          aspectRatio: 16 / 9,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(stablePlane.rects, isNotEmpty);
+    expect(stablePlane.rects.last.isVisible, isTrue);
+
+    unawaited(
+      navigatorKey.currentState!.push(
+        PageRouteBuilder<void>(
+          transitionDuration: const Duration(seconds: 1),
+          reverseTransitionDuration: const Duration(seconds: 1),
+          pageBuilder: (_, _, _) => NativeVideoSurface(
+            textureId: null,
+            platformView: null,
+            nativePlane: transitioningPlane,
+            aspectRatio: 16 / 9,
+          ),
+          transitionsBuilder: (_, animation, _, child) {
+            return SlideTransition(
+              position: Tween<Offset>(
+                begin: const Offset(1, 0),
+                end: Offset.zero,
+              ).animate(animation),
+              child: child,
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(transitioningPlane.rects, isNotEmpty);
+    expect(transitioningPlane.rects.last.isVisible, isFalse);
+
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+
+    final completedRect = transitioningPlane.rects.last;
+    expect(completedRect.isVisible, isTrue);
+    expect(completedRect.x, greaterThanOrEqualTo(0));
+    expect(completedRect.y, greaterThanOrEqualTo(0));
+    expect(
+      completedRect.x + completedRect.width,
+      lessThanOrEqualTo(tester.view.physicalSize.width),
+    );
+    expect(
+      completedRect.y + completedRect.height,
+      lessThanOrEqualTo(tester.view.physicalSize.height),
+    );
+
+    navigatorKey.currentState!.pop();
+
+    expect(transitioningPlane.rects.last.isVisible, isFalse);
+  });
 }
 
 class _FakeNativePlane implements NativePlaneProvider {
@@ -80,4 +156,33 @@ class _FakeNativePlane implements NativePlaneProvider {
     double height,
     double devicePixelRatio,
   ) {}
+}
+
+class _RecordingNativePlane implements NativePlaneProvider {
+  final rects = <_ReportedRect>[];
+
+  @override
+  bool get usesNativePlane => true;
+
+  @override
+  void reportVideoRect(
+    double x,
+    double y,
+    double width,
+    double height,
+    double devicePixelRatio,
+  ) {
+    rects.add(_ReportedRect(x, y, width, height));
+  }
+}
+
+class _ReportedRect {
+  const _ReportedRect(this.x, this.y, this.width, this.height);
+
+  final double x;
+  final double y;
+  final double width;
+  final double height;
+
+  bool get isVisible => width > 0 && height > 0;
 }

--- a/flutter_client/test/playback/native_video_surface_test.dart
+++ b/flutter_client/test/playback/native_video_surface_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/playback/native_video_surface.dart';
+import 'package:m3u_tv/playback/player_adapter.dart';
+
+void main() {
+  testWidgets('active native plane has no black surface wrapper', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: NativeVideoSurface(
+          textureId: null,
+          platformView: null,
+          nativePlane: _FakeNativePlane(usesNativePlane: true),
+          aspectRatio: 16 / 9,
+        ),
+      ),
+    );
+
+    final blackBoxes = tester
+        .widgetList<ColoredBox>(find.byType(ColoredBox))
+        .where((box) => box.color == Colors.black);
+    expect(blackBoxes, isEmpty);
+  });
+
+  testWidgets('texture surface retains its black backing', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: NativeVideoSurface(
+          textureId: 42,
+          platformView: null,
+          aspectRatio: 16 / 9,
+        ),
+      ),
+    );
+
+    expect(
+      tester
+          .widgetList<ColoredBox>(find.byType(ColoredBox))
+          .where((box) => box.color == Colors.black),
+      isNotEmpty,
+    );
+  });
+
+  testWidgets('inactive native provider retains startup black backing', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: NativeVideoSurface(
+          textureId: null,
+          platformView: null,
+          nativePlane: _FakeNativePlane(usesNativePlane: false),
+          aspectRatio: 16 / 9,
+        ),
+      ),
+    );
+
+    expect(
+      tester
+          .widgetList<ColoredBox>(find.byType(ColoredBox))
+          .where((box) => box.color == Colors.black),
+      isNotEmpty,
+    );
+  });
+}
+
+class _FakeNativePlane implements NativePlaneProvider {
+  const _FakeNativePlane({required this.usesNativePlane});
+
+  @override
+  final bool usesNativePlane;
+
+  @override
+  void reportVideoRect(
+    double x,
+    double y,
+    double width,
+    double height,
+    double devicePixelRatio,
+  ) {}
+}

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -486,6 +486,72 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
   });
 
+  testWidgets(
+    'active native plane suppresses browsing paint and restores it on release and close',
+    (tester) async {
+      final adapter = _NavigationPlayerAdapter();
+      final appState = _testAppState(xtreamService: _NavigationXtreamService());
+      addTearDown(appState.dispose);
+      await appState.connectXtream(
+        const UserCredentials(
+          server: 'http://example.com',
+          username: 'user',
+          password: 'pass',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _TestApp(
+          deviceType: DeviceType.tv,
+          appState: appState,
+          useProductionPlayer: true,
+          playbackOrchestratorBuilder: () => _testPlaybackOrchestrator(adapter),
+        ),
+      );
+      await _pumpAppFrame(tester);
+      await tester.tap(find.text('Route News').last);
+      await _pumpAppFrame(tester);
+
+      bool browsingPaintSuppressed() => tester
+          .widgetList<Opacity>(
+            find.ancestor(
+              of: find.byType(NavigationSidebar),
+              matching: find.byType(Opacity),
+            ),
+          )
+          .any((opacity) => opacity.opacity == 0);
+
+      expect(browsingPaintSuppressed(), isFalse);
+
+      adapter.setUsesNativePlane(value: true);
+      await tester.pump();
+
+      expect(browsingPaintSuppressed(), isTrue);
+
+      adapter.setUsesNativePlane(value: false);
+      await tester.pump();
+
+      expect(browsingPaintSuppressed(), isFalse);
+
+      adapter.setUsesNativePlane(value: true);
+      await tester.pump();
+      expect(browsingPaintSuppressed(), isTrue);
+
+      expect(
+        await tester
+            .state<_TestAppState>(find.byType(_TestApp))
+            .dispatchRouterBack(),
+        isTrue,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PlayerScreen), findsNothing);
+      expect(find.byType(NavigationSidebar), findsOneWidget);
+      expect(browsingPaintSuppressed(), isFalse);
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
   testWidgets('player open and Android back apply route system UI policies', (
     tester,
   ) async {
@@ -2003,7 +2069,7 @@ PlaybackOrchestrator _testPlaybackOrchestrator([
   );
 }
 
-class _NavigationPlayerAdapter implements PlayerAdapter {
+class _NavigationPlayerAdapter implements PlayerAdapter, NativePlaneProvider {
   _NavigationPlayerAdapter({
     this.audioTracks = const <PlaybackTrack>[],
   });
@@ -2016,6 +2082,10 @@ class _NavigationPlayerAdapter implements PlayerAdapter {
 
   int loadCallCount = 0;
   int disposeCallCount = 0;
+  bool _usesNativePlane = false;
+
+  @override
+  bool get usesNativePlane => _usesNativePlane;
 
   @override
   PlaybackCapabilities get capabilities => PlaybackCapabilities.desktopLibmpv;
@@ -2041,6 +2111,25 @@ class _NavigationPlayerAdapter implements PlayerAdapter {
   }
 
   void emitError(PlaybackError error) => _errorController.add(error);
+
+  void setUsesNativePlane({required bool value}) {
+    _usesNativePlane = value;
+    _stateController.add(
+      const PlaybackState(
+        backend: PlaybackBackend.desktopLibmpv,
+        status: PlaybackStatus.playing,
+      ),
+    );
+  }
+
+  @override
+  void reportVideoRect(
+    double x,
+    double y,
+    double width,
+    double height,
+    double devicePixelRatio,
+  ) {}
 
   @override
   Future<void> play() async {}

--- a/flutter_client/test/ui/navigation/navigation_test.dart
+++ b/flutter_client/test/ui/navigation/navigation_test.dart
@@ -552,6 +552,82 @@ void main() {
     },
   );
 
+  testWidgets(
+    'native-plane playback failure restores browsing composition',
+    (tester) async {
+      final adapter = _NavigationPlayerAdapter();
+      final appState = _testAppState(xtreamService: _NavigationXtreamService());
+      addTearDown(appState.dispose);
+      await appState.connectXtream(
+        const UserCredentials(
+          server: 'http://example.com',
+          username: 'user',
+          password: 'pass',
+        ),
+      );
+
+      await tester.pumpWidget(
+        _TestApp(
+          deviceType: DeviceType.tv,
+          appState: appState,
+          useProductionPlayer: true,
+          playbackOrchestratorBuilder: () => _testPlaybackOrchestrator(adapter),
+        ),
+      );
+      await _pumpAppFrame(tester);
+      await tester.tap(find.text('Route News').last);
+      await _pumpAppFrame(tester);
+
+      final sidebar = find.byType(NavigationSidebar);
+      Iterable<T> browsingAncestors<T extends Widget>() => tester.widgetList<T>(
+        find.ancestor(of: sidebar, matching: find.byType(T)),
+      );
+
+      adapter.setUsesNativePlane(value: true);
+      await tester.pump();
+
+      expect(browsingAncestors<Opacity>().any((w) => w.opacity == 0), isTrue);
+      expect(browsingAncestors<IgnorePointer>().any((w) => w.ignoring), isTrue);
+      expect(
+        browsingAncestors<ExcludeSemantics>().any((w) => w.excluding),
+        isTrue,
+      );
+
+      adapter.emitError(
+        const PlaybackError(
+          backend: PlaybackBackend.desktopLibmpv,
+          message: 'Playback failed',
+          code: 'playback_failed',
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Playback error'), findsOneWidget);
+      expect(browsingAncestors<Opacity>().any((w) => w.opacity == 0), isFalse);
+      expect(
+        browsingAncestors<IgnorePointer>().any((w) => w.ignoring),
+        isFalse,
+      );
+      expect(
+        browsingAncestors<ExcludeSemantics>().any((w) => w.excluding),
+        isFalse,
+      );
+      expect(
+        tester
+            .widget<Scaffold>(
+              find.ancestor(
+                of: find.text('Playback error'),
+                matching: find.byType(Scaffold),
+              ),
+            )
+            .backgroundColor,
+        Colors.black,
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+    },
+  );
+
   testWidgets('player open and Android back apply route system UI policies', (
     tester,
   ) async {

--- a/flutter_client/test/ui/player/fake_player_adapter.dart
+++ b/flutter_client/test/ui/player/fake_player_adapter.dart
@@ -5,10 +5,12 @@ import 'package:m3u_tv/playback/player_adapter.dart';
 
 /// A fake PlayerAdapter for widget tests that records calls and emits
 /// configurable state/error streams.
-class FakePlayerAdapter implements PlayerAdapter, VideoTextureProvider {
+class FakePlayerAdapter
+    implements PlayerAdapter, VideoTextureProvider, NativePlaneProvider {
   FakePlayerAdapter({
     PlaybackCapabilities? capabilities,
     this.textureId,
+    this.usesNativePlane = false,
   }) : capabilities = capabilities ?? PlaybackCapabilities.androidExoPlayer;
 
   @override
@@ -16,6 +18,9 @@ class FakePlayerAdapter implements PlayerAdapter, VideoTextureProvider {
 
   @override
   final int? textureId;
+
+  @override
+  final bool usesNativePlane;
 
   final StreamController<PlaybackState> _stateController =
       StreamController<PlaybackState>.broadcast();
@@ -91,4 +96,13 @@ class FakePlayerAdapter implements PlayerAdapter, VideoTextureProvider {
 
   /// Emit an error for testing.
   void emitError(PlaybackError error) => _errorController.add(error);
+
+  @override
+  void reportVideoRect(
+    double x,
+    double y,
+    double width,
+    double height,
+    double devicePixelRatio,
+  ) {}
 }

--- a/flutter_client/test/ui/player/player_screen_test.dart
+++ b/flutter_client/test/ui/player/player_screen_test.dart
@@ -1193,6 +1193,106 @@ void main() {
 
   group('PlayerScreen', () {
     testWidgets(
+      'active native plane makes the full-screen scaffold transparent but errors stay black',
+      (tester) async {
+        final adapter = FakePlayerAdapter(
+          capabilities: PlaybackCapabilities.desktopLibmpv,
+          usesNativePlane: true,
+        );
+        final orchestrator = PlaybackOrchestrator(
+          platform: PlaybackPlatform.desktop,
+          adapters: <PlaybackBackend, PlayerAdapter>{
+            PlaybackBackend.desktopLibmpv: adapter,
+          },
+          transcodeGateway: FakeTranscodeGateway(),
+        );
+        addTearDown(orchestrator.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: PlayerScreen(
+              args: const PlayerArgs(
+                streamUrl: 'https://example.com/native-plane.m3u8',
+                title: 'Native Plane Fixture',
+                type: 'live',
+              ),
+              orchestrator: orchestrator,
+              epgService: EpgService(clock: () => DateTime.utc(2026)),
+            ),
+          ),
+        );
+        await tester.pump();
+        adapter.emitState(
+          const PlaybackState(
+            backend: PlaybackBackend.desktopLibmpv,
+            status: PlaybackStatus.playing,
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          tester.widget<Scaffold>(find.byType(Scaffold)).backgroundColor,
+          Colors.transparent,
+        );
+
+        adapter.emitError(
+          const PlaybackError(
+            backend: PlaybackBackend.desktopLibmpv,
+            message: 'Native plane failed',
+            code: 'native_plane_failed',
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          tester.widget<Scaffold>(find.byType(Scaffold)).backgroundColor,
+          Colors.black,
+        );
+      },
+    );
+
+    testWidgets('texture player keeps the full-screen scaffold black', (
+      tester,
+    ) async {
+      final adapter = FakePlayerAdapter(
+        capabilities: PlaybackCapabilities.desktopLibmpv,
+        textureId: 42,
+      );
+      final orchestrator = PlaybackOrchestrator(
+        platform: PlaybackPlatform.desktop,
+        adapters: <PlaybackBackend, PlayerAdapter>{
+          PlaybackBackend.desktopLibmpv: adapter,
+        },
+        transcodeGateway: FakeTranscodeGateway(),
+      );
+      addTearDown(orchestrator.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PlayerScreen(
+            args: const PlayerArgs(
+              streamUrl: 'https://example.com/texture.m3u8',
+              title: 'Texture Backing Fixture',
+              type: 'live',
+            ),
+            orchestrator: orchestrator,
+            epgService: EpgService(clock: () => DateTime.utc(2026)),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.widget<Scaffold>(find.byType(Scaffold)).backgroundColor,
+        Colors.black,
+      );
+    });
+
+    testWidgets(
       'hides visible controls when the overlay background is tapped',
       (
         tester,


### PR DESCRIPTION
## Summary

Fix the confirmed Linux Wayland black-screen regression by making the complete Flutter composition above an active native mpv plane transparent.

## Confirmed root cause

A runtime-instrumented build on CachyOS with GNOME Wayland and an AMD Radeon RX 7900 XTX proved that mpv produced colored post-VIDEO_RECONFIG pixels, EGL swaps succeeded, and Mutter acknowledged the Wayland frames while the user still saw black. The below-parent mpv subsurface was hidden by opaque Flutter ancestors in AppShell, PlayerScreen, and Multiview.

## Changes

- publish active native-plane composition state from PlaybackOrchestrator
- suppress browsing-shell paint only while a native plane is active
- make the healthy full-screen player scaffold transparent for native-plane rendering
- keep error, loading, texture, platform-view, and fallback paths black
- create clipped clear holes for active native-plane Multiview tiles
- retain Flutter controls, overlays, focus handling, semantics, geometry reporting, and aspect ratio
- add focused tests for activation, release, fallback, full-screen composition, Multiview, and non-native paths

## Verification

- focused composition suite: 154 passed, 5 skipped
- full serial Flutter suite: 1022 passed, 7 skipped
- dart format: clean
- flutter analyze lib test: no issues
- Android native unit gate: BUILD SUCCESSFUL
- temporary CI Firebase stub removed and verified
- Linux release build: successful
- bundled libmpv.so.2: present
- ldd: no missing dependencies
- git diff --check: clean

## Manual acceptance

CachyOS GNOME Wayland full-screen playback and Multiview remain mandatory before promotion. This PR remains Draft until that real-system test and exact-head review pass.

Fixes #242
Fixes #244

## Follow-up acceptance

Closes #247: hide Linux Wayland native Multiview planes during route transitions so they never render outside the GTK toplevel.
