### PR TITLE
perf: split the content cache into its own file

### DIFF
--- a/flutter_client/lib/main.dart
+++ b/flutter_client/lib/main.dart
@@ -82,7 +82,7 @@ Future<void> _initPushNotifications(AppStateController appState) async {
 
 Future<AppStateController> _buildAppState() async {
   final operatingSystem = Platform.operatingSystem;
-  final store = await _createAppStateStore(operatingSystem);
+  final (store, cacheStore) = await _createAppStateStores(operatingSystem);
   final storage = createProductionStorage(
     operatingSystem: operatingSystem,
     persistentStore: store,
@@ -95,11 +95,16 @@ Future<AppStateController> _buildAppState() async {
   }
   return AppStateController(
     persistentStore: storage.appStateStore,
+    cacheStore: cacheStore,
     secureStorage: storage.credentialStorage,
   );
 }
 
-Future<PersistentJsonStore> _createAppStateStore(
+/// Returns the app-state store and the content-cache store as a pair. The
+/// cache (whole channel/VOD/series catalog) is a sibling `cache.json` so a
+/// small single-key write to `app_state.json` - e.g. the resume tracker every
+/// ~10s during playback - never has to re-serialize the catalog.
+Future<(PersistentJsonStore, PersistentJsonStore)> _createAppStateStores(
   String operatingSystem,
 ) async {
   if (operatingSystem == 'tvos') {
@@ -117,13 +122,22 @@ Future<PersistentJsonStore> _createAppStateStore(
     // before any image widget builds, lets the manager use a writable
     // directory instead.
     MediaImageCacheManager.tvosCacheDirectory = dir;
-    return PersistentJsonStore(file: File('${dir.path}/app_state.json'));
+    return (
+      PersistentJsonStore(file: File('${dir.path}/app_state.json')),
+      PersistentJsonStore(file: File('${dir.path}/cache.json')),
+    );
   }
   if (operatingSystem == 'android' || operatingSystem == 'ios') {
     final dir = await getApplicationDocumentsDirectory();
-    return PersistentJsonStore(file: File('${dir.path}/app_state.json'));
+    return (
+      PersistentJsonStore(file: File('${dir.path}/app_state.json')),
+      PersistentJsonStore(file: File('${dir.path}/cache.json')),
+    );
   }
-  return PersistentJsonStore();
+  return (
+    PersistentJsonStore(),
+    PersistentJsonStore(fileName: 'cache.json'),
+  );
 }
 
 class MyApp extends StatefulWidget {

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -470,11 +470,17 @@ class AppStateController extends ChangeNotifier {
 
     // One-time move of the content cache into its own file for installs that
     // predate the split. No-op once done, or when a single store is in use.
+    // Best-effort: an IO failure here just defers the split to a later boot,
+    // it must not block startup.
     if (!identical(_cacheStore, _appStateStore)) {
-      await _cacheStore.adoptKeysFrom(
-        _appStateStore,
-        (key) => key.startsWith('m3ue_cache_'),
-      );
+      try {
+        await _cacheStore.adoptKeysFrom(
+          _appStateStore,
+          (key) => key.startsWith('m3ue_cache_'),
+        );
+      } on Object catch (error) {
+        debugPrint('Content cache migration deferred: $error');
+      }
     }
 
     final savedLocale = await secureStorage.read(_localeKey);

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -75,6 +75,7 @@ class AppStateController extends ChangeNotifier {
     ViewerService? viewerService,
     EpgService? epgService,
     PersistentJsonStore? persistentStore,
+    PersistentJsonStore? cacheStore,
     TvNotificationService? tvNotificationService,
     TvNotificationStore? tvNotificationStore,
     ReverbService? reverbService,
@@ -88,7 +89,18 @@ class AppStateController extends ChangeNotifier {
     final store = persistentStore ?? PersistentJsonStore();
     final resolvedSecureStorage =
         secureStorage ?? FileSecureStorage(store: store);
-    final resolvedCacheService = cacheService ?? CacheService(store: store);
+    // The content cache (whole channel/VOD/series catalog) lives in its own
+    // file on the production path so a small single-key write elsewhere -
+    // e.g. the resume tracker every ~10s during playback - never has to
+    // re-serialize it. When a caller supplies its own store or cacheService
+    // (tests), keep everything in the one file so their assertions hold.
+    final resolvedCacheStore =
+        cacheStore ??
+        (persistentStore == null && cacheService == null
+            ? PersistentJsonStore(fileName: 'cache.json')
+            : store);
+    final resolvedCacheService =
+        cacheService ?? CacheService(store: resolvedCacheStore);
     final resolvedXtreamService =
         xtreamService ??
         authNotifier?.xtreamService ??
@@ -103,6 +115,8 @@ class AppStateController extends ChangeNotifier {
       xtreamService: resolvedXtreamService,
       secureStorage: resolvedSecureStorage,
       cacheService: resolvedCacheService,
+      appStateStore: store,
+      cacheStore: resolvedCacheStore,
       favoritesService: favoritesService ?? FavoritesService(store: store),
       vodFavoritesService:
           vodFavoritesService ??
@@ -136,6 +150,8 @@ class AppStateController extends ChangeNotifier {
     required this.xtreamService,
     required this.secureStorage,
     required this.cacheService,
+    required this._appStateStore,
+    required this._cacheStore,
     required this.favoritesService,
     required this.vodFavoritesService,
     required this.seriesFavoritesService,
@@ -185,6 +201,12 @@ class AppStateController extends ChangeNotifier {
 
   final AuthNotifier authNotifier;
   final XtreamService xtreamService;
+
+  /// The app-state file (credentials, settings, favorites, resume progress)
+  /// and the content-cache file. Equal when a test forces a single store; a
+  /// one-time key migration between them runs in [boot].
+  final PersistentJsonStore _appStateStore;
+  final PersistentJsonStore _cacheStore;
   final SecureStorage secureStorage;
   final CacheService cacheService;
   final FavoritesService favoritesService;
@@ -445,6 +467,15 @@ class AppStateController extends ChangeNotifier {
     unawaited(traktService.init());
     unawaited(proxyPlaybackSettings.load());
     unawaited(comskipSettings.load());
+
+    // One-time move of the content cache into its own file for installs that
+    // predate the split. No-op once done, or when a single store is in use.
+    if (!identical(_cacheStore, _appStateStore)) {
+      await _cacheStore.adoptKeysFrom(
+        _appStateStore,
+        (key) => key.startsWith('m3ue_cache_'),
+      );
+    }
 
     final savedLocale = await secureStorage.read(_localeKey);
     if (savedLocale != null) _locale = Locale(savedLocale);

--- a/flutter_client/lib/services/persistent_store.dart
+++ b/flutter_client/lib/services/persistent_store.dart
@@ -144,18 +144,29 @@ class PersistentJsonStore {
   }
 
   /// One-time move of keys matching [test] out of [source] and into this
-  /// store. No-op when this store already holds a matching key (migration
-  /// already ran) or [source] has none. Writes here first, then clears
-  /// [source]; a crash in between leaves the keys in both files, which the
-  /// "already holds a matching key" guard treats as done - dead keys in
-  /// [source] are harmless.
+  /// store, run on boot. Writes here first, then clears [source]. It is
+  /// idempotent: once this store holds the keys, later calls only sweep any
+  /// copy still left in [source] - e.g. from a crash between the two writes,
+  /// or from [source] being reseeded - so the large payload can never linger
+  /// there (which would defeat the point of the split).
   Future<void> adoptKeysFrom(
     PersistentJsonStore source,
     bool Function(String key) test,
   ) async {
-    if (identical(source, this)) return;
+    // Distinct instances can share one file, and its cache + write queue, via
+    // the static _states map; a shared state means there is nothing to move.
+    if (identical(_state, source._state)) return;
+    await _writeQueue.drained;
     final existing = await _readAllUnlocked();
-    if (existing.keys.any(test)) return;
+    if (existing.keys.any(test)) {
+      // Destination already migrated. Only rewrite the source if an earlier
+      // run left matching keys behind - otherwise every boot would rewrite
+      // app_state.json for nothing.
+      if ((await source.snapshot()).keys.any(test)) {
+        await source.removeWhere(test);
+      }
+      return;
+    }
     final sourceData = await source.snapshot();
     final migrated = <String, Object?>{
       for (final entry in sourceData.entries)

--- a/flutter_client/lib/services/persistent_store.dart
+++ b/flutter_client/lib/services/persistent_store.dart
@@ -5,7 +5,13 @@ import 'package:m3u_tv/services/async_lifecycle.dart';
 import 'package:m3u_tv/services/json_isolate.dart';
 
 class PersistentJsonStore {
-  PersistentJsonStore({File? file}) : this._(file ?? File(_defaultPath()));
+  /// [fileName] picks the basename inside the platform app-data directory
+  /// (default `app_state.json`). Pass a distinct name (e.g. `cache.json`) to
+  /// keep a large, frequently-rewritten section in its own file so an
+  /// unrelated single-key write does not re-serialize it. Ignored when an
+  /// explicit [file] is given (tests).
+  PersistentJsonStore({File? file, String fileName = 'app_state.json'})
+    : this._(file ?? File(_defaultPath(fileName)));
 
   PersistentJsonStore._(File file)
     : _file = file,
@@ -137,6 +143,33 @@ class PersistentJsonStore {
     return Map<String, Object?>.from(await _readAllUnlocked());
   }
 
+  /// One-time move of keys matching [test] out of [source] and into this
+  /// store. No-op when this store already holds a matching key (migration
+  /// already ran) or [source] has none. Writes here first, then clears
+  /// [source]; a crash in between leaves the keys in both files, which the
+  /// "already holds a matching key" guard treats as done - dead keys in
+  /// [source] are harmless.
+  Future<void> adoptKeysFrom(
+    PersistentJsonStore source,
+    bool Function(String key) test,
+  ) async {
+    if (identical(source, this)) return;
+    final existing = await _readAllUnlocked();
+    if (existing.keys.any(test)) return;
+    final sourceData = await source.snapshot();
+    final migrated = <String, Object?>{
+      for (final entry in sourceData.entries)
+        if (test(entry.key)) entry.key: entry.value,
+    };
+    if (migrated.isEmpty) return;
+    await _queueWrite(() async {
+      final data = await _readAllUnlocked();
+      data.addAll(migrated);
+      await _writeAll(data);
+    });
+    await source.removeWhere(test);
+  }
+
   Future<void> removeWhere(bool Function(String key) test) async {
     await _queueWrite(() async {
       final data = await _readAllUnlocked();
@@ -217,7 +250,7 @@ class PersistentJsonStore {
     return true;
   }
 
-  static String _defaultPath() {
+  static String _defaultPath(String fileName) {
     final env = Platform.environment;
     final base = switch (Platform.operatingSystem) {
       'windows' =>
@@ -229,7 +262,7 @@ class PersistentJsonStore {
             '${env['HOME'] ?? Directory.systemTemp.path}/.local/share',
       _ => '${env['HOME'] ?? Directory.systemTemp.path}/.m3u_tv',
     };
-    return '$base/m3u_tv/app_state.json';
+    return '$base/m3u_tv/$fileName';
   }
 }
 

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -1116,6 +1116,69 @@ void main() {
       },
     );
 
+    test(
+      'content cache migrates into its own file for pre-split installs',
+      () async {
+        final directory = await io.Directory.systemTemp.createTemp(
+          'm3u-tv-split-',
+        );
+        addTearDown(() => _deleteDirectoryRetrying(directory));
+        final stateFile = io.File('${directory.path}/app_state.json');
+        final cacheFile = io.File('${directory.path}/cache.json');
+
+        // Pre-split install: one store, so the whole catalog lands in
+        // app_state.json alongside credentials and resume progress.
+        final legacy = AppStateController(
+          persistentStore: PersistentJsonStore(file: stateFile),
+          xtreamService: XtreamService(
+            transport: _FakeXtreamTransport.success().call,
+          ),
+        );
+        expect(
+          await legacy.connectXtream(
+            const UserCredentials(
+              server: 'https://fixture.example',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+        final stateBefore = await PersistentJsonStore(file: stateFile).snapshot();
+        expect(
+          stateBefore.keys.any((key) => key.startsWith('m3ue_cache_')),
+          isTrue,
+        );
+        expect(cacheFile.existsSync(), isFalse);
+
+        // Next launch has the split wired up: boot() moves the cache keys
+        // into cache.json and the hydrate still succeeds off the new file.
+        final migrated = AppStateController(
+          persistentStore: PersistentJsonStore(file: stateFile),
+          cacheStore: PersistentJsonStore(file: cacheFile),
+          xtreamService: XtreamService(
+            transport: _FakeXtreamTransport.success().call,
+          ),
+        );
+        await migrated.boot();
+        await _waitForXtreamRefresh(migrated);
+
+        expect(migrated.sourceType, AppSourceType.xtream);
+        expect(migrated.channels.single.name, 'BBC One');
+
+        final stateAfter = await PersistentJsonStore(file: stateFile).snapshot();
+        final cacheAfter = await PersistentJsonStore(file: cacheFile).snapshot();
+        expect(
+          stateAfter.keys.any((key) => key.startsWith('m3ue_cache_')),
+          isFalse,
+        );
+        expect(
+          cacheAfter.keys.any((key) => key.startsWith('m3ue_cache_')),
+          isTrue,
+        );
+      },
+    );
+
     test('newer EPG range wins when an older request completes last', () async {
       final oldRange = Completer<Object?>();
       final newRange = Completer<Object?>();

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -1185,6 +1185,79 @@ void main() {
       },
     );
 
+    test(
+      'boot sweeps cache keys still left in app_state.json after a '
+      'half-finished earlier migration',
+      () async {
+        final directory = await io.Directory.systemTemp.createTemp(
+          'm3u-tv-split-leftover-',
+        );
+        addTearDown(() => _deleteDirectoryRetrying(directory));
+        final stateFile = io.File('${directory.path}/app_state.json');
+        final cacheFile = io.File('${directory.path}/cache.json');
+
+        final legacy = AppStateController(
+          persistentStore: PersistentJsonStore(file: stateFile),
+          xtreamService: XtreamService(
+            transport: _FakeXtreamTransport.success().call,
+          ),
+        );
+        expect(
+          await legacy.connectXtream(
+            const UserCredentials(
+              server: 'https://fixture.example',
+              username: 'fixture-user',
+              password: 'fixture-password',
+            ),
+          ),
+          isTrue,
+        );
+
+        // Simulate a crash between adoptKeysFrom's two writes: cache.json
+        // already has the keys, but app_state.json was never cleared.
+        final stateSnapshot = await PersistentJsonStore(
+          file: stateFile,
+        ).snapshot();
+        final seededCache = PersistentJsonStore(file: cacheFile);
+        for (final entry in stateSnapshot.entries) {
+          if (entry.key.startsWith('m3ue_cache_')) {
+            await seededCache.write(entry.key, entry.value);
+          }
+        }
+        expect(
+          (await PersistentJsonStore(file: stateFile).snapshot()).keys.any(
+            (key) => key.startsWith('m3ue_cache_'),
+          ),
+          isTrue,
+        );
+
+        final migrated = AppStateController(
+          persistentStore: PersistentJsonStore(file: stateFile),
+          cacheStore: PersistentJsonStore(file: cacheFile),
+          xtreamService: XtreamService(
+            transport: _FakeXtreamTransport.success().call,
+          ),
+        );
+        await migrated.boot();
+        await _waitForXtreamRefresh(migrated);
+
+        expect(migrated.sourceType, AppSourceType.xtream);
+        expect(migrated.channels.single.name, 'BBC One');
+        expect(
+          (await PersistentJsonStore(file: stateFile).snapshot()).keys.any(
+            (key) => key.startsWith('m3ue_cache_'),
+          ),
+          isFalse,
+        );
+        expect(
+          (await PersistentJsonStore(file: cacheFile).snapshot()).keys.any(
+            (key) => key.startsWith('m3ue_cache_'),
+          ),
+          isTrue,
+        );
+      },
+    );
+
     test('newer EPG range wins when an older request completes last', () async {
       final oldRange = Completer<Object?>();
       final newRange = Completer<Object?>();

--- a/flutter_client/test/integration/app_state_boot_test.dart
+++ b/flutter_client/test/integration/app_state_boot_test.dart
@@ -1144,7 +1144,9 @@ void main() {
           ),
           isTrue,
         );
-        final stateBefore = await PersistentJsonStore(file: stateFile).snapshot();
+        final stateBefore = await PersistentJsonStore(
+          file: stateFile,
+        ).snapshot();
         expect(
           stateBefore.keys.any((key) => key.startsWith('m3ue_cache_')),
           isTrue,
@@ -1166,8 +1168,12 @@ void main() {
         expect(migrated.sourceType, AppSourceType.xtream);
         expect(migrated.channels.single.name, 'BBC One');
 
-        final stateAfter = await PersistentJsonStore(file: stateFile).snapshot();
-        final cacheAfter = await PersistentJsonStore(file: cacheFile).snapshot();
+        final stateAfter = await PersistentJsonStore(
+          file: stateFile,
+        ).snapshot();
+        final cacheAfter = await PersistentJsonStore(
+          file: cacheFile,
+        ).snapshot();
         expect(
           stateAfter.keys.any((key) => key.startsWith('m3ue_cache_')),
           isFalse,


### PR DESCRIPTION
The channel/VOD/series catalog shared app_state.json with credentials, settings, favorites and resume progress. Every single-key write - most visibly the resume tracker firing every ~10s during playback - re-read and re-serialized the entire file, catalog included.

- PersistentJsonStore gains a `fileName` constructor arg and a one-time `adoptKeysFrom` migration helper.
- On the production path the CacheService now writes to a sibling cache.json; boot() moves any legacy `m3ue_cache_*` keys across on first launch after upgrade, then it is a no-op.
- Callers that supply their own store or cacheService (tests) keep the single-file behavior, so existing assertions are unaffected.

Follow-up to #229.