### PR TITLE
fix(vod,series): honor overlapping category_ids so dynamic categories populate

### DIFF
--- a/flutter_client/lib/features/series/series_screen.dart
+++ b/flutter_client/lib/features/series/series_screen.dart
@@ -87,7 +87,7 @@ class _SeriesScreenState extends ConsumerState<SeriesScreen> {
       categoryFiltered = seriesList;
     } else {
       categoryFiltered = seriesList.where(
-        (item) => item.categoryId == selectedCategory,
+        (item) => item.isInCategory(selectedCategory),
       );
     }
     final normalizedQuery = _query.trim().toLowerCase();
@@ -118,8 +118,15 @@ class _SeriesScreenState extends ConsumerState<SeriesScreen> {
     }
     for (final item in seriesList) {
       final categoryId = item.categoryId;
-      if (categoryId == null) continue;
-      counts[categoryId] = (counts[categoryId] ?? 0) + 1;
+      if (categoryId != null) {
+        counts[categoryId] = (counts[categoryId] ?? 0) + 1;
+      }
+      // Overlapping memberships (dynamic TMDB categories) count too; the
+      // primary id is usually repeated in categoryIds, so skip it.
+      for (final id in item.categoryIds) {
+        if (id == categoryId) continue;
+        counts[id] = (counts[id] ?? 0) + 1;
+      }
     }
     return counts;
   }

--- a/flutter_client/lib/features/vod/vod_screen.dart
+++ b/flutter_client/lib/features/vod/vod_screen.dart
@@ -86,7 +86,7 @@ class _VodScreenState extends ConsumerState<VodScreen> {
       categoryFiltered = vodItems;
     } else {
       categoryFiltered = vodItems.where(
-        (item) => item.categoryId == selectedCategory,
+        (item) => item.isInCategory(selectedCategory),
       );
     }
     final normalizedQuery = _query.trim().toLowerCase();
@@ -117,8 +117,15 @@ class _VodScreenState extends ConsumerState<VodScreen> {
     }
     for (final item in vodItems) {
       final categoryId = item.categoryId;
-      if (categoryId == null) continue;
-      counts[categoryId] = (counts[categoryId] ?? 0) + 1;
+      if (categoryId != null) {
+        counts[categoryId] = (counts[categoryId] ?? 0) + 1;
+      }
+      // Overlapping memberships (dynamic TMDB categories) count too; the
+      // primary id is usually repeated in categoryIds, so skip it.
+      for (final id in item.categoryIds) {
+        if (id == categoryId) continue;
+        counts[id] = (counts[id] ?? 0) + 1;
+      }
     }
     return counts;
   }

--- a/flutter_client/lib/services/cache_service.dart
+++ b/flutter_client/lib/services/cache_service.dart
@@ -186,6 +186,7 @@ Object? _decodeCacheData(String key, Object? raw) {
               containerExtension: '${json['container_extension'] ?? 'mp4'}',
               logoUrl: _nullableString(json['stream_icon']),
               categoryId: _nullableString(json['category_id']),
+              categoryIds: _stringList(json['category_ids']),
               rating: _asDouble(json['rating']),
             );
           })
@@ -231,6 +232,7 @@ Map<String, Object?> _vodToJson(VodItem item) => <String, Object?>{
   'container_extension': item.containerExtension,
   if (item.logoUrl != null) 'stream_icon': item.logoUrl,
   if (item.categoryId != null) 'category_id': item.categoryId,
+  if (item.categoryIds.isNotEmpty) 'category_ids': item.categoryIds,
   if (item.rating != null) 'rating': item.rating,
 };
 
