### PR TITLE
feat(series): inline season card row with per-season poster artwork

### DIFF
--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -262,6 +262,18 @@
       }
     }
   },
+  "seriesSeasonPillLabel": "Staffel {season} · {count, plural, =0{keine Folgen} =1{1 Folge} other{{count} Folgen}}",
+  "@seriesSeasonPillLabel": {
+    "description": "Compact label for the season selector pill on the Series Details screen, e.g. 'Staffel 3 · 12 Folgen'.",
+    "placeholders": {
+      "season": {
+        "type": "int"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "traktWatchHistory": "Wiedergabeverlauf",
   "traktWatchHistorySubtitle": "Synchronisiere deinen Wiedergabeverlauf mit Trakt, um den Fortschritt über Apps und Dienste hinweg zu verfolgen.",
   "traktNotConfigured": "Trakt-Client-Anmeldedaten sind nicht konfiguriert.",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -262,6 +262,18 @@
       }
     }
   },
+  "seriesSeasonPillLabel": "Season {season} · {count, plural, =0{no episodes} =1{1 episode} other{{count} episodes}}",
+  "@seriesSeasonPillLabel": {
+    "description": "Compact label for the season selector pill on the Series Details screen, e.g. 'Season 3 · 12 episodes'.",
+    "placeholders": {
+      "season": {
+        "type": "int"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "traktWatchHistory": "Watch History",
   "traktWatchHistorySubtitle": "Sync your watch history with Trakt to track progress across apps and services.",
   "traktNotConfigured": "Trakt client credentials are not configured.",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -262,6 +262,18 @@
       }
     }
   },
+  "seriesSeasonPillLabel": "Temporada {season} · {count, plural, =0{sin episodios} =1{1 episodio} other{{count} episodios}}",
+  "@seriesSeasonPillLabel": {
+    "description": "Compact label for the season selector pill on the Series Details screen, e.g. 'Temporada 3 · 12 episodios'.",
+    "placeholders": {
+      "season": {
+        "type": "int"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "traktWatchHistory": "Historial de visionado",
   "traktWatchHistorySubtitle": "Sincroniza tu historial de visionado con Trakt para seguir el progreso entre apps y servicios.",
   "traktNotConfigured": "Las credenciales del cliente Trakt no están configuradas.",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -262,6 +262,18 @@
       }
     }
   },
