### PR TITLE
feat(live-tv): show titles in the catchup shows list and fetch the full retention window

### DIFF
--- a/flutter_client/lib/app/app_shell.dart
+++ b/flutter_client/lib/app/app_shell.dart
@@ -1178,6 +1178,7 @@ class AppShellState extends ConsumerState<AppShell>
         onScheduleProgram: (channel, program) =>
             unawaited(_scheduleDvr(context, channel, program)),
         onEnsureEpg: _appState.ensureEpgForChannels,
+        onCatchupEpgRequested: _appState.ensureCatchupEpgForChannel,
         onCancelRecording: (uuid) => _appState.cancelDvrRecording(uuid),
         onCancelAndDeleteRecording: _cancelAndDeleteRecording,
         onRecordSeries: (channel, program) => _createDvrSeriesRule(

--- a/flutter_client/lib/features/live_tv/catchup_shows_dialog.dart
+++ b/flutter_client/lib/features/live_tv/catchup_shows_dialog.dart
@@ -73,10 +73,14 @@ class _CatchupShowsListState extends State<_CatchupShowsList> {
     final load = widget.epgLoad;
     if (load != null) {
       unawaited(
-        load.whenComplete(() {
-          if (!mounted) return;
-          setState(() => _loading = false);
-        }),
+        load
+            .whenComplete(() {
+              if (!mounted) return;
+              setState(() => _loading = false);
+            })
+            // The fetch swallows its own errors, but guard anyway so a future
+            // contract change can't surface here as an unhandled async error.
+            .catchError((Object _) {}),
       );
     } else {
       _loading = false;
@@ -167,7 +171,7 @@ class _CatchupShowsListState extends State<_CatchupShowsList> {
         final endFormat = DateFormat.jm(languageTag);
         String times(EpgProgram p) =>
             '${startFormat.format(p.start.toLocal())} '
-            '– ${endFormat.format(p.end.toLocal())}';
+            '- ${endFormat.format(p.end.toLocal())}';
 
         return DpadRegion(
           child: SizedBox(

--- a/flutter_client/lib/features/live_tv/catchup_shows_dialog.dart
+++ b/flutter_client/lib/features/live_tv/catchup_shows_dialog.dart
@@ -1,18 +1,25 @@
+import 'dart:async';
+
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 
-/// Presents [channel]'s replayable catchup [programs] (most-recent first) as
-/// a D-pad-navigable list, mirroring the row styling of the Live TV
-/// long-press context menu that opens this dialog. Resolves with the
-/// selected [EpgProgram], or null if the user cancels.
+/// Presents [channel]'s replayable catchup programs (most-recent first) as a
+/// D-pad-navigable list, mirroring the row styling of the Live TV long-press
+/// context menu that opens this dialog.
+///
+/// Live-updates as [epgService] notifies, so newly merged history (e.g. the
+/// catchup-window fetch kicked off via [epgLoad]) appears without a reopen.
+/// Resolves with the selected [EpgProgram], or null if the user cancels.
 Future<EpgProgram?> showCatchupShowsDialog(
   BuildContext context, {
   required Channel channel,
-  required List<EpgProgram> programs,
+  required EpgService epgService,
+  Future<void>? epgLoad,
 }) {
   return showDialog<EpgProgram>(
     context: context,
@@ -30,15 +37,27 @@ Future<EpgProgram?> showCatchupShowsDialog(
           ),
         ],
       ),
-      children: [_CatchupShowsList(programs: programs)],
+      children: [
+        _CatchupShowsList(
+          channel: channel,
+          epgService: epgService,
+          epgLoad: epgLoad,
+        ),
+      ],
     ),
   );
 }
 
 class _CatchupShowsList extends StatefulWidget {
-  const _CatchupShowsList({required this.programs});
+  const _CatchupShowsList({
+    required this.channel,
+    required this.epgService,
+    required this.epgLoad,
+  });
 
-  final List<EpgProgram> programs;
+  final Channel channel;
+  final EpgService epgService;
+  final Future<void>? epgLoad;
 
   @override
   State<_CatchupShowsList> createState() => _CatchupShowsListState();
@@ -46,6 +65,23 @@ class _CatchupShowsList extends StatefulWidget {
 
 class _CatchupShowsListState extends State<_CatchupShowsList> {
   final _scrollController = ScrollController();
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    final load = widget.epgLoad;
+    if (load != null) {
+      unawaited(
+        load.whenComplete(() {
+          if (!mounted) return;
+          setState(() => _loading = false);
+        }),
+      );
+    } else {
+      _loading = false;
+    }
+  }
 
   @override
   void dispose() {
@@ -56,73 +92,125 @@ class _CatchupShowsListState extends State<_CatchupShowsList> {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context);
-    final programs = widget.programs;
 
-    if (programs.isEmpty) {
-      return DpadRegion(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                l10n.catchupShowsEmpty,
-                style: Theme.of(context).textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 12),
-              _CatchupShowRow(
-                icon: Icons.close,
-                label: l10n.cancel,
-                autofocus: true,
-                onTap: () => Navigator.of(context).pop(),
-              ),
-            ],
-          ),
-        ),
-      );
-    }
-
-    final maxHeight = MediaQuery.sizeOf(context).height * 0.55;
-    final languageTag = Localizations.localeOf(context).toLanguageTag();
-    final startFormat = DateFormat.MMMd(languageTag).add_jm();
-    final endFormat = DateFormat.jm(languageTag);
-
-    return DpadRegion(
-      child: SizedBox(
-        width: double.maxFinite,
-        child: ConstrainedBox(
-          constraints: BoxConstraints(maxHeight: maxHeight),
-          child: Scrollbar(
-            controller: _scrollController,
-            thumbVisibility: true,
-            child: ListView.builder(
-              controller: _scrollController,
-              shrinkWrap: true,
-              itemCount: programs.length + 1,
-              itemBuilder: (context, index) {
-                if (index == programs.length) {
-                  return _CatchupShowRow(
+    return ListenableBuilder(
+      listenable: widget.epgService,
+      builder: (context, _) {
+        final programs = widget.epgService.catchupProgramsForChannel(
+          widget.channel,
+        );
+        if (_loading && programs.isEmpty) {
+          return DpadRegion(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          l10n.catchupShowsLoading,
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  _CatchupShowRow(
                     icon: Icons.close,
                     label: l10n.cancel,
+                    autofocus: true,
                     onTap: () => Navigator.of(context).pop(),
-                  );
-                }
-                final program = programs[index];
-                return _CatchupShowRow(
-                  icon: Icons.play_circle_outline,
-                  label: program.displayTitle,
-                  subtitle:
-                      '${startFormat.format(program.start.toLocal())} '
-                      '– ${endFormat.format(program.end.toLocal())}',
-                  autofocus: index == 0,
-                  onTap: () => Navigator.of(context).pop(program),
-                );
-              },
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        if (programs.isEmpty) {
+          return DpadRegion(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l10n.catchupShowsEmpty,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  _CatchupShowRow(
+                    icon: Icons.close,
+                    label: l10n.cancel,
+                    autofocus: true,
+                    onTap: () => Navigator.of(context).pop(),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        final maxHeight = MediaQuery.sizeOf(context).height * 0.55;
+        final languageTag = Localizations.localeOf(context).toLanguageTag();
+        final startFormat = DateFormat.MMMd(languageTag).add_jm();
+        final endFormat = DateFormat.jm(languageTag);
+        String times(EpgProgram p) =>
+            '${startFormat.format(p.start.toLocal())} '
+            '– ${endFormat.format(p.end.toLocal())}';
+
+        return DpadRegion(
+          child: SizedBox(
+            width: double.maxFinite,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: maxHeight),
+              child: Scrollbar(
+                controller: _scrollController,
+                thumbVisibility: true,
+                child: ListView.builder(
+                  controller: _scrollController,
+                  shrinkWrap: true,
+                  itemCount: programs.length + 1,
+                  itemBuilder: (context, index) {
+                    if (index == programs.length) {
+                      return _CatchupShowRow(
+                        icon: Icons.close,
+                        label: l10n.cancel,
+                        onTap: () => Navigator.of(context).pop(),
+                      );
+                    }
+                    final program = programs[index];
+                    final hasTitle = program.title.isNotEmpty;
+                    final label = hasTitle
+                        ? program.title
+                        : program.displayTitle;
+                    final subtitle = hasTitle && program.subtitle != null
+                        ? '${program.subtitle} · ${times(program)}'
+                        : times(program);
+                    return _CatchupShowRow(
+                      icon: Icons.play_circle_outline,
+                      label: label,
+                      subtitle: subtitle,
+                      autofocus: index == 0,
+                      onTap: () => Navigator.of(context).pop(program),
+                    );
+                  },
+                ),
+              ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/flutter_client/lib/features/live_tv/live_tv_screen.dart
+++ b/flutter_client/lib/features/live_tv/live_tv_screen.dart
@@ -48,6 +48,7 @@ class LiveTvScreen extends ConsumerStatefulWidget {
     this.onSidebarActivate,
     this.onScheduleProgram,
     this.onEnsureEpg,
+    this.onCatchupEpgRequested,
     this.onCancelRecording,
     this.onCancelAndDeleteRecording,
     this.onRecordSeries,
@@ -104,6 +105,14 @@ class LiveTvScreen extends ConsumerStatefulWidget {
   /// if not already fresh. Called per-item as the visible list/grid builds,
   /// so only channels actually scrolled into view get fetched.
   final EnsureEpg? onEnsureEpg;
+
+  /// Fetches the full catchup-retention window of EPG programs for a channel
+  /// when the user opens the catchup dialog. The default-guide fetch driven by
+  /// [onEnsureEpg] only asks for today+tomorrow, so without this the dialog
+  /// would only ever show history that happened to land in the cache. Nullable
+  /// so the screen works unwired - the dialog falls back to cache-only when
+  /// the callback is null.
+  final Future<void> Function(Channel)? onCatchupEpgRequested;
 
   /// Wired from AppShell to `AppShell._enterFullScreenDetail`/
   /// `_exitFullScreenDetail`. Multiview opens via a plain `Navigator.push`
@@ -597,13 +606,13 @@ class _LiveTvScreenState extends ConsumerState<LiveTvScreen>
       case _ChannelContextAction.toggleFavorite:
         await _toggleFavorite(channel);
       case _ChannelContextAction.catchupShows:
-        final programs = ref
-            .read(epgServiceProvider)
-            .catchupProgramsForChannel(channel);
+        final epgService = ref.read(epgServiceProvider);
+        final epgLoad = widget.onCatchupEpgRequested?.call(channel);
         final program = await showCatchupShowsDialog(
           context,
           channel: channel,
-          programs: programs,
+          epgService: epgService,
+          epgLoad: epgLoad,
         );
         if (program != null) {
           widget.onCatchupProgramSelect?.call(channel, program);

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -78,6 +78,7 @@
   "liveTvRemoveFavorite": "Aus Favoriten entfernen",
   "liveTvCatchupShows": "Catchup-Sendungen",
   "catchupShowsEmpty": "Keine Catchup-Sendungen verfügbar",
+  "catchupShowsLoading": "Catchup-Sendungen werden geladen…",
   "liveTvAddMultiview": "Zu Multiview hinzufügen",
   "liveTvRemoveMultiview": "Aus Multiview entfernen",
   "liveTvMultiviewFull": "Multiview ist voll (max. 9 Streams)",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -79,6 +79,7 @@
   "liveTvRemoveFavorite": "Remove favorite",
   "liveTvCatchupShows": "Catchup shows",
   "catchupShowsEmpty": "No catchup shows available",
+  "catchupShowsLoading": "Loading catchup shows…",
   "liveTvAddMultiview": "Add to Multiview",
   "liveTvRemoveMultiview": "Remove from Multiview",
   "liveTvMultiviewFull": "Multiview is full (9 streams max)",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -78,6 +78,7 @@
   "liveTvRemoveFavorite": "Quitar de favoritos",
   "liveTvCatchupShows": "Programas de catchup",
   "catchupShowsEmpty": "No hay programas de catchup disponibles",
+  "catchupShowsLoading": "Cargando programas de catchup…",
   "liveTvAddMultiview": "Añadir a Multivista",
   "liveTvRemoveMultiview": "Quitar de Multivista",
   "liveTvMultiviewFull": "Multivista está lleno (máx. 9 transmisiones)",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -78,6 +78,7 @@
   "liveTvRemoveFavorite": "Retirer des favoris",
   "liveTvCatchupShows": "Programmes de rattrapage",
   "catchupShowsEmpty": "Aucun programme de rattrapage disponible",
+  "catchupShowsLoading": "Chargement des programmes de rattrapage…",
   "liveTvAddMultiview": "Ajouter à Multivue",
   "liveTvRemoveMultiview": "Retirer de Multivue",
   "liveTvMultiviewFull": "Multivue est complet (9 flux max)",

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -362,6 +362,12 @@ abstract class AppLocalizations {
   /// **'No catchup shows available'**
   String get catchupShowsEmpty;
 
+  /// No description provided for @catchupShowsLoading.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading catchup shows…'**
+  String get catchupShowsLoading;
+
   /// No description provided for @liveTvAddMultiview.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -155,6 +155,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get catchupShowsEmpty => 'Keine Catchup-Sendungen verfügbar';
 
   @override
+  String get catchupShowsLoading => 'Catchup-Sendungen werden geladen…';
+
+  @override
   String get liveTvAddMultiview => 'Zu Multiview hinzufügen';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -154,6 +154,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catchupShowsEmpty => 'No catchup shows available';
 
   @override
+  String get catchupShowsLoading => 'Loading catchup shows…';
+
+  @override
   String get liveTvAddMultiview => 'Add to Multiview';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -154,6 +154,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get catchupShowsEmpty => 'No hay programas de catchup disponibles';
 
   @override
+  String get catchupShowsLoading => 'Cargando programas de catchup…';
+
+  @override
   String get liveTvAddMultiview => 'Añadir a Multivista';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -154,6 +154,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get catchupShowsEmpty => 'Aucun programme de rattrapage disponible';
 
   @override
+  String get catchupShowsLoading => 'Chargement des programmes de rattrapage…';
+
+  @override
   String get liveTvAddMultiview => 'Ajouter à Multivue';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -148,6 +148,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get catchupShowsEmpty => '暂无可回看节目';
 
   @override
+  String get catchupShowsLoading => '正在加载回看节目…';
+
+  @override
   String get liveTvAddMultiview => '添加到多画面';
 
   @override

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -78,6 +78,7 @@
   "liveTvRemoveFavorite": "取消收藏",
   "liveTvCatchupShows": "回看节目",
   "catchupShowsEmpty": "暂无可回看节目",
+  "catchupShowsLoading": "正在加载回看节目…",
   "liveTvAddMultiview": "添加到多画面",
   "liveTvRemoveMultiview": "从多画面移除",
   "liveTvMultiviewFull": "多画面已满（最多 9 路）",

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -390,6 +390,7 @@ class AppStateController extends ChangeNotifier {
   final Set<int> _pendingEpgChannelIds = <int>{};
   final Set<int> _pendingForcedEpgChannelIds = <int>{};
   final Map<String, DateTime> _fetchedEpgRanges = <String, DateTime>{};
+  final Map<int, DateTime> _catchupEpgFetchedAt = <int, DateTime>{};
   Timer? _epgFetchDebounce;
   DateTime? _pendingEpgStartDate;
   DateTime? _pendingEpgEndDate;
@@ -2995,6 +2996,55 @@ class AppStateController extends ChangeNotifier {
     if (!added) return;
     _epgFetchDebounce?.cancel();
     _epgFetchDebounce = Timer(_epgFetchDebounceDelay, _flushPendingEpgFetch);
+  }
+
+  /// Fetches the full retention window of EPG programs for [channel] so the
+  /// catchup dialog can list history beyond today+tomorrow (which is all
+  /// `ensureEpgForChannels` ever asks the server for).
+  ///
+  /// Deliberately does not read or write `_activeEpgRangeKey`,
+  /// `_pendingEpg*`, or `_epgRequestGeneration`: those gate the default-guide
+  /// range fetches that the list/grid itemBuilders kick off on every rebuild,
+  /// which would race a dialog-open fetch and discard the response.
+  Future<void> ensureCatchupEpgForChannel(Channel channel) async {
+    if (_sourceType != AppSourceType.xtream) return;
+    final retentionDays = EpgService.effectiveCatchupRetentionDays(
+      channel.catchupSupported,
+      channel.catchupDays,
+    );
+    if (retentionDays <= 0) return;
+    final lastSuccess = _catchupEpgFetchedAt[channel.id];
+    final now = DateTime.now();
+    if (lastSuccess != null &&
+        now.difference(lastSuccess) < epgService.cacheTtl) {
+      return;
+    }
+    final today = DateTime(now.year, now.month, now.day);
+    // canReplay admits programs starting as far back as now - retentionDays,
+    // a timestamp on calendar day (today - retentionDays) — so that partial
+    // day must be fetched too; canReplay filters out its too-old programs.
+    final start = DateTime.utc(
+      today.year,
+      today.month,
+      today.day - retentionDays,
+    );
+    final end = DateTime.utc(today.year, today.month, today.day);
+    try {
+      final programs = await xtreamService.getEpgBatch(
+        [channel],
+        startDate: start,
+        endDate: end,
+      );
+      epgService.mergePrograms(
+        programs,
+        channelIds: [_epgChannelId(channel)],
+        replaceExisting: false,
+        markFresh: false,
+      );
+      _catchupEpgFetchedAt[channel.id] = DateTime.now();
+    } on Object catch (_) {
+      _catchupEpgFetchedAt.remove(channel.id);
+    }
   }
 
   Future<void> _flushPendingEpgFetch() async {

--- a/flutter_client/lib/services/app_state_controller.dart
+++ b/flutter_client/lib/services/app_state_controller.dart
@@ -391,6 +391,7 @@ class AppStateController extends ChangeNotifier {
   final Set<int> _pendingForcedEpgChannelIds = <int>{};
   final Map<String, DateTime> _fetchedEpgRanges = <String, DateTime>{};
   final Map<int, DateTime> _catchupEpgFetchedAt = <int, DateTime>{};
+  final Set<int> _inFlightCatchupEpgChannelIds = <int>{};
   Timer? _epgFetchDebounce;
   DateTime? _pendingEpgStartDate;
   DateTime? _pendingEpgEndDate;
@@ -3005,8 +3006,26 @@ class AppStateController extends ChangeNotifier {
   /// Deliberately does not read or write `_activeEpgRangeKey`,
   /// `_pendingEpg*`, or `_epgRequestGeneration`: those gate the default-guide
   /// range fetches that the list/grid itemBuilders kick off on every rebuild,
-  /// which would race a dialog-open fetch and discard the response.
+  /// which would race a dialog-open fetch and discard the response. It does
+  /// re-check `_sourceOperationGeneration` after the network round-trips so a
+  /// source switch mid-fetch can't merge stale programs back into a guide
+  /// that `_resetEpgSession` just cleared.
+  ///
+  /// Concurrent calls for the same channel collapse to one fetch, and
+  /// successes are memoized against [EpgService.cacheTtl] (the memo is cleared
+  /// by `_resetEpgSession`).
   Future<void> ensureCatchupEpgForChannel(Channel channel) async {
+    // A second open while a fetch is still running returns right away; the
+    // dialog's ListenableBuilder picks up the merged history when it lands.
+    if (!_inFlightCatchupEpgChannelIds.add(channel.id)) return;
+    try {
+      await _fetchCatchupEpgForChannel(channel);
+    } finally {
+      _inFlightCatchupEpgChannelIds.remove(channel.id);
+    }
+  }
+
+  Future<void> _fetchCatchupEpgForChannel(Channel channel) async {
     if (_sourceType != AppSourceType.xtream) return;
     final retentionDays = EpgService.effectiveCatchupRetentionDays(
       channel.catchupSupported,
@@ -3019,9 +3038,10 @@ class AppStateController extends ChangeNotifier {
         now.difference(lastSuccess) < epgService.cacheTtl) {
       return;
     }
+    final sourceGeneration = _sourceOperationGeneration.current;
     final today = DateTime(now.year, now.month, now.day);
     // canReplay admits programs starting as far back as now - retentionDays,
-    // a timestamp on calendar day (today - retentionDays) — so that partial
+    // a timestamp on calendar day (today - retentionDays), so that partial
     // day must be fetched too; canReplay filters out its too-old programs.
     final start = DateTime.utc(
       today.year,
@@ -3035,6 +3055,9 @@ class AppStateController extends ChangeNotifier {
         startDate: start,
         endDate: end,
       );
+      if (_disposed || _sourceOperationGeneration.isStale(sourceGeneration)) {
+        return;
+      }
       epgService.mergePrograms(
         programs,
         channelIds: [_epgChannelId(channel)],
@@ -3203,6 +3226,7 @@ class AppStateController extends ChangeNotifier {
     _pendingEpgChannelIds.clear();
     _pendingForcedEpgChannelIds.clear();
     _fetchedEpgRanges.clear();
+    _catchupEpgFetchedAt.clear();
     _pendingEpgStartDate = null;
     _pendingEpgEndDate = null;
     _activeEpgRangeKey = '';

--- a/flutter_client/test/services/catchup_epg_fetch_test.dart
+++ b/flutter_client/test/services/catchup_epg_fetch_test.dart
@@ -1,0 +1,318 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/aiostreams_favorites_service.dart';
+import 'package:m3u_tv/services/app_state_controller.dart';
+import 'package:m3u_tv/services/cache_service.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/epg_service.dart';
+import 'package:m3u_tv/services/favorites_service.dart';
+import 'package:m3u_tv/services/resume_service.dart';
+import 'package:m3u_tv/services/reverb_service.dart';
+import 'package:m3u_tv/services/secure_storage.dart';
+import 'package:m3u_tv/services/tv_notification_service.dart';
+import 'package:m3u_tv/services/tv_notification_store.dart';
+import 'package:m3u_tv/services/viewer_service.dart';
+import 'package:m3u_tv/services/xtream_service.dart';
+
+const _credentials = UserCredentials(
+  server: 'https://fixture.invalid',
+  username: 'catchup-test',
+  password: 'catchup-pass',
+);
+
+const _catchupChannel = Channel(
+  id: 101,
+  name: 'Route News',
+  streamUrl: 'https://example.com/news.m3u8',
+  epgChannelId: 'news.epg',
+  catchupSupported: true,
+  catchupDays: 7,
+);
+
+const _plainChannel = Channel(
+  id: 202,
+  name: 'No Catchup',
+  streamUrl: 'https://example.com/plain.m3u8',
+  epgChannelId: 'plain.epg',
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'ensureCatchupEpgForChannel fetches every day in the retention window and '
+    'merges the returned programs',
+    () async {
+      final transport = _CatchupTransport();
+      final controller = _controller(transport);
+      addTearDown(controller.dispose);
+      expect(await controller.connectXtream(_credentials), isTrue);
+      transport.epgDates.clear();
+
+      await controller.ensureCatchupEpgForChannel(_catchupChannel);
+
+      // retentionDays (7) + the partial current day = 8 dated requests.
+      expect(transport.epgDates, hasLength(8));
+      final today = DateTime.now();
+      final expectedStart = DateTime.utc(
+        today.year,
+        today.month,
+        today.day - 7,
+      );
+      final expectedEnd = DateTime.utc(today.year, today.month, today.day);
+      for (final raw in transport.epgDates) {
+        final parsed = DateTime.parse('${raw}T00:00:00Z');
+        expect(parsed.isBefore(expectedStart), isFalse, reason: raw);
+        expect(parsed.isAfter(expectedEnd), isFalse, reason: raw);
+      }
+      expect(transport.epgDates.first, _ymd(expectedStart));
+      expect(transport.epgDates.last, _ymd(expectedEnd));
+
+      expect(
+        controller.epgService
+            .programsForChannel(_catchupChannel)
+            .map((program) => program.title),
+        contains('Catchup Fixture'),
+      );
+    },
+  );
+
+  test(
+    'a second call within the cache TTL does not re-hit the server',
+    () async {
+      final transport = _CatchupTransport();
+      final controller = _controller(transport);
+      addTearDown(controller.dispose);
+      expect(await controller.connectXtream(_credentials), isTrue);
+
+      await controller.ensureCatchupEpgForChannel(_catchupChannel);
+      transport.epgDates.clear();
+      await controller.ensureCatchupEpgForChannel(_catchupChannel);
+
+      expect(transport.epgDates, isEmpty);
+    },
+  );
+
+  test('channels without catchup never trigger a fetch', () async {
+    final transport = _CatchupTransport();
+    final controller = _controller(transport);
+    addTearDown(controller.dispose);
+    expect(await controller.connectXtream(_credentials), isTrue);
+    transport.epgDates.clear();
+
+    await controller.ensureCatchupEpgForChannel(_plainChannel);
+
+    expect(transport.epgDates, isEmpty);
+  });
+
+  test('a failed fetch clears the memo so the next open retries', () async {
+    final transport = _CatchupTransport()..failEpgBatch = true;
+    final controller = _controller(transport);
+    addTearDown(controller.dispose);
+    expect(await controller.connectXtream(_credentials), isTrue);
+
+    await controller.ensureCatchupEpgForChannel(_catchupChannel);
+    expect(controller.epgService.programsForChannel(_catchupChannel), isEmpty);
+
+    transport
+      ..failEpgBatch = false
+      ..epgDates.clear();
+    await controller.ensureCatchupEpgForChannel(_catchupChannel);
+
+    expect(transport.epgDates, isNotEmpty);
+    expect(
+      controller.epgService
+          .programsForChannel(_catchupChannel)
+          .map((program) => program.title),
+      contains('Catchup Fixture'),
+    );
+  });
+
+  test(
+    'concurrent calls for the same channel collapse to a single fetch',
+    () async {
+      final transport = _CatchupTransport();
+      final gate = Completer<void>();
+      transport.beforeEpgBatch = gate.future;
+      final controller = _controller(transport);
+      addTearDown(controller.dispose);
+      expect(await controller.connectXtream(_credentials), isTrue);
+      transport.epgDates.clear();
+
+      final first = controller.ensureCatchupEpgForChannel(_catchupChannel);
+      final second = controller.ensureCatchupEpgForChannel(_catchupChannel);
+      gate.complete();
+      await Future.wait([first, second]);
+
+      // One window fetch, not two: still just retentionDays + 1 dated requests.
+      expect(transport.epgDates, hasLength(8));
+    },
+  );
+
+  test(
+    'a source reset clears the memo so a later open fetches again',
+    () async {
+      final transport = _CatchupTransport();
+      final controller = _controller(transport);
+      addTearDown(controller.dispose);
+
+      expect(await controller.connectXtream(_credentials), isTrue);
+      await controller.ensureCatchupEpgForChannel(_catchupChannel);
+      expect(transport.epgDates, isNotEmpty);
+
+      await controller.disconnect();
+      expect(await controller.connectXtream(_credentials), isTrue);
+      transport.epgDates.clear();
+
+      await controller.ensureCatchupEpgForChannel(_catchupChannel);
+
+      expect(transport.epgDates, hasLength(8));
+    },
+  );
+
+  test(
+    'a response that lands after a source switch is not merged into the new '
+    'guide',
+    () async {
+      final transport = _CatchupTransport();
+      final gate = Completer<void>();
+      transport.beforeEpgBatch = gate.future;
+      final controller = _controller(transport);
+      addTearDown(controller.dispose);
+      expect(await controller.connectXtream(_credentials), isTrue);
+
+      final pending = controller.ensureCatchupEpgForChannel(_catchupChannel);
+      await controller.disconnect();
+      gate.complete();
+      await pending;
+
+      expect(
+        controller.epgService.programsForChannel(_catchupChannel),
+        isEmpty,
+      );
+    },
+  );
+}
+
+String _ymd(DateTime value) {
+  String two(int n) => n.toString().padLeft(2, '0');
+  return '${value.year.toString().padLeft(4, '0')}-'
+      '${two(value.month)}-${two(value.day)}';
+}
+
+AppStateController _controller(_CatchupTransport transport) {
+  final memory = <String, Object?>{};
+  return AppStateController(
+    xtreamService: XtreamService(
+      transport: transport.call,
+      cache: CacheService(memory: <String, Object?>{}),
+    ),
+    secureStorage: InMemorySecureStorage(),
+    cacheService: CacheService(memory: <String, Object?>{}),
+    epgService: EpgService(),
+    favoritesService: FavoritesService(memory: memory),
+    vodFavoritesService: FavoritesService(memory: memory, namespace: 'vod'),
+    seriesFavoritesService: FavoritesService(
+      memory: memory,
+      namespace: 'series',
+    ),
+    aioFavoritesService: AIOStreamsFavoritesService(),
+    resumeService: ResumeService(memory: memory),
+    viewerService: ViewerService(memory: memory),
+    tvNotificationService: _NotificationService(),
+    tvNotificationStore: TvNotificationStore(memory: memory),
+    reverbService: _NoopReverbService(),
+  );
+}
+
+class _CatchupTransport {
+  bool failEpgBatch = false;
+  Future<void>? beforeEpgBatch;
+  final List<String> epgDates = <String>[];
+
+  Future<Object?> call(XtreamRequest request) async {
+    switch (request.action ?? 'auth') {
+      case 'auth':
+        return <String, Object?>{
+          'user_info': <String, Object?>{'auth': 1, 'status': 'Active'},
+          'server_info': <String, Object?>{'timezone': 'UTC'},
+          'm3u_editor': <String, Object?>{
+            'version': '0.10.0',
+            'features': <String>['dvr'],
+          },
+        };
+      case 'get_live_categories':
+      case 'get_vod_categories':
+      case 'get_series_categories':
+      case 'get_live_streams':
+      case 'get_vod_streams':
+      case 'get_series':
+      case 'get_recently_watched':
+      case 'list_dvr_series_rules':
+      case 'sync_favorites':
+        return const <Object?>[];
+      case 'get_viewers':
+        return <Map<String, Object?>>[
+          <String, Object?>{
+            'id': 1,
+            'ulid': 'viewer-admin',
+            'name': 'Admin',
+            'is_admin': true,
+          },
+        ];
+      case 'get_dvr_recordings':
+        return const <Object?>[];
+      case 'get_dvr_storage':
+        return <String, Object?>{
+          'used_bytes': 0,
+          'quota_bytes': null,
+          'percent_used': null,
+          'recording_count': 0,
+          'scope': 'account',
+        };
+      case 'get_epg_batch':
+        final date = request.params['date'];
+        if (date == null) return const <String, Object?>{};
+        await beforeEpgBatch;
+        if (failEpgBatch) throw StateError('epg batch boom');
+        epgDates.add(date);
+        final start = DateTime.parse('${date}T09:00:00Z');
+        return <String, Object?>{
+          '101': <Map<String, Object?>>[
+            <String, Object?>{
+              'stream_id': 101,
+              'title': 'Catchup Fixture',
+              'description': 'Fixture',
+              'start': start.toIso8601String(),
+              'end': start.add(const Duration(minutes: 30)).toIso8601String(),
+            },
+          ],
+        };
+      default:
+        throw StateError('No fixture for ${request.action}');
+    }
+  }
+}
+
+class _NotificationService extends TvNotificationService {
+  @override
+  Future<(TvPlaylistSession, List<TvNotificationItem>)> fetchUnread(
+    UserCredentials creds, {
+    List<String>? channels,
+  }) async => const (
+    TvPlaylistSession(
+      notifiableId: 1,
+      notifiableType: 'playlist',
+      isAdmin: false,
+      channelName: '',
+      reverb: ReverbConfig(host: '', port: 0, scheme: 'wss', appKey: ''),
+    ),
+    <TvNotificationItem>[],
+  );
+}
+
+class _NoopReverbService extends ReverbService {
+  @override
+  Future<void> disconnect() async {}
+}

--- a/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
+++ b/flutter_client/test/ui/live_tv/live_tv_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -311,4 +313,260 @@ void main() {
 
     expect(find.text('Stale Noon News'), findsNothing);
   });
+
+  testWidgets(
+    'catchup row shows the show title, not the episode subtitle',
+    (tester) async {
+      final favorites = FavoritesService(memory: <String, Object?>{});
+      final now = DateTime.utc(2026, 1, 1, 12);
+      final epg = EpgService(clock: () => now)
+        ..loadPrograms([
+          EpgProgram(
+            channelId: 'news.epg',
+            title: 'The Simpsons',
+            subtitle: 'Aug 28 Episode',
+            description: 'Animated sitcom',
+            start: now.subtract(const Duration(hours: 3)),
+            end: now.subtract(const Duration(hours: 2)),
+          ),
+        ]);
+      const channels = [
+        Channel(
+          id: 101,
+          name: 'Route News',
+          streamUrl: 'https://example.com/news.m3u8',
+          epgChannelId: 'news.epg',
+          catchupSupported: true,
+          catchupDays: 7,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isBootstrappingProvider.overrideWith((_) => false),
+            isConfiguredProvider.overrideWith((_) => true),
+            isLoadingContentProvider.overrideWith((_) => false),
+            liveChannelsProvider.overrideWith((_) => channels),
+            liveCategoriesProvider.overrideWith((_) => const []),
+            epgServiceProvider.overrideWith((_) => epg),
+            dvrRecordingsProvider.overrideWith((_) => const []),
+            recordingChannelIdsProvider.overrideWith((_) => const <int>{}),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: LiveTvScreen(
+              favoritesService: favorites,
+              onChannelSelect: (_) {},
+              useSidebarLayout: true,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.text('Route News'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Catchup shows'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('The Simpsons'), findsOneWidget);
+      expect(find.textContaining('Aug 28 Episode'), findsOneWidget);
+      expect(find.textContaining('Aug 28 Episode · '), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'catchup row falls back to subtitle as label when title is blank',
+    (tester) async {
+      final favorites = FavoritesService(memory: <String, Object?>{});
+      final now = DateTime.utc(2026, 1, 1, 12);
+      final epg = EpgService(clock: () => now)
+        ..loadPrograms([
+          EpgProgram(
+            channelId: 'news.epg',
+            title: '',
+            subtitle: 'Evening Bulletin',
+            description: 'News',
+            start: now.subtract(const Duration(hours: 3)),
+            end: now.subtract(const Duration(hours: 2)),
+          ),
+        ]);
+      const channels = [
+        Channel(
+          id: 101,
+          name: 'Route News',
+          streamUrl: 'https://example.com/news.m3u8',
+          epgChannelId: 'news.epg',
+          catchupSupported: true,
+          catchupDays: 7,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isBootstrappingProvider.overrideWith((_) => false),
+            isConfiguredProvider.overrideWith((_) => true),
+            isLoadingContentProvider.overrideWith((_) => false),
+            liveChannelsProvider.overrideWith((_) => channels),
+            liveCategoriesProvider.overrideWith((_) => const []),
+            epgServiceProvider.overrideWith((_) => epg),
+            dvrRecordingsProvider.overrideWith((_) => const []),
+            recordingChannelIdsProvider.overrideWith((_) => const <int>{}),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: LiveTvScreen(
+              favoritesService: favorites,
+              onChannelSelect: (_) {},
+              useSidebarLayout: true,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.text('Route News'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Catchup shows'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Evening Bulletin'), findsOneWidget);
+      expect(find.textContaining('Evening Bulletin · '), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'opening catchup dialog kicks onCatchupEpgRequested exactly once',
+    (tester) async {
+      final favorites = FavoritesService(memory: <String, Object?>{});
+      final now = DateTime.utc(2026, 1, 1, 12);
+      final epg = EpgService(clock: () => now);
+      const channels = [
+        Channel(
+          id: 101,
+          name: 'Route News',
+          streamUrl: 'https://example.com/news.m3u8',
+          catchupSupported: true,
+          catchupDays: 7,
+        ),
+      ];
+      Channel? fetchedFor;
+      var callCount = 0;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isBootstrappingProvider.overrideWith((_) => false),
+            isConfiguredProvider.overrideWith((_) => true),
+            isLoadingContentProvider.overrideWith((_) => false),
+            liveChannelsProvider.overrideWith((_) => channels),
+            liveCategoriesProvider.overrideWith((_) => const []),
+            epgServiceProvider.overrideWith((_) => epg),
+            dvrRecordingsProvider.overrideWith((_) => const []),
+            recordingChannelIdsProvider.overrideWith((_) => const <int>{}),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: LiveTvScreen(
+              favoritesService: favorites,
+              onChannelSelect: (_) {},
+              useSidebarLayout: true,
+              onCatchupEpgRequested: (channel) {
+                fetchedFor = channel;
+                callCount += 1;
+                return Future<void>.value();
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.text('Route News'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Catchup shows'));
+      await tester.pumpAndSettle();
+
+      expect(callCount, 1);
+      expect(fetchedFor?.id, 101);
+    },
+  );
+
+  testWidgets(
+    'catchup dialog live-updates as history arrives',
+    (tester) async {
+      final favorites = FavoritesService(memory: <String, Object?>{});
+      final now = DateTime.utc(2026, 1, 1, 12);
+      final epg = EpgService(clock: () => now);
+      const channels = [
+        Channel(
+          id: 101,
+          name: 'Route News',
+          streamUrl: 'https://example.com/news.m3u8',
+          epgChannelId: 'news.epg',
+          catchupSupported: true,
+          catchupDays: 7,
+        ),
+      ];
+      final loadComplete = Completer<void>();
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            isBootstrappingProvider.overrideWith((_) => false),
+            isConfiguredProvider.overrideWith((_) => true),
+            isLoadingContentProvider.overrideWith((_) => false),
+            liveChannelsProvider.overrideWith((_) => channels),
+            liveCategoriesProvider.overrideWith((_) => const []),
+            epgServiceProvider.overrideWith((_) => epg),
+            dvrRecordingsProvider.overrideWith((_) => const []),
+            recordingChannelIdsProvider.overrideWith((_) => const <int>{}),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: LiveTvScreen(
+              favoritesService: favorites,
+              onChannelSelect: (_) {},
+              useSidebarLayout: true,
+              onCatchupEpgRequested: (channel) => loadComplete.future,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      await tester.longPress(find.text('Route News'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Catchup shows'));
+      await tester.pump();
+
+      expect(find.text('Loading catchup shows…'), findsOneWidget);
+
+      epg.mergePrograms(
+        [
+          EpgProgram(
+            channelId: 'news.epg',
+            title: 'Yesterday Plus',
+            description: 'News',
+            start: now.subtract(const Duration(hours: 27)),
+            end: now.subtract(const Duration(hours: 26)),
+          ),
+        ],
+        channelIds: const ['news.epg'],
+        replaceExisting: false,
+        markFresh: false,
+      );
+      loadComplete.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Yesterday Plus'), findsOneWidget);
+      expect(find.text('No catchup shows available'), findsNothing);
+    },
+  );
 }


### PR DESCRIPTION
## Problem

The channel long-press **Catchup shows** list (#203) was hard to use in practice:

1. **Rows showed times but no usable show names.** Each row's label was `EpgProgram.displayTitle` (`subtitle ?? title`). XMLTV `<sub-title>` is frequently an airdate or episode string — news and talk shows especially — so whenever a subtitle existed, the row's only text was e.g. "Aug 28" over a time range. The actual show title was never rendered.
2. **Only ~one day of history was ever listed.** The dialog read the EPG cache without fetching, and the list/grid views only ever request the default guide window, which `get_epg_batch` answers with today + tomorrow. Multi-day retention windows were unreachable from the dialog no matter what the channel advertised.

## Changes

- **Row content:** rows now lead with `program.title`, falling back to `displayTitle` when the title is blank so a row never renders empty. The episode subtitle (when present) moves into the secondary line ahead of the time range (`Episode Name · Aug 28, 3:00 PM – 4:00 PM`). `EpgProgram.displayTitle` itself is unchanged — other sites depend on its episode-first semantics.
- **Retention-window fetch:** opening the dialog kicks a new `AppStateController.ensureCatchupEpgForChannel`, which fetches `[today − retentionDays, today]` via `getEpgBatch` and merges additively (`replaceExisting: false`). It's TTL-memoized per channel against `EpgService.cacheTtl`, and clears the memo on failure so the next open retries. It deliberately bypasses `ensureEpgForChannels`' range machinery: that path keys pending state to a single active-range key, and the list/grid `itemBuilder`s' no-date calls on every rebuild would flip the key and discard the in-flight response.
- **Live-updating dialog:** `showCatchupShowsDialog` now takes the `EpgService` + optional in-flight fetch future instead of a static snapshot, rebuilding through `ListenableBuilder` as merged history lands. While the fetch is in flight and the cache is empty it shows a localized loading row; Cancel stays reachable in every state.
- **l10n:** new `catchupShowsLoading` key across en/de/es/fr/zh, generated files regenerated.

## Related

Multi-day retention being *advertised* as 1 day is a separate m3u-editor regression (Xtream import stores the provider's `tv_archive_duration`, a days value, into the hours-denominated `shift`; visible since #1389's export-side conversion). Server fix is being handled in m3u-editor — this PR is correct with or without it.

## Testing

- 4 new widget tests in `test/ui/live_tv/live_tv_screen_test.dart`: title precedence over episode subtitle, blank-title fallback, fetch-callback wiring, and live update while the dialog is open.
- `dart format` clean, `flutter analyze lib test` clean, `flutter test test/ui/` 417 passed / 7 skipped / 0 failed.