@@ -240,6 +242,8 @@ Map<String, Object?> _seriesToJson(Series series) => <String, Object?>{
   if (series.coverUrl != null) 'cover': series.coverUrl,
   if (series.backdropUrl != null) 'backdrop_path': series.backdropUrl,
   if (series.categoryId != null) 'category_id': series.categoryId,
+  // Decoded via Series.fromXtream, which reads `category_ids` natively.
+  if (series.categoryIds.isNotEmpty) 'category_ids': series.categoryIds,
   if (series.plot != null) 'plot': series.plot,
   if (series.rating != null) 'rating': series.rating,
   if (series.tmdbId != null) 'tmdb_id': series.tmdbId,
@@ -266,6 +270,10 @@ bool _asBool(Object? value) {
   final text = '$value'.trim().toLowerCase();
   return text == '1' || text == 'true' || text == 'yes';
 }
+
+List<String> _stringList(Object? value) => value is List
+    ? value.map(_nullableString).whereType<String>().toList(growable: false)
+    : const <String>[];
 
 String? _nullableString(Object? value) {
   if (value == null) return null;

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -125,6 +125,7 @@ class VodItem {
     required this.containerExtension,
     this.logoUrl,
     this.categoryId,
+    this.categoryIds = const [],
     this.rating,
   });
 
@@ -134,7 +135,17 @@ class VodItem {
   final String containerExtension;
   final String? logoUrl;
   final String? categoryId;
+
+  /// Extra category memberships from the Xtream `category_ids` array.
+  /// m3u-editor's dynamic TMDB categories (Trending, Top Genre, …) overlap
+  /// the regular group, so an item can belong to several categories at once
+  /// while [categoryId] stays the primary group.
+  final List<String> categoryIds;
+
   final double? rating;
+
+  bool isInCategory(String categoryId) =>
+      this.categoryId == categoryId || categoryIds.contains(categoryId);
 
   factory VodItem.fromXtream(Map<String, Object?> json, String streamUrl) =>
       VodItem(
@@ -144,6 +155,7 @@ class VodItem {
         containerExtension: '${json['container_extension'] ?? 'mp4'}',
         logoUrl: _asNullableString(json['stream_icon']),
         categoryId: _asNullableString(json['category_id']),
+        categoryIds: _asStringList(json['category_ids']),
         rating: _asDoubleOrNull(json['rating']),
       );
 }
@@ -240,6 +252,7 @@ class Series {
     this.coverUrl,
     this.backdropUrl,
     this.categoryId,
+    this.categoryIds = const [],
     this.plot,
     this.rating,
     this.tmdbId,
@@ -250,9 +263,17 @@ class Series {
   final String? coverUrl;
   final String? backdropUrl;
   final String? categoryId;
+
+  /// Extra category memberships from the Xtream `category_ids` array — see
+  /// [VodItem.categoryIds].
+  final List<String> categoryIds;
+
   final String? plot;
   final double? rating;
   final int? tmdbId;
+
+  bool isInCategory(String categoryId) =>
+      this.categoryId == categoryId || categoryIds.contains(categoryId);
 
   factory Series.fromXtream(Map<String, Object?> json) => Series(
     id: _asInt(json['series_id']),
@@ -260,6 +281,7 @@ class Series {
     coverUrl: _asNullableString(json['cover']),
     backdropUrl: _asNullableString(_firstListItem(json['backdrop_path'])),
     categoryId: _asNullableString(json['category_id']),
+    categoryIds: _asStringList(json['category_ids']),
     plot: _asNullableString(json['plot']),
     rating: _asDoubleOrNull(json['rating'] ?? json['rating_5based']),
     tmdbId: _asIntOrNull(json['tmdb_id'] ?? json['tmdb']),
@@ -1376,6 +1398,10 @@ String? _asNullableString(Object? value) {
   if (value is num) return '$value';
   return null;
 }
+
+List<String> _asStringList(Object? value) => _asList(
+  value,
+).map(_asNullableString).whereType<String>().toList(growable: false);
 
 Map<String, Object?> _asMap(Object? value) {
   if (value is Map<String, Object?>) return value;

--- a/flutter_client/test/services/cache_service_test.dart
+++ b/flutter_client/test/services/cache_service_test.dart
@@ -26,6 +26,7 @@ void main() {
           coverUrl: 'https://img/cover.jpg',
           backdropUrl: 'https://img/backdrop.jpg',
           categoryId: '7',
+          categoryIds: ['7', '900000002'],
           plot: 'A plot.',
           rating: 4.3,
           tmdbId: 99123,
@@ -43,9 +44,38 @@ void main() {
       expect(series.coverUrl, 'https://img/cover.jpg');
       expect(series.backdropUrl, 'https://img/backdrop.jpg');
       expect(series.categoryId, '7');
+      expect(series.categoryIds, <String>['7', '900000002']);
       expect(series.plot, 'A plot.');
       expect(series.rating, 4.3);
       expect(series.tmdbId, 99123);
+    },
+  );
+
+  test(
+    'vod overlapping category_ids survive a persist + cold hydrate round trip',
+    () async {
+      final store = await newStore('m3u-tv-vod-cache-roundtrip-');
+      final source = CacheService(store: store);
+      final original = <VodItem>[
+        const VodItem(
+          id: 7,
+          name: 'Flow',
+          streamUrl: 'http://example.com/7.mp4',
+          containerExtension: 'mp4',
+          categoryId: '357',
+          categoryIds: ['357', '900000001'],
+          rating: 4.1,
+        ),
+      ];
+      await source.set<List<VodItem>>('vodStreams', original);
+
+      final hydrated = CacheService(store: store);
+      final entry = await hydrated.get<List<VodItem>>('vodStreams');
+      final item = entry!.data.single;
+
+      expect(item.categoryId, '357');
+      expect(item.categoryIds, <String>['357', '900000001']);
+      expect(item.isInCategory('900000001'), isTrue);
     },
   );
 

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -298,4 +298,50 @@ void main() {
       },
     );
   });
+
+  group('overlapping category_ids (dynamic TMDB categories)', () {
+    test('VodItem.fromXtream parses category_ids and matches membership', () {
+      final item = VodItem.fromXtream(<String, Object?>{
+        'stream_id': 1,
+        'name': 'Flow',
+        'category_id': '357',
+        // m3u-editor emits ints here; the model must stringify them.
+        'category_ids': <Object?>[357, 900000001],
+      }, 'http://example.com/1.mp4');
+
+      expect(item.categoryId, '357');
+      expect(item.categoryIds, <String>['357', '900000001']);
+      expect(item.isInCategory('357'), isTrue);
+      expect(item.isInCategory('900000001'), isTrue);
+      expect(item.isInCategory('999'), isFalse);
+    });
+
+    test('VodItem.isInCategory falls back to categoryId when the '
+        'category_ids array is absent', () {
+      final item = VodItem.fromXtream(<String, Object?>{
+        'stream_id': 1,
+        'name': 'Flow',
+        'category_id': '357',
+      }, 'http://example.com/1.mp4');
+
+      expect(item.categoryIds, isEmpty);
+      expect(item.isInCategory('357'), isTrue);
+      expect(item.isInCategory('900000001'), isFalse);
+    });
+
+    test('Series.fromXtream parses category_ids and matches membership', () {
+      final series = Series.fromXtream(<String, Object?>{
+        'series_id': 2,
+        'name': 'Hot Show',
+        'category_id': '30',
+        'category_ids': <Object?>[30, 900000002],
+      });
+
+      expect(series.categoryId, '30');
+      expect(series.categoryIds, <String>['30', '900000002']);
+      expect(series.isInCategory('30'), isTrue);
+      expect(series.isInCategory('900000002'), isTrue);
+      expect(series.isInCategory('999'), isFalse);
+    });
+  });
 }

--- a/flutter_client/test/ui/features/series_screen_test.dart
+++ b/flutter_client/test/ui/features/series_screen_test.dart
@@ -105,6 +105,38 @@ void main() {
       expect(find.text('Breaking Bad'), findsOneWidget);
     });
 
+    testWidgets(
+      'dynamic category tab filters series by overlapping category_ids',
+      (tester) async {
+        // See the matching VodScreen test — dynamic TMDB categories overlap
+        // the regular category, carried via categoryIds.
+        final seriesList = [
+          const Series(
+            id: 1,
+            name: 'Breaking Bad',
+            categoryId: '30',
+            categoryIds: ['30', '900000002'],
+          ),
+          const Series(id: 2, name: 'Firefly', categoryId: '30'),
+        ];
+        final categories = [
+          const Category(id: '900000002', name: 'Trending Shows'),
+          const Category(id: '30', name: 'Thriller'),
+        ];
+
+        await tester.pumpWidget(
+          _TestApp(seriesList: seriesList, categories: categories),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Trending Shows'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Breaking Bad'), findsOneWidget);
+        expect(find.text('Firefly'), findsNothing);
+      },
+    );
+
     testWidgets('shows loading indicator only when there is nothing to show', (
       tester,
     ) async {

--- a/flutter_client/test/ui/features/vod_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_screen_test.dart
@@ -138,6 +138,47 @@ void main() {
       expect(find.text('Tears of Steel'), findsOneWidget);
     });
 
+    testWidgets(
+      'dynamic category tab filters movies by overlapping category_ids',
+      (tester) async {
+        // m3u-editor's dynamic TMDB categories overlap the regular groups:
+        // a member keeps its primary categoryId and additionally carries the
+        // dynamic category id in categoryIds.
+        final items = [
+          const VodItem(
+            id: 1,
+            name: 'Big Buck Bunny',
+            streamUrl: 'http://example.com/1.mp4',
+            containerExtension: 'mp4',
+            categoryId: '20',
+            categoryIds: ['20', '900000001'],
+          ),
+          const VodItem(
+            id: 2,
+            name: 'Sintel',
+            streamUrl: 'http://example.com/2.mp4',
+            containerExtension: 'mp4',
+            categoryId: '20',
+          ),
+        ];
+        final categories = [
+          const Category(id: '900000001', name: 'Trending Now'),
+          const Category(id: '20', name: 'Action'),
+        ];
+
+        await tester.pumpWidget(
+          _TestApp(vodItems: items, categories: categories),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Trending Now'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Big Buck Bunny'), findsOneWidget);
+        expect(find.text('Sintel'), findsNothing);
+      },
+    );
+
     testWidgets('shows loading indicator only when there is nothing to show', (
       tester,
     ) async {


### PR DESCRIPTION
## Problem

m3u-editor's new per-playlist dynamic TMDB categories (Trending, Popular, Top Genre, by Network, by Streaming Service) appear as VOD/series category tabs, but the tabs render empty.

Dynamic categories overlap the regular groups, so a member stream keeps its primary `category_id` and additionally carries the dynamic category id in the Xtream `category_ids` array. The app fetches the full VOD/series lists once and buckets client-side by the single primary id only — `category_ids` was never parsed anywhere — so nothing ever matched a dynamic tab.

(Server counterpart: m3u-editor now stamps dynamic membership into `category_ids` in the full `get_vod_streams` / `get_series` listings.)

## Changes

- **`VodItem` / `Series`**: parse `category_ids` (ints stringified to match `Category.id`) and expose `isInCategory()`, which falls back to the primary id so items from older caches keep working. `Channel` untouched — dynamic categories are VOD/series only.
- **VOD/series screens**: category tabs filter via `isInCategory()`, and tab badge counts include overlapping memberships (primary id skipped to avoid double-counting).
- **`cache_service`**: persists and rehydrates `category_ids` so offline-loaded catalogs keep dynamic membership (VOD decode is hand-rolled; series decodes through `Series.fromXtream`).

## Tests

- `domain_models_test`: `fromXtream` parses int `category_ids` → strings; `isInCategory` matches primary + extras; absent array falls back to primary.
- `cache_service_test`: `categoryIds` survives persist + cold hydrate for both VOD and series.
- `vod_screen_test` / `series_screen_test`: tapping a dynamic category tab shows only members carrying that id.

## Validation

- `dart format --set-exit-if-changed lib test` → 0 changed
- `flutter analyze lib test` → no issues
- Targeted tests → 65/65 passed; `flutter test test/ui/` → 419 passed, 7 skipped, 0 failed
- Verified end-to-end against a dev m3u-editor: a 24-member "Top Family" dynamic category now populates from the full listing (previously 0)