+  "seriesSeasonPillLabel": "Saison {season} · {count, plural, =0{aucun épisode} =1{1 épisode} other{{count} épisodes}}",
+  "@seriesSeasonPillLabel": {
+    "description": "Compact label for the season selector pill on the Series Details screen, e.g. 'Saison 3 · 12 épisodes'.",
+    "placeholders": {
+      "season": {
+        "type": "int"
+      },
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "traktWatchHistory": "Historique de visionnage",
   "traktWatchHistorySubtitle": "Synchronisez votre historique de visionnage avec Trakt pour suivre votre progression sur toutes les applications et services.",
   "traktNotConfigured": "Les identifiants du client Trakt ne sont pas configurés.",

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -1,434 +1,1676 @@
-{
-  "@@locale": "zh",
-  "navHome": "主页",
-  "navSearch": "搜索",
-  "navLiveTv": "直播电视",
-  "navVod": "电影",
-  "navSeries": "剧集",
-  "navDvr": "录像",
-  "navRequests": "请求",
-  "navNotifications": "通知",
-  "navSettings": "设置",
-  "navMore": "更多",
-  "notificationsDesktopOpen": "打开",
-  "appBackToExit": "再次按返回键退出",
-  "appRecordingScheduled": "录制已安排：{title}",
-  "@appRecordingScheduled": {
-    "placeholders": {
-      "title": {
-        "type": "String"
-      }
-    }
-  },
-  "appRecordingFailed": "无法安排录制：{error}",
-  "@appRecordingFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "appNotConfigured": "请在设置中连接您的服务",
-  "cancel": "取消",
-  "disconnect": "断开连接",
-  "unknown": "未知",
-  "admin": "管理员",
-  "liveTvSearchHint": "搜索直播电视…",
-  "liveTvNoChannels": "暂无可用频道",
-  "liveTvAllChannels": "全部频道",
-  "liveTvFavorites": "★ 收藏",
-  "liveTvNoProgram": "暂无节目信息",
-  "liveTvNext": "下一个",
-  "liveTvRecord": "录制",
-  "liveTvRecording": "录制中",
-  "liveTvFavorite": "收藏",
-  "liveTvRemoveFavorite": "取消收藏",
-  "catchupBadgeAvailable": "可回看",
-  "catchupBadgeAvailableDays": "可回看 {days} 天",
-  "@catchupBadgeAvailableDays": {
-    "placeholders": {
-      "days": {
-        "type": "int"
-      }
-    }
-  },
-  "catchupProgramReplayable": "可回看重播",
-  "epgPreviousDay": "前一天",
-  "epgNow": "现在",
-  "epgNextDay": "后一天",
-  "epgChannels": "频道",
-  "epgNoData": "暂无 EPG 数据",
-  "playerGoBack": "返回",
-  "playerResumeWatching": "继续观看",
-  "playerContinue": "继续",
-  "playerFromTime": "从 {time} 开始",
-  "@playerFromTime": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "playerStartFromBeginning": "从头开始",
-  "playerResume": "恢复播放",
-  "playerSkipPreviousTooltip": "上一个频道",
-  "playerSkipNextTooltip": "下一个频道",
-  "playerNowPlayingMovie": "电影",
-  "playerNowPlayingSeries": "剧集",
-  "playerNowPlayingSeasonEpisode": "第{season}季 · 第{episode}集",
-  "@playerNowPlayingSeasonEpisode": {
-    "placeholders": {
-      "season": {
-        "type": "int"
-      },
-      "episode": {
-        "type": "int"
-      }
-    }
-  },
-  "playerCommercialSkipped": "已跳过广告",
-  "playerSkipCommercial": "跳过广告",
-  "searchHint": "搜索直播电视、电影和剧集…",
-  "searchSectionLiveTv": "直播电视",
-  "searchSectionMovies": "电影",
-  "searchSectionSeries": "剧集",
-  "vodSearchHint": "搜索电影…",
-  "seriesSearchHint": "搜索剧集…",
-  "settingsTitle": "设置",
-  "settingsGeneral": "通用",
-  "settingsIntegrations": "集成",
-  "settingsLanguage": "语言",
-  "settingsLanguageSystem": "系统语言",
-  "settingsLangEnglish": "英语",
-  "settingsLangGerman": "德语",
-  "settingsLangSpanish": "西班牙语",
-  "settingsLangFrench": "法语",
-  "settingsLangChinese": "中文（简体）",
-  "settingsConnection": "连接",
-  "settingsStatusConnected": "已连接",
-  "settingsStatusUnavailable": "不可用",
-  "settingsStatusLabel": "状态",
-  "settingsSourceLabel": "来源",
-  "settingsServerTimezone": "服务器时区",
-  "settingsLastError": "最近错误",
-  "settingsRetryConnection": "重试连接",
-  "settingsEditServer": "编辑服务器设置",
-  "settingsActiveViewer": "当前用户",
-  "settingsClearCacheTitle": "清除缓存并刷新？",
-  "settingsClearCacheBody": "所有缓存内容将被清除并从您的来源重新加载。",
-  "settingsClearCacheConfirm": "清除并刷新",
-  "settingsCacheCleared": "缓存已清除 — 内容正在后台刷新。",
-  "settingsAccount": "账户",
-  "settingsProxyPlayback": "代理播放",
-  "settingsProxyPlaybackSubtitle": "通过 m3u-editor 代理播放，并可为此设备选择转码配置。",
-  "settingsProxyUse": "使用代理",
-  "settingsProxyForced": "代理已在播放列表级别启用，无法关闭。",
-  "settingsProxyLiveProfile": "直播转码配置",
-  "settingsProxyVodProfile": "点播和剧集转码配置",
-  "settingsProxyProfileDefault": "默认",
-  "settingsProxyProfileDirect": "直连（不转码）",
-  "settingsProxyNoProfiles": "没有可用的转码配置——将使用直连代理播放。",
-  "settingsDvr": "DVR",
-  "settingsDvrSubtitle": "录制内容播放设置。",
-  "settingsComskip": "广告跳过",
-  "settingsComskipSubtitle": "控制播放器在录制内容中检测到广告时的处理方式。",
-  "settingsComskipAutoSkip": "自动跳过广告",
-  "settingsDisconnectTitle": "断开连接？",
-  "settingsDisconnectBody": "您将被退出登录，需要重新输入凭据才能重新连接。",
-  "settingsDisconnectConfirm": "断开连接",
-  "settingsApp": "应用",
-  "settingsAppVersion": "版本",
-  "settingsAppUpdateStatus": "更新",
-  "settingsAppVersionChecking": "正在检查更新…",
-  "settingsAppUpToDate": "已是最新版本",
-  "settingsAppUpdateAvailable": "有可用更新：{version}",
-  "@settingsAppUpdateAvailable": {
-    "placeholders": {
-      "version": {
-        "type": "String"
-      }
-    }
-  },
-  "settingsAppViewRelease": "查看版本",
-  "settingsAppScanQr": "扫描以在手机上打开",
-  "settingsFillAllFields": "请填写所有字段",
-  "settingsConnectionSettings": "连接设置",
-  "settingsConnectionSettingsSubtitle": "输入您的 Xtream Codes 信息",
-  "settingsServerUrl": "服务器地址",
-  "settingsUsername": "用户名",
-  "settingsPassword": "密码",
-  "settingsConnect": "连接",
-  "settingsPairWithCode": "使用代码配对",
-  "settingsTabPair": "配对",
-  "settingsTabSignIn": "登录",
-  "settingsPairTabSubtitle": "输入您的服务器地址，然后使用代码配对此电视。",
-  "pairingEnterServerFirst": "请先输入您的服务器地址",
-  "pairingErrorGeneric": "配对失败或代码已过期，请重试。",
-  "pairingScanQr": "扫描以在手机上打开配对页面",
-  "pairingOpenBrowser": "在浏览器中打开",
-  "pairingPendingGoTo": "在您的手机或电脑上，访问：",
-  "pairingPendingEnterCode": "然后输入此代码：",
-  "pairingPendingWaiting": "等待批准…",
-  "settingsContentCache": "内容缓存",
-  "settingsCacheSubtitle": "缓存内容即时加载，数据在后台自动刷新。",
-  "settingsEpgRefreshInterval": "EPG 刷新间隔",
-  "settingsEpgDurationMinutes": "{count} 分钟",
-  "@settingsEpgDurationMinutes": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsEpgDurationHour": "1 小时",
-  "settingsEpgDurationHours": "{count} 小时",
-  "@settingsEpgDurationHours": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "settingsManageViewers": "管理用户",
-  "settingsAddViewer": "添加新用户",
-  "settingsSwitchViewer": "切换用户",
-  "settingsViewerNameLabel": "用户名称",
-  "settingsCreate": "创建",
-  "homeContinueWatching": "继续观看",
-  "homeNoContinueWatching": "暂无可继续观看的内容",
-  "homeNoLiveTv": "暂无直播电视",
-  "homeFavoriteChannels": "收藏频道",
-  "homeNoFavoriteChannels": "暂无收藏频道",
-  "homeNoMovies": "暂无电影",
-  "homeLiveChannel": "直播频道",
-  "homeMovie": "电影",
-  "notificationsTitle": "通知",
-  "notificationsTabNotifications": "通知",
-  "notificationsTabChannelSettings": "频道设置",
-  "notificationsMarkAllRead": "全部标为已读",
-  "notificationsEmpty": "暂无通知",
-  "notificationsEmptyFiltered": "订阅频道暂无通知",
-  "notificationsChannelSubscriptions": "频道订阅",
-  "notificationsChannelSubtitle": "选择您希望接收的频道。全部不选则接收所有通知。",
-  "notificationsAllChannels": "全部频道",
-  "notificationsNoChannels": "暂无频道 — 收到通知后将在此显示。",
-  "notificationsJustNow": "刚刚",
-  "notificationsMinutesAgo": "{count}分钟前",
-  "@notificationsMinutesAgo": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "notificationsHoursAgo": "{count}小时前",
-  "@notificationsHoursAgo": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "notificationsDaysAgo": "{count}天前",
-  "@notificationsDaysAgo": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "notificationsReceivedAt": "收到 {time}",
-  "@notificationsReceivedAt": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "notificationsReadAt": "已读 {time}",
-  "@notificationsReadAt": {
-    "placeholders": {
-      "time": {
-        "type": "String"
-      }
-    }
-  },
-  "homeNoSeries": "暂无剧集",
-  "homeSeason": "第{number}季",
-  "@homeSeason": {
-    "placeholders": {
-      "number": {
-        "type": "int"
-      }
-    }
-  },
-  "traktWatchHistory": "观看历史",
-  "traktWatchHistorySubtitle": "将您的观看历史与 Trakt 同步，在各应用和服务间追踪进度。",
-  "traktNotConfigured": "Trakt 客户端凭据未配置。",
-  "traktNotConfiguredHint": "在 trakt.tv/oauth/applications 注册应用，并在构建时通过 --dart-define 设置 client ID 和 secret。",
-  "traktConnectPrompt": "连接您的 Trakt 账户，自动记录您的观看内容。",
-  "traktConnectButton": "连接 Trakt",
-  "traktScanQr": "扫描以在手机上打开",
-  "traktOpenBrowser": "在浏览器中打开",
-  "traktPendingGoTo": "在您的手机或电脑上，访问：",
-  "traktPendingEnterCode": "然后输入此代码：",
-  "traktPendingWaiting": "等待授权…",
-  "traktConnected": "已连接到 Trakt",
-  "traktDisconnectButton": "断开 Trakt",
-  "vodAllMovies": "全部电影",
-  "seriesAllSeries": "全部剧集",
-  "homeConnectedSource": "已连接来源：{label}",
-  "@homeConnectedSource": {
-    "placeholders": {
-      "label": {
-        "type": "String"
-      }
-    }
-  },
-  "searchTypeToSearch": "输入以搜索",
-  "vodPlayMovie": "播放电影",
-  "vodContinueMovie": "继续播放",
-  "navAioStreams": "AIOStreams",
-  "aiostreamsGetStreams": "获取播放源",
-  "aiostreamsLoadingStreams": "正在加载播放源…",
-  "aiostreamsNoStreams": "未找到播放源",
-  "aiostreamsSelectStream": "选择播放源",
-  "aiostreamsLoadMore": "加载更多",
-  "aiostreamsSearchHint": "搜索电影和剧集…",
-  "aiostrreamsCatalogEmpty": "暂无内容",
-  "aiostreamsToggleFavorite": "收藏",
-  "aiostreamsMyFavorites": "我的收藏",
-  "aiostreamsContinueWatching": "继续观看",
-  "aiostreamsSearch": "搜索 AIOStreams",
-  "aiostreamsSearchResults": "搜索结果",
-  "aiostreamsNoResults": "未找到结果",
-  "aiostreamsSearchAll": "全部",
-  "requestsTitle": "请求",
-  "requestsTabSearch": "搜索",
-  "requestsTabMyRequests": "我的请求",
-  "requestsSearchHint": "搜索电影和剧集…",
-  "requestsNoResults": "未找到结果",
-  "requestsAlreadyAvailable": "已可观看",
-  "requestsAlreadyRequested": "已请求",
-  "requestsRequestButton": "请求",
-  "requestsSeasonsHeading": "季",
-  "requestsSeasonSpecials": "特别篇",
-  "requestsSelectAllSeasons": "全选",
-  "requestsClearSeasons": "清除",
-  "requestsSubmitted": "已请求“{title}”",
-  "@requestsSubmitted": {
-    "placeholders": {
-      "title": {
-        "type": "String"
-      }
-    }
-  },
-  "requestsSubmittedPendingApproval": "“{title}”已提交等待批准",
-  "@requestsSubmittedPendingApproval": {
-    "placeholders": {
-      "title": {
-        "type": "String"
-      }
-    }
-  },
-  "requestsSubmitFailed": "无法请求“{title}”：{error}",
-  "@requestsSubmitFailed": {
-    "placeholders": {
-      "title": {
-        "type": "String"
-      },
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "requestsMyRequestsEmpty": "您还没有请求过任何内容",
-  "requestsDismiss": "移除",
-  "requestsDismissFailed": "无法移除请求：{error}",
-  "@requestsDismissFailed": {
-    "placeholders": {
-      "error": {
-        "type": "String"
-      }
-    }
-  },
-  "requestsStatusPendingApproval": "待批准",
-  "requestsStatusApproved": "已批准",
-  "requestsStatusRejected": "已拒绝",
-  "requestsStatusCompleted": "已完成",
-  "requestsStatusUnknown": "未知",
-  "dvrRecordingsTitle": "DVR 录制",
-  "dvrRecordingsSubtitle": "已完成的录制和正在录制的节目",
-  "dvrNoRecordings": "没有可用的 DVR 录制",
-  "dvrNotConfigured": "请在设置中连接到您的服务",
-  "dvrCancel": "取消",
-  "dvrDelete": "删除",
-  "dvrStopTitle": "停止录制 — {title}",
-  "@dvrStopTitle": {
-    "placeholders": {
-      "title": {
-        "type": "String"
-      }
-    }
-  },
-  "dvrStopMessage": "保留在录制列表中，还是立即删除？",
-  "dvrStopKeep": "保留录制",
-  "dvrStopDelete": "删除录制",
-  "dvrStopBack": "返回",
-  "dvrCancelSuccess": "录制已取消",
-  "dvrCancelFailed": "无法取消录制",
-  "dvrDeleteTitle": "删除录制？",
-  "dvrDeleteMessage": "此录制将被永久删除。",
-  "dvrDeleteDismiss": "保留",
-  "dvrDeleteConfirm": "删除录制",
-  "dvrDeleteSuccess": "录制已删除",
-  "dvrDeleteFailed": "无法删除录制",
-  "liveTvStopRecording": "停止录制",
-  "playerRecordNowTooltip": "录制当前节目",
-  "playerStopRecordingTooltip": "停止录制",
-  "dvrMoreActions": "更多操作",
-  "dvrPlay": "播放",
-  "dvrSelect": "选择",
-  "dvrStop": "停止",
-  "dvrStatusRecording": "正在录制",
-  "dvrStatusScheduled": "已计划",
-  "dvrStatusFailed": "失败",
-  "dvrExitSelection": "退出选择",
-  "dvrSelectedCount": "{count, plural, =0{未选择任何项目} other{已选择 {count} 项}}",
-  "@dvrSelectedCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
-  },
-  "dvrStorageTitle": "DVR 存储",
-  "dvrStorageUnlimited": "无限",
-  "dvrStorageUsedUnlimited": "已使用 {used}",
-  "@dvrStorageUsedUnlimited": {
-    "placeholders": {
-      "used": {
-        "type": "String"
-      }
-    }
-  },
-  "dvrStorageUsedWithQuota": "已使用 {used}，共 {quota}",
-  "@dvrStorageUsedWithQuota": {
-    "placeholders": {
-      "used": {
-        "type": "String"
-      },
-      "quota": {
-        "type": "String"
-      }
-    }
-  },
-  "dvrStorageRecordingCount": "{count} 个录制",
-  "@dvrStorageRecordingCount": {
-    "placeholders": {
-      "count": {
-        "type": "int"
-      }
-    }
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:intl/intl.dart' as intl;
+
+import 'app_localizations_de.dart';
+import 'app_localizations_en.dart';
+import 'app_localizations_es.dart';
+import 'app_localizations_fr.dart';
+import 'app_localizations_zh.dart';
+
+// ignore_for_file: type=lint
+
+/// Callers can lookup localized strings with an instance of AppLocalizations
+/// returned by `AppLocalizations.of(context)`.
+///
+/// Applications need to include `AppLocalizations.delegate()` in their app's
+/// `localizationDelegates` list, and the locales they support in the app's
+/// `supportedLocales` list. For example:
+///
+/// ```dart
+/// import 'l10n/app_localizations.dart';
+///
+/// return MaterialApp(
+///   localizationsDelegates: AppLocalizations.localizationsDelegates,
+///   supportedLocales: AppLocalizations.supportedLocales,
+///   home: MyApplicationHome(),
+/// );
+/// ```
+///
+/// ## Update pubspec.yaml
+///
+/// Please make sure to update your pubspec.yaml to include the following
+/// packages:
+///
+/// ```yaml
+/// dependencies:
+///   # Internationalization support.
+///   flutter_localizations:
+///     sdk: flutter
+///   intl: any # Use the pinned version from flutter_localizations
+///
+///   # Rest of dependencies
+/// ```
+///
+/// ## iOS Applications
+///
+/// iOS applications define key application metadata, including supported
+/// locales, in an Info.plist file that is built into the application bundle.
+/// To configure the locales supported by your app, you’ll need to edit this
+/// file.
+///
+/// First, open your project’s ios/Runner.xcworkspace Xcode workspace file.
+/// Then, in the Project Navigator, open the Info.plist file under the Runner
+/// project’s Runner folder.
+///
+/// Next, select the Information Property List item, select Add Item from the
+/// Editor menu, then select Localizations from the pop-up menu.
+///
+/// Select and expand the newly-created Localizations item then, for each
+/// locale your application supports, add a new item and select the locale
+/// you wish to add from the pop-up menu in the Value field. This list should
+/// be consistent with the languages listed in the AppLocalizations.supportedLocales
+/// property.
+abstract class AppLocalizations {
+  AppLocalizations(String locale)
+    : localeName = intl.Intl.canonicalizedLocale(locale.toString());
+
+  final String localeName;
+
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
   }
+
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// A list of this localizations delegate along with the default localizations
+  /// delegates.
+  ///
+  /// Returns a list of localizations delegates containing this delegate along with
+  /// GlobalMaterialLocalizations.delegate, GlobalCupertinoLocalizations.delegate,
+  /// and GlobalWidgetsLocalizations.delegate.
+  ///
+  /// Additional delegates can be added by appending to this list in
+  /// MaterialApp. This list does not have to be used at all if a custom list
+  /// of delegates is preferred or required.
+  static const List<LocalizationsDelegate<dynamic>> localizationsDelegates =
+      <LocalizationsDelegate<dynamic>>[
+        delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ];
+
+  /// A list of this localizations delegate's supported locales.
+  static const List<Locale> supportedLocales = <Locale>[
+    Locale('de'),
+    Locale('en'),
+    Locale('es'),
+    Locale('fr'),
+    Locale('zh'),
+  ];
+
+  /// No description provided for @navHome.
+  ///
+  /// In en, this message translates to:
+  /// **'Home'**
+  String get navHome;
+
+  /// No description provided for @navSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get navSearch;
+
+  /// No description provided for @navLiveTv.
+  ///
+  /// In en, this message translates to:
+  /// **'Live TV'**
+  String get navLiveTv;
+
+  /// No description provided for @navVod.
+  ///
+  /// In en, this message translates to:
+  /// **'Movies'**
+  String get navVod;
+
+  /// No description provided for @navSeries.
+  ///
+  /// In en, this message translates to:
+  /// **'Series'**
+  String get navSeries;
+
+  /// No description provided for @navDvr.
+  ///
+  /// In en, this message translates to:
+  /// **'DVR'**
+  String get navDvr;
+
+  /// No description provided for @navRequests.
+  ///
+  /// In en, this message translates to:
+  /// **'Requests'**
+  String get navRequests;
+
+  /// No description provided for @navNotifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get navNotifications;
+
+  /// No description provided for @navSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get navSettings;
+
+  /// No description provided for @navMore.
+  ///
+  /// In en, this message translates to:
+  /// **'More'**
+  String get navMore;
+
+  /// No description provided for @notificationsDesktopOpen.
+  ///
+  /// In en, this message translates to:
+  /// **'Open'**
+  String get notificationsDesktopOpen;
+
+  /// No description provided for @appBackToExit.
+  ///
+  /// In en, this message translates to:
+  /// **'Press back again to exit'**
+  String get appBackToExit;
+
+  /// No description provided for @appRecordingScheduled.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording scheduled: {title}'**
+  String appRecordingScheduled(String title);
+
+  /// No description provided for @appRecordingFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not schedule recording: {error}'**
+  String appRecordingFailed(String error);
+
+  /// No description provided for @appNotConfigured.
+  ///
+  /// In en, this message translates to:
+  /// **'Please connect to your service in Settings'**
+  String get appNotConfigured;
+
+  /// No description provided for @cancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get cancel;
+
+  /// No description provided for @disconnect.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect'**
+  String get disconnect;
+
+  /// No description provided for @unknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get unknown;
+
+  /// No description provided for @admin.
+  ///
+  /// In en, this message translates to:
+  /// **'Admin'**
+  String get admin;
+
+  /// No description provided for @liveTvSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search live TV...'**
+  String get liveTvSearchHint;
+
+  /// No description provided for @liveTvNoChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'No channels available'**
+  String get liveTvNoChannels;
+
+  /// No description provided for @liveTvAllChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'All Channels'**
+  String get liveTvAllChannels;
+
+  /// No description provided for @liveTvFavorites.
+  ///
+  /// In en, this message translates to:
+  /// **'★ Favorites'**
+  String get liveTvFavorites;
+
+  /// No description provided for @liveTvNoProgram.
+  ///
+  /// In en, this message translates to:
+  /// **'No program info'**
+  String get liveTvNoProgram;
+
+  /// No description provided for @liveTvNext.
+  ///
+  /// In en, this message translates to:
+  /// **'NEXT'**
+  String get liveTvNext;
+
+  /// No description provided for @liveTvRecord.
+  ///
+  /// In en, this message translates to:
+  /// **'Record'**
+  String get liveTvRecord;
+
+  /// No description provided for @liveTvRecording.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording'**
+  String get liveTvRecording;
+
+  /// No description provided for @liveTvFavorite.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite'**
+  String get liveTvFavorite;
+
+  /// No description provided for @liveTvRemoveFavorite.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove favorite'**
+  String get liveTvRemoveFavorite;
+
+  /// No description provided for @catchupBadgeAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Catchup available'**
+  String get catchupBadgeAvailable;
+
+  /// No description provided for @catchupBadgeAvailableDays.
+  ///
+  /// In en, this message translates to:
+  /// **'Catchup available: {days}d'**
+  String catchupBadgeAvailableDays(int days);
+
+  /// No description provided for @catchupProgramReplayable.
+  ///
+  /// In en, this message translates to:
+  /// **'Catchup replay available'**
+  String get catchupProgramReplayable;
+
+  /// No description provided for @epgPreviousDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Previous day'**
+  String get epgPreviousDay;
+
+  /// No description provided for @epgNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Now'**
+  String get epgNow;
+
+  /// No description provided for @epgNextDay.
+  ///
+  /// In en, this message translates to:
+  /// **'Next day'**
+  String get epgNextDay;
+
+  /// No description provided for @epgChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'CHANNELS'**
+  String get epgChannels;
+
+  /// No description provided for @epgNoData.
+  ///
+  /// In en, this message translates to:
+  /// **'No EPG data'**
+  String get epgNoData;
+
+  /// No description provided for @playerGoBack.
+  ///
+  /// In en, this message translates to:
+  /// **'Go back'**
+  String get playerGoBack;
+
+  /// No description provided for @playerResumeWatching.
+  ///
+  /// In en, this message translates to:
+  /// **'Resume Watching'**
+  String get playerResumeWatching;
+
+  /// No description provided for @playerContinue.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue'**
+  String get playerContinue;
+
+  /// No description provided for @playerFromTime.
+  ///
+  /// In en, this message translates to:
+  /// **'From {time}'**
+  String playerFromTime(String time);
+
+  /// No description provided for @playerStartFromBeginning.
+  ///
+  /// In en, this message translates to:
+  /// **'Start from Beginning'**
+  String get playerStartFromBeginning;
+
+  /// No description provided for @playerResume.
+  ///
+  /// In en, this message translates to:
+  /// **'Resume'**
+  String get playerResume;
+
+  /// No description provided for @playerSkipPreviousTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Previous channel'**
+  String get playerSkipPreviousTooltip;
+
+  /// No description provided for @playerSkipNextTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Next channel'**
+  String get playerSkipNextTooltip;
+
+  /// No description provided for @playerNowPlayingMovie.
+  ///
+  /// In en, this message translates to:
+  /// **'Movie'**
+  String get playerNowPlayingMovie;
+
+  /// No description provided for @playerNowPlayingSeries.
+  ///
+  /// In en, this message translates to:
+  /// **'Series'**
+  String get playerNowPlayingSeries;
+
+  /// No description provided for @playerNowPlayingSeasonEpisode.
+  ///
+  /// In en, this message translates to:
+  /// **'S{season} · E{episode}'**
+  String playerNowPlayingSeasonEpisode(int season, int episode);
+
+  /// No description provided for @playerCommercialSkipped.
+  ///
+  /// In en, this message translates to:
+  /// **'Skipped commercial'**
+  String get playerCommercialSkipped;
+
+  /// No description provided for @playerSkipCommercial.
+  ///
+  /// In en, this message translates to:
+  /// **'Skip commercial'**
+  String get playerSkipCommercial;
+
+  /// No description provided for @searchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search live TV, movies, and series...'**
+  String get searchHint;
+
+  /// No description provided for @searchSectionLiveTv.
+  ///
+  /// In en, this message translates to:
+  /// **'Live TV'**
+  String get searchSectionLiveTv;
+
+  /// No description provided for @searchSectionMovies.
+  ///
+  /// In en, this message translates to:
+  /// **'Movies'**
+  String get searchSectionMovies;
+
+  /// No description provided for @searchSectionSeries.
+  ///
+  /// In en, this message translates to:
+  /// **'Series'**
+  String get searchSectionSeries;
+
+  /// No description provided for @vodSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search movies...'**
+  String get vodSearchHint;
+
+  /// No description provided for @seriesSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search series...'**
+  String get seriesSearchHint;
+
+  /// No description provided for @settingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings'**
+  String get settingsTitle;
+
+  /// No description provided for @settingsGeneral.
+  ///
+  /// In en, this message translates to:
+  /// **'General'**
+  String get settingsGeneral;
+
+  /// No description provided for @settingsIntegrations.
+  ///
+  /// In en, this message translates to:
+  /// **'Integrations'**
+  String get settingsIntegrations;
+
+  /// No description provided for @settingsLanguage.
+  ///
+  /// In en, this message translates to:
+  /// **'Language'**
+  String get settingsLanguage;
+
+  /// No description provided for @settingsLanguageSystem.
+  ///
+  /// In en, this message translates to:
+  /// **'System language'**
+  String get settingsLanguageSystem;
+
+  /// No description provided for @settingsLangEnglish.
+  ///
+  /// In en, this message translates to:
+  /// **'English'**
+  String get settingsLangEnglish;
+
+  /// No description provided for @settingsLangGerman.
+  ///
+  /// In en, this message translates to:
+  /// **'German'**
+  String get settingsLangGerman;
+
+  /// No description provided for @settingsLangSpanish.
+  ///
+  /// In en, this message translates to:
+  /// **'Spanish'**
+  String get settingsLangSpanish;
+
+  /// No description provided for @settingsLangFrench.
+  ///
+  /// In en, this message translates to:
+  /// **'French'**
+  String get settingsLangFrench;
+
+  /// No description provided for @settingsLangChinese.
+  ///
+  /// In en, this message translates to:
+  /// **'Chinese (Simplified)'**
+  String get settingsLangChinese;
+
+  /// No description provided for @settingsConnection.
+  ///
+  /// In en, this message translates to:
+  /// **'Connection'**
+  String get settingsConnection;
+
+  /// No description provided for @settingsStatusConnected.
+  ///
+  /// In en, this message translates to:
+  /// **'Connected'**
+  String get settingsStatusConnected;
+
+  /// No description provided for @settingsStatusUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Unavailable'**
+  String get settingsStatusUnavailable;
+
+  /// No description provided for @settingsStatusLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Status'**
+  String get settingsStatusLabel;
+
+  /// No description provided for @settingsSourceLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Source'**
+  String get settingsSourceLabel;
+
+  /// No description provided for @settingsServerTimezone.
+  ///
+  /// In en, this message translates to:
+  /// **'Server Timezone'**
+  String get settingsServerTimezone;
+
+  /// No description provided for @settingsLastError.
+  ///
+  /// In en, this message translates to:
+  /// **'Last error'**
+  String get settingsLastError;
+
+  /// No description provided for @settingsRetryConnection.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry connection'**
+  String get settingsRetryConnection;
+
+  /// No description provided for @settingsEditServer.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit server settings'**
+  String get settingsEditServer;
+
+  /// No description provided for @settingsActiveViewer.
+  ///
+  /// In en, this message translates to:
+  /// **'Active Viewer'**
+  String get settingsActiveViewer;
+
+  /// No description provided for @settingsClearCacheTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear Cache & Refresh?'**
+  String get settingsClearCacheTitle;
+
+  /// No description provided for @settingsClearCacheBody.
+  ///
+  /// In en, this message translates to:
+  /// **'All cached content will be cleared and reloaded from your source.'**
+  String get settingsClearCacheBody;
+
+  /// No description provided for @settingsClearCacheConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear & Refresh'**
+  String get settingsClearCacheConfirm;
+
+  /// No description provided for @settingsCacheCleared.
+  ///
+  /// In en, this message translates to:
+  /// **'Cache cleared — content is refreshing in the background.'**
+  String get settingsCacheCleared;
+
+  /// No description provided for @settingsContentCache.
+  ///
+  /// In en, this message translates to:
+  /// **'Content Cache'**
+  String get settingsContentCache;
+
+  /// No description provided for @settingsCacheSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Cached content loads instantly. Data refreshes automatically in the background.'**
+  String get settingsCacheSubtitle;
+
+  /// No description provided for @settingsEpgRefreshInterval.
+  ///
+  /// In en, this message translates to:
+  /// **'EPG refresh interval'**
+  String get settingsEpgRefreshInterval;
+
+  /// No description provided for @settingsEpgDurationMinutes.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} min'**
+  String settingsEpgDurationMinutes(int count);
+
+  /// No description provided for @settingsEpgDurationHour.
+  ///
+  /// In en, this message translates to:
+  /// **'1 hour'**
+  String get settingsEpgDurationHour;
+
+  /// No description provided for @settingsEpgDurationHours.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} hours'**
+  String settingsEpgDurationHours(int count);
+
+  /// No description provided for @settingsManageViewers.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage Viewers'**
+  String get settingsManageViewers;
+
+  /// No description provided for @settingsAddViewer.
+  ///
+  /// In en, this message translates to:
+  /// **'Add New Viewer'**
+  String get settingsAddViewer;
+
+  /// No description provided for @settingsSwitchViewer.
+  ///
+  /// In en, this message translates to:
+  /// **'Switch Viewer'**
+  String get settingsSwitchViewer;
+
+  /// No description provided for @settingsViewerNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Viewer name'**
+  String get settingsViewerNameLabel;
+
+  /// No description provided for @settingsCreate.
+  ///
+  /// In en, this message translates to:
+  /// **'Create'**
+  String get settingsCreate;
+
+  /// No description provided for @settingsAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'Account'**
+  String get settingsAccount;
+
+  /// No description provided for @settingsProxyPlayback.
+  ///
+  /// In en, this message translates to:
+  /// **'Proxy Playback'**
+  String get settingsProxyPlayback;
+
+  /// No description provided for @settingsProxyPlaybackSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Stream through the m3u-editor proxy with an optional transcoding profile for this device.'**
+  String get settingsProxyPlaybackSubtitle;
+
+  /// No description provided for @settingsProxyUse.
+  ///
+  /// In en, this message translates to:
+  /// **'Use proxy'**
+  String get settingsProxyUse;
+
+  /// No description provided for @settingsProxyForced.
+  ///
+  /// In en, this message translates to:
+  /// **'The proxy is enabled at the playlist level and cannot be turned off.'**
+  String get settingsProxyForced;
+
+  /// No description provided for @settingsProxyLiveProfile.
+  ///
+  /// In en, this message translates to:
+  /// **'Live transcoding profile'**
+  String get settingsProxyLiveProfile;
+
+  /// No description provided for @settingsProxyVodProfile.
+  ///
+  /// In en, this message translates to:
+  /// **'VOD & Series transcoding profile'**
+  String get settingsProxyVodProfile;
+
+  /// No description provided for @settingsProxyProfileDefault.
+  ///
+  /// In en, this message translates to:
+  /// **'Default'**
+  String get settingsProxyProfileDefault;
+
+  /// No description provided for @settingsProxyProfileDirect.
+  ///
+  /// In en, this message translates to:
+  /// **'Direct (no transcoding)'**
+  String get settingsProxyProfileDirect;
+
+  /// No description provided for @settingsProxyNoProfiles.
+  ///
+  /// In en, this message translates to:
+  /// **'No transcoding profiles available — streams use the direct proxy.'**
+  String get settingsProxyNoProfiles;
+
+  /// No description provided for @settingsDvr.
+  ///
+  /// In en, this message translates to:
+  /// **'DVR'**
+  String get settingsDvr;
+
+  /// No description provided for @settingsDvrSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Settings for recorded content playback.'**
+  String get settingsDvrSubtitle;
+
+  /// No description provided for @settingsComskip.
+  ///
+  /// In en, this message translates to:
+  /// **'Commercial Skipping'**
+  String get settingsComskip;
+
+  /// No description provided for @settingsComskipSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Controls how the player reacts to commercial breaks detected in DVR recordings.'**
+  String get settingsComskipSubtitle;
+
+  /// No description provided for @settingsComskipAutoSkip.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-skip commercials'**
+  String get settingsComskipAutoSkip;
+
+  /// No description provided for @settingsDisconnectTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect?'**
+  String get settingsDisconnectTitle;
+
+  /// No description provided for @settingsDisconnectBody.
+  ///
+  /// In en, this message translates to:
+  /// **'You will be signed out and will need to re-enter your credentials to reconnect.'**
+  String get settingsDisconnectBody;
+
+  /// No description provided for @settingsDisconnectConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect'**
+  String get settingsDisconnectConfirm;
+
+  /// No description provided for @settingsApp.
+  ///
+  /// In en, this message translates to:
+  /// **'App'**
+  String get settingsApp;
+
+  /// No description provided for @settingsAppVersion.
+  ///
+  /// In en, this message translates to:
+  /// **'Version'**
+  String get settingsAppVersion;
+
+  /// No description provided for @settingsAppUpdateStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Update'**
+  String get settingsAppUpdateStatus;
+
+  /// No description provided for @settingsAppVersionChecking.
+  ///
+  /// In en, this message translates to:
+  /// **'Checking for updates…'**
+  String get settingsAppVersionChecking;
+
+  /// No description provided for @settingsAppUpToDate.
+  ///
+  /// In en, this message translates to:
+  /// **'Up to date'**
+  String get settingsAppUpToDate;
+
+  /// No description provided for @settingsAppUpdateAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Update available: {version}'**
+  String settingsAppUpdateAvailable(String version);
+
+  /// No description provided for @settingsAppViewRelease.
+  ///
+  /// In en, this message translates to:
+  /// **'View release'**
+  String get settingsAppViewRelease;
+
+  /// No description provided for @settingsAppScanQr.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan to open on your phone'**
+  String get settingsAppScanQr;
+
+  /// No description provided for @settingsFillAllFields.
+  ///
+  /// In en, this message translates to:
+  /// **'Please fill in all fields'**
+  String get settingsFillAllFields;
+
+  /// No description provided for @settingsConnectionSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Connection Settings'**
+  String get settingsConnectionSettings;
+
+  /// No description provided for @settingsConnectionSettingsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your Xtream codes details'**
+  String get settingsConnectionSettingsSubtitle;
+
+  /// No description provided for @settingsServerUrl.
+  ///
+  /// In en, this message translates to:
+  /// **'Server URL'**
+  String get settingsServerUrl;
+
+  /// No description provided for @settingsUsername.
+  ///
+  /// In en, this message translates to:
+  /// **'Username'**
+  String get settingsUsername;
+
+  /// No description provided for @settingsPassword.
+  ///
+  /// In en, this message translates to:
+  /// **'Password'**
+  String get settingsPassword;
+
+  /// No description provided for @settingsConnect.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect'**
+  String get settingsConnect;
+
+  /// No description provided for @settingsPairWithCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Pair with code'**
+  String get settingsPairWithCode;
+
+  /// No description provided for @settingsTabPair.
+  ///
+  /// In en, this message translates to:
+  /// **'Pair'**
+  String get settingsTabPair;
+
+  /// No description provided for @settingsTabSignIn.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign In'**
+  String get settingsTabSignIn;
+
+  /// No description provided for @settingsPairTabSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your server address, then pair this TV using a code.'**
+  String get settingsPairTabSubtitle;
+
+  /// No description provided for @pairingEnterServerFirst.
+  ///
+  /// In en, this message translates to:
+  /// **'Enter your server URL first'**
+  String get pairingEnterServerFirst;
+
+  /// No description provided for @pairingErrorGeneric.
+  ///
+  /// In en, this message translates to:
+  /// **'Pairing failed or the code expired. Please try again.'**
+  String get pairingErrorGeneric;
+
+  /// No description provided for @pairingScanQr.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan to open the pairing page on your phone'**
+  String get pairingScanQr;
+
+  /// No description provided for @pairingOpenBrowser.
+  ///
+  /// In en, this message translates to:
+  /// **'Open in browser'**
+  String get pairingOpenBrowser;
+
+  /// No description provided for @pairingPendingGoTo.
+  ///
+  /// In en, this message translates to:
+  /// **'On your phone or computer, go to:'**
+  String get pairingPendingGoTo;
+
+  /// No description provided for @pairingPendingEnterCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Then enter this code:'**
+  String get pairingPendingEnterCode;
+
+  /// No description provided for @pairingPendingWaiting.
+  ///
+  /// In en, this message translates to:
+  /// **'Waiting for approval…'**
+  String get pairingPendingWaiting;
+
+  /// No description provided for @homeContinueWatching.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue Watching'**
+  String get homeContinueWatching;
+
+  /// No description provided for @homeNoContinueWatching.
+  ///
+  /// In en, this message translates to:
+  /// **'No Continue Watching available'**
+  String get homeNoContinueWatching;
+
+  /// No description provided for @homeNoLiveTv.
+  ///
+  /// In en, this message translates to:
+  /// **'No Live TV available'**
+  String get homeNoLiveTv;
+
+  /// No description provided for @homeFavoriteChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite Channels'**
+  String get homeFavoriteChannels;
+
+  /// No description provided for @homeNoFavoriteChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'No favorite channels available'**
+  String get homeNoFavoriteChannels;
+
+  /// No description provided for @homeNoMovies.
+  ///
+  /// In en, this message translates to:
+  /// **'No Movies available'**
+  String get homeNoMovies;
+
+  /// No description provided for @homeLiveChannel.
+  ///
+  /// In en, this message translates to:
+  /// **'Live channel'**
+  String get homeLiveChannel;
+
+  /// No description provided for @homeMovie.
+  ///
+  /// In en, this message translates to:
+  /// **'Movie'**
+  String get homeMovie;
+
+  /// No description provided for @notificationsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get notificationsTitle;
+
+  /// No description provided for @notificationsTabNotifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get notificationsTabNotifications;
+
+  /// No description provided for @notificationsTabChannelSettings.
+  ///
+  /// In en, this message translates to:
+  /// **'Channel Settings'**
+  String get notificationsTabChannelSettings;
+
+  /// No description provided for @notificationsMarkAllRead.
+  ///
+  /// In en, this message translates to:
+  /// **'Mark all read'**
+  String get notificationsMarkAllRead;
+
+  /// No description provided for @notificationsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No notifications yet'**
+  String get notificationsEmpty;
+
+  /// No description provided for @notificationsEmptyFiltered.
+  ///
+  /// In en, this message translates to:
+  /// **'No notifications for your subscribed channels'**
+  String get notificationsEmptyFiltered;
+
+  /// No description provided for @notificationsChannelSubscriptions.
+  ///
+  /// In en, this message translates to:
+  /// **'Channel subscriptions'**
+  String get notificationsChannelSubscriptions;
+
+  /// No description provided for @notificationsChannelSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Select which channels you want to receive. Leave all unselected to receive everything.'**
+  String get notificationsChannelSubtitle;
+
+  /// No description provided for @notificationsAllChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'All channels'**
+  String get notificationsAllChannels;
+
+  /// No description provided for @notificationsNoChannels.
+  ///
+  /// In en, this message translates to:
+  /// **'No channels seen yet — they appear here as notifications arrive.'**
+  String get notificationsNoChannels;
+
+  /// No description provided for @notificationsJustNow.
+  ///
+  /// In en, this message translates to:
+  /// **'just now'**
+  String get notificationsJustNow;
+
+  /// No description provided for @notificationsMinutesAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{count}m ago'**
+  String notificationsMinutesAgo(int count);
+
+  /// No description provided for @notificationsHoursAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{count}h ago'**
+  String notificationsHoursAgo(int count);
+
+  /// No description provided for @notificationsDaysAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{count}d ago'**
+  String notificationsDaysAgo(int count);
+
+  /// No description provided for @notificationsReceivedAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Received {time}'**
+  String notificationsReceivedAt(String time);
+
+  /// No description provided for @notificationsReadAt.
+  ///
+  /// In en, this message translates to:
+  /// **'Read {time}'**
+  String notificationsReadAt(String time);
+
+  /// No description provided for @homeNoSeries.
+  ///
+  /// In en, this message translates to:
+  /// **'No Series available'**
+  String get homeNoSeries;
+
+  /// No description provided for @homeSeason.
+  ///
+  /// In en, this message translates to:
+  /// **'Season {number}'**
+  String homeSeason(int number);
+
+  /// Compact label for the season selector pill on the Series Details screen, e.g. 'Season 3 · 12 episodes'.
+  ///
+  /// In en, this message translates to:
+  /// **'Season {season} · {count, plural, =0{no episodes} =1{1 episode} other{{count} episodes}}'**
+  String seriesSeasonPillLabel(int season, int count);
+
+  /// No description provided for @traktWatchHistory.
+  ///
+  /// In en, this message translates to:
+  /// **'Watch History'**
+  String get traktWatchHistory;
+
+  /// No description provided for @traktWatchHistorySubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Sync your watch history with Trakt to track progress across apps and services.'**
+  String get traktWatchHistorySubtitle;
+
+  /// No description provided for @traktNotConfigured.
+  ///
+  /// In en, this message translates to:
+  /// **'Trakt client credentials are not configured.'**
+  String get traktNotConfigured;
+
+  /// No description provided for @traktNotConfiguredHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Register an app at trakt.tv/oauth/applications and set the client ID and secret via --dart-define at build time.'**
+  String get traktNotConfiguredHint;
+
+  /// No description provided for @traktConnectPrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect your Trakt account to automatically track what you watch.'**
+  String get traktConnectPrompt;
+
+  /// No description provided for @traktConnectButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Connect with Trakt'**
+  String get traktConnectButton;
+
+  /// No description provided for @traktScanQr.
+  ///
+  /// In en, this message translates to:
+  /// **'Scan to open on your phone'**
+  String get traktScanQr;
+
+  /// No description provided for @traktOpenBrowser.
+  ///
+  /// In en, this message translates to:
+  /// **'Open in browser'**
+  String get traktOpenBrowser;
+
+  /// No description provided for @traktPendingGoTo.
+  ///
+  /// In en, this message translates to:
+  /// **'On your phone or computer, go to:'**
+  String get traktPendingGoTo;
+
+  /// No description provided for @traktPendingEnterCode.
+  ///
+  /// In en, this message translates to:
+  /// **'Then enter this code:'**
+  String get traktPendingEnterCode;
+
+  /// No description provided for @traktPendingWaiting.
+  ///
+  /// In en, this message translates to:
+  /// **'Waiting for authorization…'**
+  String get traktPendingWaiting;
+
+  /// No description provided for @traktConnected.
+  ///
+  /// In en, this message translates to:
+  /// **'Connected to Trakt'**
+  String get traktConnected;
+
+  /// No description provided for @traktDisconnectButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Disconnect Trakt'**
+  String get traktDisconnectButton;
+
+  /// No description provided for @vodAllMovies.
+  ///
+  /// In en, this message translates to:
+  /// **'All Movies'**
+  String get vodAllMovies;
+
+  /// No description provided for @seriesAllSeries.
+  ///
+  /// In en, this message translates to:
+  /// **'All Series'**
+  String get seriesAllSeries;
+
+  /// No description provided for @homeConnectedSource.
+  ///
+  /// In en, this message translates to:
+  /// **'Connected source: {label}'**
+  String homeConnectedSource(String label);
+
+  /// No description provided for @searchTypeToSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Type to search'**
+  String get searchTypeToSearch;
+
+  /// No description provided for @vodPlayMovie.
+  ///
+  /// In en, this message translates to:
+  /// **'Play movie'**
+  String get vodPlayMovie;
+
+  /// No description provided for @vodContinueMovie.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue movie'**
+  String get vodContinueMovie;
+
+  /// No description provided for @navAioStreams.
+  ///
+  /// In en, this message translates to:
+  /// **'AIOStreams'**
+  String get navAioStreams;
+
+  /// No description provided for @aiostreamsGetStreams.
+  ///
+  /// In en, this message translates to:
+  /// **'Get Streams'**
+  String get aiostreamsGetStreams;
+
+  /// No description provided for @aiostreamsLoadingStreams.
+  ///
+  /// In en, this message translates to:
+  /// **'Loading streams…'**
+  String get aiostreamsLoadingStreams;
+
+  /// No description provided for @aiostreamsNoStreams.
+  ///
+  /// In en, this message translates to:
+  /// **'No streams found'**
+  String get aiostreamsNoStreams;
+
+  /// No description provided for @aiostreamsSelectStream.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a stream'**
+  String get aiostreamsSelectStream;
+
+  /// No description provided for @aiostreamsLoadMore.
+  ///
+  /// In en, this message translates to:
+  /// **'Load more'**
+  String get aiostreamsLoadMore;
+
+  /// No description provided for @aiostreamsSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search movies & series…'**
+  String get aiostreamsSearchHint;
+
+  /// No description provided for @aiostrreamsCatalogEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing here yet'**
+  String get aiostrreamsCatalogEmpty;
+
+  /// No description provided for @aiostreamsToggleFavorite.
+  ///
+  /// In en, this message translates to:
+  /// **'Favorite'**
+  String get aiostreamsToggleFavorite;
+
+  /// No description provided for @aiostreamsMyFavorites.
+  ///
+  /// In en, this message translates to:
+  /// **'My Favorites'**
+  String get aiostreamsMyFavorites;
+
+  /// No description provided for @aiostreamsContinueWatching.
+  ///
+  /// In en, this message translates to:
+  /// **'Continue Watching'**
+  String get aiostreamsContinueWatching;
+
+  /// No description provided for @aiostreamsSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Search AIOStreams'**
+  String get aiostreamsSearch;
+
+  /// No description provided for @aiostreamsSearchResults.
+  ///
+  /// In en, this message translates to:
+  /// **'Search Results'**
+  String get aiostreamsSearchResults;
+
+  /// No description provided for @aiostreamsNoResults.
+  ///
+  /// In en, this message translates to:
+  /// **'No results found'**
+  String get aiostreamsNoResults;
+
+  /// No description provided for @aiostreamsSearchAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get aiostreamsSearchAll;
+
+  /// No description provided for @requestsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Requests'**
+  String get requestsTitle;
+
+  /// No description provided for @requestsTabSearch.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get requestsTabSearch;
+
+  /// No description provided for @requestsTabMyRequests.
+  ///
+  /// In en, this message translates to:
+  /// **'My Requests'**
+  String get requestsTabMyRequests;
+
+  /// No description provided for @requestsSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search movies & shows…'**
+  String get requestsSearchHint;
+
+  /// No description provided for @requestsNoResults.
+  ///
+  /// In en, this message translates to:
+  /// **'No results found'**
+  String get requestsNoResults;
+
+  /// No description provided for @requestsAlreadyAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Already available'**
+  String get requestsAlreadyAvailable;
+
+  /// No description provided for @requestsAlreadyRequested.
+  ///
+  /// In en, this message translates to:
+  /// **'Already requested'**
+  String get requestsAlreadyRequested;
+
+  /// No description provided for @requestsRequestButton.
+  ///
+  /// In en, this message translates to:
+  /// **'Request'**
+  String get requestsRequestButton;
+
+  /// No description provided for @requestsSeasonsHeading.
+  ///
+  /// In en, this message translates to:
+  /// **'Seasons'**
+  String get requestsSeasonsHeading;
+
+  /// No description provided for @requestsSeasonSpecials.
+  ///
+  /// In en, this message translates to:
+  /// **'Specials'**
+  String get requestsSeasonSpecials;
+
+  /// No description provided for @requestsSelectAllSeasons.
+  ///
+  /// In en, this message translates to:
+  /// **'Select All'**
+  String get requestsSelectAllSeasons;
+
+  /// No description provided for @requestsClearSeasons.
+  ///
+  /// In en, this message translates to:
+  /// **'Clear'**
+  String get requestsClearSeasons;
+
+  /// No description provided for @requestsSubmitted.
+  ///
+  /// In en, this message translates to:
+  /// **'\"{title}\" was requested'**
+  String requestsSubmitted(String title);
+
+  /// No description provided for @requestsSubmittedPendingApproval.
+  ///
+  /// In en, this message translates to:
+  /// **'\"{title}\" was sent for approval'**
+  String requestsSubmittedPendingApproval(String title);
+
+  /// No description provided for @requestsSubmitFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not request \"{title}\": {error}'**
+  String requestsSubmitFailed(String title, String error);
+
+  /// No description provided for @requestsMyRequestsEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'You haven\'t requested anything yet'**
+  String get requestsMyRequestsEmpty;
+
+  /// No description provided for @requestsDismiss.
+  ///
+  /// In en, this message translates to:
+  /// **'Dismiss'**
+  String get requestsDismiss;
+
+  /// No description provided for @requestsDismissFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not dismiss request: {error}'**
+  String requestsDismissFailed(String error);
+
+  /// No description provided for @requestsStatusPendingApproval.
+  ///
+  /// In en, this message translates to:
+  /// **'Pending Approval'**
+  String get requestsStatusPendingApproval;
+
+  /// No description provided for @requestsStatusApproved.
+  ///
+  /// In en, this message translates to:
+  /// **'Approved'**
+  String get requestsStatusApproved;
+
+  /// No description provided for @requestsStatusRejected.
+  ///
+  /// In en, this message translates to:
+  /// **'Rejected'**
+  String get requestsStatusRejected;
+
+  /// No description provided for @requestsStatusCompleted.
+  ///
+  /// In en, this message translates to:
+  /// **'Completed'**
+  String get requestsStatusCompleted;
+
+  /// No description provided for @requestsStatusUnknown.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown'**
+  String get requestsStatusUnknown;
+
+  /// No description provided for @dvrRecordingsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'DVR Recordings'**
+  String get dvrRecordingsTitle;
+
+  /// No description provided for @dvrRecordingsSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Completed recordings and currently recording programmes'**
+  String get dvrRecordingsSubtitle;
+
+  /// No description provided for @dvrNoRecordings.
+  ///
+  /// In en, this message translates to:
+  /// **'No DVR recordings available'**
+  String get dvrNoRecordings;
+
+  /// No description provided for @dvrNotConfigured.
+  ///
+  /// In en, this message translates to:
+  /// **'Please connect to your service in Settings'**
+  String get dvrNotConfigured;
+
+  /// No description provided for @dvrCancel.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel'**
+  String get dvrCancel;
+
+  /// No description provided for @dvrDelete.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete'**
+  String get dvrDelete;
+
+  /// No description provided for @dvrStopTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop recording — {title}'**
+  String dvrStopTitle(String title);
+
+  /// No description provided for @dvrStopMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep it in your recordings list, or delete it now?'**
+  String get dvrStopMessage;
+
+  /// No description provided for @dvrStopKeep.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep recording'**
+  String get dvrStopKeep;
+
+  /// No description provided for @dvrStopDelete.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete recording'**
+  String get dvrStopDelete;
+
+  /// No description provided for @dvrStopBack.
+  ///
+  /// In en, this message translates to:
+  /// **'Back'**
+  String get dvrStopBack;
+
+  /// No description provided for @dvrCancelSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording cancelled'**
+  String get dvrCancelSuccess;
+
+  /// No description provided for @dvrCancelFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not cancel recording'**
+  String get dvrCancelFailed;
+
+  /// No description provided for @dvrDeleteTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete recording?'**
+  String get dvrDeleteTitle;
+
+  /// No description provided for @dvrDeleteMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This recording will be deleted permanently.'**
+  String get dvrDeleteMessage;
+
+  /// No description provided for @dvrDeleteDismiss.
+  ///
+  /// In en, this message translates to:
+  /// **'Keep'**
+  String get dvrDeleteDismiss;
+
+  /// No description provided for @dvrDeleteConfirm.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete recording'**
+  String get dvrDeleteConfirm;
+
+  /// No description provided for @dvrDeleteSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording deleted'**
+  String get dvrDeleteSuccess;
+
+  /// No description provided for @dvrDeleteFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not delete recording'**
+  String get dvrDeleteFailed;
+
+  /// No description provided for @liveTvStopRecording.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop Recording'**
+  String get liveTvStopRecording;
+
+  /// No description provided for @playerRecordNowTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Record current program'**
+  String get playerRecordNowTooltip;
+
+  /// No description provided for @playerStopRecordingTooltip.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop recording'**
+  String get playerStopRecordingTooltip;
+
+  /// No description provided for @dvrMoreActions.
+  ///
+  /// In en, this message translates to:
+  /// **'More actions'**
+  String get dvrMoreActions;
+
+  /// No description provided for @dvrPlay.
+  ///
+  /// In en, this message translates to:
+  /// **'Play'**
+  String get dvrPlay;
+
+  /// No description provided for @dvrSelect.
+  ///
+  /// In en, this message translates to:
+  /// **'Select'**
+  String get dvrSelect;
+
+  /// No description provided for @dvrStop.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop'**
+  String get dvrStop;
+
+  /// No description provided for @dvrStatusRecording.
+  ///
+  /// In en, this message translates to:
+  /// **'Recording'**
+  String get dvrStatusRecording;
+
+  /// No description provided for @dvrStatusScheduled.
+  ///
+  /// In en, this message translates to:
+  /// **'Scheduled'**
+  String get dvrStatusScheduled;
+
+  /// No description provided for @dvrStatusFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Failed'**
+  String get dvrStatusFailed;
+
+  /// No description provided for @dvrExitSelection.
+  ///
+  /// In en, this message translates to:
+  /// **'Exit selection'**
+  String get dvrExitSelection;
+
+  /// No description provided for @dvrSelectedCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No items selected} one{1 item selected} other{{count} items selected}}'**
+  String dvrSelectedCount(int count);
+
+  /// No description provided for @dvrStorageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'DVR Storage'**
+  String get dvrStorageTitle;
+
+  /// No description provided for @dvrStorageUnlimited.
+  ///
+  /// In en, this message translates to:
+  /// **'Unlimited'**
+  String get dvrStorageUnlimited;
+
+  /// No description provided for @dvrStorageUsedUnlimited.
+  ///
+  /// In en, this message translates to:
+  /// **'{used} used'**
+  String dvrStorageUsedUnlimited(String used);
+
+  /// No description provided for @dvrStorageUsedWithQuota.
+  ///
+  /// In en, this message translates to:
+  /// **'{used} of {quota} used'**
+  String dvrStorageUsedWithQuota(String used, String quota);
+
+  /// No description provided for @dvrStorageRecordingCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} recordings'**
+  String dvrStorageRecordingCount(int count);
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  Future<AppLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppLocalizations>(lookupAppLocalizations(locale));
+  }
+
+  @override
+  bool isSupported(Locale locale) =>
+      <String>['de', 'en', 'es', 'fr', 'zh'].contains(locale.languageCode);
+
+  @override
+  bool shouldReload(_AppLocalizationsDelegate old) => false;
+}
+
+AppLocalizations lookupAppLocalizations(Locale locale) {
+  // Lookup logic when only language code is specified.
+  switch (locale.languageCode) {
+    case 'de':
+      return AppLocalizationsDe();
+    case 'en':
+      return AppLocalizationsEn();
+    case 'es':
+      return AppLocalizationsEs();
+    case 'fr':
+      return AppLocalizationsFr();
+    case 'zh':
+      return AppLocalizationsZh();
+  }
+
+  throw FlutterError(
+    'AppLocalizations.delegate failed to load unsupported locale "$locale". This is likely '
+    'an issue with the localizations generation tool. Please file an issue '
+    'on GitHub with a reproducible sample app and the gen-l10n configuration '
+    'that was used.',
+  );
 }

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -264,11 +264,22 @@ class Season {
     required this.number,
     required this.name,
     this.episodeCount = 0,
+    this.coverUrl,
+    this.coverBigUrl,
   });
 
   final int number;
   final String name;
   final int episodeCount;
+
+  /// TMDB poster URL (`w500` size) for this season. The Xtream
+  /// `get_series_info` endpoint already returns it (`cover`), but it may be
+  /// null if TMDB enrichment hasn't run yet or returned no artwork.
+  final String? coverUrl;
+
+  /// TMDB poster URL (`original` size) for this season. Higher resolution
+  /// than [coverUrl] — use for the TV-wide dropdown's large poster thumb.
+  final String? coverBigUrl;
 
   factory Season.fromXtream(Map<String, Object?> json) {
     final number = _asInt(json['season_number']);
@@ -276,6 +287,8 @@ class Season {
       number: number,
       name: '${json['name'] ?? 'Season $number'}',
       episodeCount: _asInt(json['episode_count']),
+      coverUrl: _asNullableString(json['cover']),
+      coverBigUrl: _asNullableString(json['cover_big']),
     );
   }
 }

--- a/flutter_client/lib/shared/season_card_row.dart
+++ b/flutter_client/lib/shared/season_card_row.dart
@@ -1,0 +1,148 @@
+import 'package:dpad/dpad.dart';
+import 'package:flutter/material.dart';
+
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
+import 'package:m3u_tv/shared/gradient_border_effect.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+/// Horizontally scrolling row of season cards for the Series Details
+/// screen. Replaces the old `_SeasonChips` pill row with poster-sized
+/// cards (120×180) — each card shows the season's TMDB poster
+/// thumbnail, name, and episode count. Tapping a card (or D-pad
+/// left/right to it + Enter) selects that season.
+///
+/// All layouts (TV / desktop / mobile) use this same component. There is
+/// no dropdown, no overlay, and no popup — the row is always visible.
+class SeasonCardRow extends StatelessWidget {
+  const SeasonCardRow({
+    super.key,
+    required this.seasons,
+    required this.selectedSeason,
+    required this.onSeasonSelected,
+  });
+
+  final List<Season> seasons;
+  final int? selectedSeason;
+  final ValueChanged<int> onSeasonSelected;
+
+  static const double _cardWidth = 120;
+  static const double _cardHeight = 180;
+  static const double _cardRadius = 8;
+
+  @override
+  Widget build(BuildContext context) {
+    if (seasons.isEmpty) return const SizedBox.shrink();
+    return DpadRegion(
+      memoryKey: 'season-card-row',
+      horizontalEdge: DpadEdgeBehavior.stop,
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(
+          horizontal: MediaBrowsingMetrics.contentPadding,
+          vertical: MediaBrowsingMetrics.itemGap,
+        ),
+        child: Row(
+          children: [
+            for (var i = 0; i < seasons.length; i++) ...[
+              if (i > 0) const SizedBox(width: MediaBrowsingMetrics.itemGap),
+              _SeasonCard(
+                season: seasons[i],
+                isSelected: seasons[i].number == selectedSeason,
+                onTap: () => onSeasonSelected(seasons[i].number),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SeasonCard extends StatelessWidget {
+  const _SeasonCard({
+    required this.season,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  final Season season;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final l = AppLocalizations.of(context);
+    final posterUrl = season.coverBigUrl ?? season.coverUrl;
+
+    return DpadInkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(SeasonCardRow._cardRadius),
+      color: colorScheme.surfaceContainerHigh,
+      effects: [
+        GradientBorderEffect(
+          borderRadius: BorderRadius.circular(SeasonCardRow._cardRadius),
+        ),
+      ],
+      child: SizedBox(
+        width: SeasonCardRow._cardWidth,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ClipRRect(
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(SeasonCardRow._cardRadius),
+              ),
+              child: SizedBox(
+                width: SeasonCardRow._cardWidth,
+                height: SeasonCardRow._cardHeight,
+                child: ResilientMediaImage(
+                  imageUrl: posterUrl,
+                  fallbackIcon: Icons.tv,
+                  borderRadius: 0,
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    l.homeSeason(season.number),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      fontWeight: isSelected
+                          ? FontWeight.bold
+                          : FontWeight.normal,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  if (season.episodeCount > 0) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      l
+                          .seriesSeasonPillLabel(
+                            season.number,
+                            season.episodeCount,
+                          )
+                          .split(' · ')
+                          .last,
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_client/test/services/season_model_test.dart
+++ b/flutter_client/test/services/season_model_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  group('Season.fromXtream', () {
+    test('parses cover and cover_big when present', () {
+      final season = Season.fromXtream(<String, Object?>{
+        'season_number': 3,
+        'name': 'Season 3',
+        'episode_count': 12,
+        'cover': 'https://image.tmdb.org/t/p/w500/abc.jpg',
+        'cover_big': 'https://image.tmdb.org/t/p/original/abc.jpg',
+      });
+      expect(season.number, 3);
+      expect(season.name, 'Season 3');
+      expect(season.episodeCount, 12);
+      expect(season.coverUrl, 'https://image.tmdb.org/t/p/w500/abc.jpg');
+      expect(season.coverBigUrl, 'https://image.tmdb.org/t/p/original/abc.jpg');
+    });
+
+    test('cover fields are null when missing from JSON', () {
+      final season = Season.fromXtream(<String, Object?>{
+        'season_number': 1,
+        'episode_count': 8,
+      });
+      expect(season.coverUrl, isNull);
+      expect(season.coverBigUrl, isNull);
+    });
+
+    test('cover fields are null when JSON values are empty strings', () {
+      final season = Season.fromXtream(<String, Object?>{
+        'season_number': 2,
+        'episode_count': 10,
+        'cover': '',
+        'cover_big': '',
+      });
+      expect(season.coverUrl, isNull);
+      expect(season.coverBigUrl, isNull);
+    });
+
+    test('falls back to "Season N" name when name missing', () {
+      final season = Season.fromXtream(<String, Object?>{
+        'season_number': 5,
+        'episode_count': 6,
+      });
+      expect(season.name, 'Season 5');
+    });
+
+    test('const constructor accepts nullable cover fields', () {
+      const season = Season(number: 1, name: 'Season 1');
+      expect(season.coverUrl, isNull);
+      expect(season.coverBigUrl, isNull);
+      expect(season.episodeCount, 0);
+    });
+  });
+}

--- a/flutter_client/test/ui/features/season_card_row_test.dart
+++ b/flutter_client/test/ui/features/season_card_row_test.dart
@@ -1,0 +1,91 @@
+import 'package:dpad/dpad.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/season_card_row.dart';
+
+Season _s(int number, {int episodes = 0, String? cover}) => Season(
+  number: number,
+  name: 'Season $number',
+  episodeCount: episodes,
+  coverUrl: cover,
+);
+
+Widget _harness({
+  required List<Season> seasons,
+  int? selected,
+  void Function(int)? onSelect,
+}) {
+  return MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Dpad(
+      child: Scaffold(
+        body: SeasonCardRow(
+          seasons: seasons,
+          selectedSeason: selected,
+          onSeasonSelected: onSelect ?? (_) {},
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('SeasonCardRow', () {
+    testWidgets('renders one card per season', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          seasons: [_s(1, episodes: 8), _s(2, episodes: 10)],
+          selected: 1,
+        ),
+      );
+      // Two tappable season cards.
+      final cards = find.byType(InkWell);
+      expect(cards, findsNWidgets(2));
+    });
+
+    testWidgets('empty seasons renders nothing', (tester) async {
+      await tester.pumpWidget(_harness(seasons: const []));
+      expect(find.byType(InkWell), findsNothing);
+    });
+
+    testWidgets(
+      'tapping a card calls onSeasonSelected with that season number',
+      (tester) async {
+        int? selected;
+        await tester.pumpWidget(
+          _harness(
+            seasons: [_s(1, episodes: 8), _s(2, episodes: 10)],
+            onSelect: (n) => selected = n,
+          ),
+        );
+        // Tap the second card.
+        await tester.tap(find.byType(InkWell).at(1));
+        await tester.pump();
+        expect(selected, 2);
+      },
+    );
+
+    testWidgets('selected season name renders in bold', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          seasons: [_s(1, episodes: 8), _s(2, episodes: 10)],
+          selected: 2,
+        ),
+      );
+      // The label for season 2 should be in bold (selected state).
+      final season2Label = find.text('Season 2');
+      expect(season2Label, findsOneWidget);
+      final style = tester.widget<Text>(season2Label).style;
+      expect(style?.fontWeight, FontWeight.bold);
+
+      // Season 1's label should be normal weight.
+      final season1Label = find.text('Season 1');
+      final style1 = tester.widget<Text>(season1Label).style;
+      expect(style1?.fontWeight, isNot(FontWeight.bold));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Per-season poster artwork on the **Series Details** screen, replacing the `_SeasonChips` row with a horizontally-scrolling, d-pad-friendly card row.

### Backend (no changes — backend already emits the data)

`/api/xtream/series/info` `seasons[]` payloads already emit `cover_big` and `cover` per season. We just weren't reading them. No m3u-editor changes in this PR.

### Dart changes (3 commits, all season-only)

| Commit | Purpose |
|---|---|
| `0a1c5d8` feat(models) | `Season.coverUrl` + `Season.coverBigUrl` fields. Null-safe. |
| `b243576` feat(l10n) | `seriesSeasonPillLabel` ICU plural string (5 locales). |
| `8db3a4b` feat(series) | `SeasonCardRow` widget (148 lines, 91 lines of tests). |

### Why this PR is split from the cast redesign

This is the **non-cast half** of the previously-named `feat/cast-redesign` draft PR. Per CJ's instruction ("the only things I want is the dropdown and view behavior between small and large screens and then seperately the casts we were working on"):

- Dropdown + responsive view behavior → already in sparkison/m3u-tv#259 (`feat/up-next-season-refresh`).
- Per-season poster artwork + SeasonCardRow → **this PR**.
- Cast redesign → moved to a separate branch (next PR), see backup at `/tmp/domain_models_r1.dart` and `/tmp/cast-redesign/` for the cast work-in-progress.

### Coverage

- `flutter_client/lib/services/domain_models.dart`: +13 lines (`Season.coverUrl`, `Season.coverBigUrl`, parser)
- `flutter_client/lib/shared/season_card_row.dart`: 148 lines, new
- `flutter_client/test/services/season_model_test.dart`: 56 lines, 5 cases
- `flutter_client/test/ui/features/season_card_row_test.dart`: 91 lines, 4 cases

### Quality gates

- `flutter analyze lib test` → 0 issues
- `flutter test` → all green
- L10n keys added to `app_{en,de,es,fr,zh}.arb` (ICU plural for "Season N • X episodes")

### Test plan

1. Open a series with per-season artwork (e.g. one with TMDB-enriched seasons).
2. The Season Card Row replaces the old `_SeasonChips` row.
3. D-pad left/right scrolls through season cards; enter selects.
4. Focus highlight (gradient border) tracks correctly.

### For sparkison

If you'd like to cherry-pick just the `Season.coverUrl/coverBigUrl` and SeasonCardRow commits (`0a1c5d8` + `b243576` + `8db3a4b`) on top of your PR #259, they're all clean, additive, and orthogonal to your series details rewrite. The l10n additions don't conflict with yours.