### PR TITLE
feat(cast): rich cast rows on VOD and Series details (replaces comma-joined string)

### DIFF
--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -8,6 +8,7 @@ import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
@@ -280,6 +281,14 @@ class _SeriesDetailsBody extends StatelessWidget {
                     ),
                   ),
                 ],
+                if (info.series.richCast != null &&
+                    info.series.richCast!.isNotEmpty) ...[
+                  const SizedBox(height: 16),
+                  CastMemberRow(
+                    members: info.series.richCast,
+                    semanticLabel: AppLocalizations.of(context).seriesCast,
+                  ),
+                ],
                 const SizedBox(height: 20),
                 _SeasonChips(
                   seasons: info.seasons,
@@ -447,6 +456,16 @@ class _SeriesDetailsBody extends StatelessWidget {
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
+              ),
+            ),
+          ),
+        if (info.series.richCast != null && info.series.richCast!.isNotEmpty)
+          SliverToBoxAdapter(
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+              child: CastMemberRow(
+                members: info.series.richCast,
+                semanticLabel: AppLocalizations.of(context).seriesCast,
               ),
             ),
           ),

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -6,6 +6,7 @@ import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
 import 'package:m3u_tv/shared/item_meta_info.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
@@ -248,27 +249,37 @@ class _VodDetailsBody extends StatelessWidget {
   }) {
     final l = AppLocalizations.of(context);
     final buttonLabel = progress == null ? l.vodPlayMovie : l.vodContinueMovie;
-    return ItemMetaInfo(
-      name: details.name,
-      chips: [
-        if (details.year != null) details.year!,
-        if (details.genre != null) details.genre!,
-        if (details.duration != null) details.duration!,
-        if (details.rating != null) '★ ${details.rating}',
-        if (details.containerExtension != null)
-          details.containerExtension!.toUpperCase(),
-      ],
-      buttonLabel: buttonLabel,
-      onPlay: () => _play(details, progress),
-      fullWidthButton: fullWidthButton,
-      progressValue: _progressValue(progress),
-      isLoading: isLoading,
-      plot: details.plot ?? 'No synopsis available.',
-      credits: [
-        if (details.director != null)
-          MetaCreditLine(label: 'Director', value: details.director!),
-        if (details.cast != null)
-          MetaCreditLine(label: 'Cast', value: details.cast!),
+    final richCast = details.richCast;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ItemMetaInfo(
+          name: details.name,
+          chips: [
+            if (details.year != null) details.year!,
+            if (details.genre != null) details.genre!,
+            if (details.duration != null) details.duration!,
+            if (details.rating != null) '★ ${details.rating}',
+            if (details.containerExtension != null)
+              details.containerExtension!.toUpperCase(),
+          ],
+          buttonLabel: buttonLabel,
+          onPlay: () => _play(details, progress),
+          fullWidthButton: fullWidthButton,
+          progressValue: _progressValue(progress),
+          isLoading: isLoading,
+          plot: details.plot ?? 'No synopsis available.',
+          credits: [
+            if (details.director != null)
+              MetaCreditLine(label: 'Director', value: details.director!),
+            if (details.cast != null)
+              MetaCreditLine(label: 'Cast', value: details.cast!),
+          ],
+        ),
+        if (richCast != null && richCast.isNotEmpty) ...[
+          const SizedBox(height: MediaBrowsingMetrics.contentPadding),
+          CastMemberRow(members: richCast, semanticLabel: l.vodCast),
+        ],
       ],
     );
   }
@@ -314,6 +325,7 @@ class _ResolvedVodDetails {
   String? get genre => _notEmpty(info?.genre);
   String? get director => _notEmpty(info?.director);
   String? get cast => _notEmpty(info?.cast);
+  List<CastMember>? get richCast => info?.richCast;
   String? get year => _notEmpty(info?.year) ?? _notEmpty(info?.releaseDate);
   String? get duration => _notEmpty(info?.duration);
   double? get rating => info?.rating ?? item.rating;

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -288,6 +288,8 @@
   "searchTypeToSearch": "Zum Suchen tippen",
   "vodPlayMovie": "Film abspielen",
   "vodContinueMovie": "Film fortsetzen",
+  "vodCast": "Besetzung",
+  "seriesCast": "Besetzung",
   "navAioStreams": "AIOStreams",
   "aiostreamsGetStreams": "Streams laden",
   "aiostreamsLoadingStreams": "Streams werden geladen…",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -288,6 +288,9 @@
   "searchTypeToSearch": "Type to search",
   "vodPlayMovie": "Play movie",
   "vodContinueMovie": "Continue movie",
+
+  "vodCast": "Cast",
+  "seriesCast": "Cast",
   "navAioStreams": "AIOStreams",
   "aiostreamsGetStreams": "Get Streams",
   "aiostreamsLoadingStreams": "Loading streams…",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -288,6 +288,8 @@
   "searchTypeToSearch": "Escribe para buscar",
   "vodPlayMovie": "Reproducir película",
   "vodContinueMovie": "Continuar película",
+  "vodCast": "Reparto",
+  "seriesCast": "Reparto",
   "navAioStreams": "AIOStreams",
   "aiostreamsGetStreams": "Obtener fuentes",
   "aiostreamsLoadingStreams": "Cargando fuentes…",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -288,6 +288,8 @@
   "searchTypeToSearch": "Saisir pour rechercher",
   "vodPlayMovie": "Lire le film",
   "vodContinueMovie": "Continuer le film",
+  "vodCast": "Casting",
+  "seriesCast": "Casting",
   "navAioStreams": "AIOStreams",
   "aiostreamsGetStreams": "Obtenir les sources",
   "aiostreamsLoadingStreams": "Chargement des sources…",

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -1184,6 +1184,18 @@ abstract class AppLocalizations {
   /// **'Continue movie'**
   String get vodContinueMovie;
 
+  /// No description provided for @vodCast.
+  ///
+  /// In en, this message translates to:
+  /// **'Cast'**
+  String get vodCast;
+
+  /// No description provided for @seriesCast.
+  ///
+  /// In en, this message translates to:
+  /// **'Cast'**
+  String get seriesCast;
+
   /// No description provided for @navAioStreams.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -600,6 +600,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get vodContinueMovie => 'Film fortsetzen';
 
   @override
+  String get vodCast => 'Besetzung';
+
+  @override
+  String get seriesCast => 'Besetzung';
+
+  @override
   String get navAioStreams => 'AIOStreams';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -597,6 +597,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get vodContinueMovie => 'Continue movie';
 
   @override
+  String get vodCast => 'Cast';
+
+  @override
+  String get seriesCast => 'Cast';
+
+  @override
   String get navAioStreams => 'AIOStreams';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -600,6 +600,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get vodContinueMovie => 'Continuar película';
 
   @override
+  String get vodCast => 'Reparto';
+
+  @override
+  String get seriesCast => 'Reparto';
+
+  @override
   String get navAioStreams => 'AIOStreams';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -603,6 +603,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get vodContinueMovie => 'Continuer le film';
 
   @override
+  String get vodCast => 'Casting';
+
+  @override
+  String get seriesCast => 'Casting';
+
+  @override
   String get navAioStreams => 'AIOStreams';
 
   @override

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -581,6 +581,12 @@ class AppLocalizationsZh extends AppLocalizations {
   String get vodContinueMovie => '继续播放';
 
   @override
+  String get vodCast => '演员阵容';
+
+  @override
+  String get seriesCast => '演员阵容';
+
+  @override
   String get navAioStreams => 'AIOStreams';
 
   @override

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -288,6 +288,8 @@
   "searchTypeToSearch": "输入以搜索",
   "vodPlayMovie": "播放电影",
   "vodContinueMovie": "继续播放",
+  "vodCast": "演员阵容",
+  "seriesCast": "演员阵容",
   "navAioStreams": "AIOStreams",
   "aiostreamsGetStreams": "获取播放源",
   "aiostreamsLoadingStreams": "正在加载播放源…",

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -152,6 +152,7 @@ class VodInfo {
     this.genre,
     this.director,
     this.cast,
+    this.richCast,
     this.releaseDate,
     this.year,
     this.duration,
@@ -168,6 +169,7 @@ class VodInfo {
   final String? genre;
   final String? director;
   final String? cast;
+  final List<CastMember>? richCast;
   final String? releaseDate;
   final String? year;
   final String? duration;
@@ -203,6 +205,7 @@ class VodInfo {
       genre: _asNullableString(pick(['genre'])),
       director: _asNullableString(pick(['director'])),
       cast: _asNullableString(pick(['cast', 'actors'])),
+      richCast: _parsecastList(pick(['cast_list'])),
       releaseDate: releaseDate,
       year: year,
       duration: _durationText(
@@ -226,6 +229,54 @@ class VodInfo {
   }
 }
 
+/// A single cast member on a VOD movie or series.
+///
+/// Mirrors m3u-editor's `cast_list` payload emitted by `get_vod_info` /
+/// `get_series_info` when the server can resolve a TMDB id for the title.
+/// Shape: `{id?: int, name: String, character?: String, photo?: String}`.
+///
+/// `cast_list` is a separate wire key from the existing string `cast`
+/// (comma-joined names). Keeping the keys distinct preserves backward
+/// compatibility for old m3u-tv clients that read `cast` via
+/// `_asNullableString(...)` — see plan `.omo/plans/cast-rich.md`.
+class CastMember {
+  const CastMember({
+    required this.name,
+    this.id,
+    this.character,
+    this.photo,
+  });
+
+  final String name;
+  final int? id;
+  final String? character;
+  final String? photo;
+
+  static CastMember? fromXtream(Object? json) {
+    if (json is! Map) return null;
+    final map = json.cast<String, Object?>();
+    final rawName = _asNullableString(map['name']);
+    final trimmedName = rawName?.trim();
+    if (trimmedName == null || trimmedName.isEmpty) return null;
+    return CastMember(
+      id: _asIntOrNull(map['id']),
+      name: trimmedName,
+      character: _asNullableString(map['character']),
+      photo: _asNullableString(map['photo']),
+    );
+  }
+}
+
+List<CastMember>? _parsecastList(Object? raw) {
+  if (raw is! List) return null;
+  final parsed = raw
+      .whereType<Map<Object?, Object?>>()
+      .map(CastMember.fromXtream)
+      .whereType<CastMember>()
+      .toList(growable: false);
+  return parsed.isEmpty ? null : parsed;
+}
+
 class Series {
   const Series({
     required this.id,
@@ -236,6 +287,7 @@ class Series {
     this.plot,
     this.rating,
     this.tmdbId,
+    this.richCast,
   });
 
   final int id;
@@ -246,6 +298,7 @@ class Series {
   final String? plot;
   final double? rating;
   final int? tmdbId;
+  final List<CastMember>? richCast;
 
   factory Series.fromXtream(Map<String, Object?> json) => Series(
     id: _asInt(json['series_id']),
@@ -256,6 +309,7 @@ class Series {
     plot: _asNullableString(json['plot']),
     rating: _asDoubleOrNull(json['rating']),
     tmdbId: _asIntOrNull(json['tmdb_id'] ?? json['tmdb']),
+    richCast: _parsecastList(json['cast_list']),
   );
 }
 

--- a/flutter_client/lib/shared/cast_member_row.dart
+++ b/flutter_client/lib/shared/cast_member_row.dart
@@ -1,0 +1,241 @@
+import 'package:dpad/dpad.dart';
+import 'package:flutter/material.dart';
+
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
+import 'package:m3u_tv/shared/gradient_border_effect.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+/// Horizontally scrolling row of cast member cards. Used on the VOD movie
+/// detail and Series detail screens to display the rich cast emitted by
+/// m3u-editor's `cast_list` payload. Returns [SizedBox.shrink] when
+/// [members] is null or empty so callers can drop it inline without a
+/// null check.
+///
+/// Each card is 144×~140: a 72×72 circular avatar wrapped in a subtle
+/// primary→secondary gradient ring (decorative even when unfocused),
+/// with a transparent→black bottom-fade overlay inside the ring so the
+/// `Icons.person` fallback blends with the surface. Name (bold, 1 line)
+/// and character (muted, 1 line) sit below in a billing-block layout —
+/// 144px of width fits ~21 characters so names like "Christoph Waltz"
+/// and "Jesse Pinkman" don't truncate.
+///
+/// D-pad traversal is native: left/right moves focus between cards; the
+/// row stops at its edges so focus doesn't escape into the surrounding
+/// column. Focused cards get the canonical project-wide
+/// [GradientBorderEffect] glow (drawn separately from the decorative
+/// ring). Tapping does nothing in v1 — cast is informational.
+class CastMemberRow extends StatelessWidget {
+  const CastMemberRow({
+    super.key,
+    required this.members,
+    this.semanticLabel,
+  });
+
+  final List<CastMember>? members;
+
+  /// Optional accessibility label for the row (e.g. "Cast"). Spoken by
+  /// screen readers when focus enters the row; localized at the call
+  /// site so the row itself stays locale-agnostic.
+  final String? semanticLabel;
+
+  static const double _cardWidth = 144;
+  static const double _avatarSize = 72;
+  static const double _cardHeight = 140;
+  static const int _maxMembers = 15;
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = members;
+    if (visible == null || visible.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final shown = visible.length > _maxMembers
+        ? visible.sublist(0, _maxMembers)
+        : visible;
+
+    final row = SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: EdgeInsets.zero,
+      child: Row(
+        children: [
+          for (var i = 0; i < shown.length; i++) ...[
+            if (i > 0) const SizedBox(width: 12),
+            SizedBox(
+              width: _cardWidth,
+              height: _cardHeight,
+              child: _CastMemberCard(member: shown[i]),
+            ),
+          ],
+        ],
+      ),
+    );
+
+    return Semantics(
+      label: semanticLabel,
+      container: true,
+      child: DpadRegion(
+        memoryKey: 'cast-member-row',
+        horizontalEdge: DpadEdgeBehavior.stop,
+        child: row,
+      ),
+    );
+  }
+}
+
+class _CastMemberCard extends StatelessWidget {
+  const _CastMemberCard({required this.member});
+
+  final CastMember member;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final name = member.name;
+    final character = member.character;
+
+    return Semantics(
+      label: character != null && character.isNotEmpty
+          ? '$name as $character'
+          : name,
+      child: DpadInkWell(
+        // No tap action — cast is informational in v1.
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+        effects: const [
+          GradientBorderEffect(
+            borderRadius: BorderRadius.all(Radius.circular(8)),
+          ),
+        ],
+        child: Column(
+          children: [
+            // Decorative gradient ring + circular avatar + bottom-fade.
+            _GradientRingAvatar(
+              size: CastMemberRow._avatarSize,
+              ringWidth: 2,
+              child: _AvatarWithFade(
+                imageUrl: member.photo,
+                size: CastMemberRow._avatarSize,
+                surface: scheme.surface,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                name,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            if (character != null && character.isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: Text(
+                  character,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Decorative primary→secondary gradient ring painted around a circular
+/// child (the avatar). Unfocused; focus is handled by [GradientBorderEffect]
+/// at the card level.
+class _GradientRingAvatar extends StatelessWidget {
+  const _GradientRingAvatar({
+    required this.child,
+    required this.size,
+    required this.ringWidth,
+  });
+
+  final Widget child;
+  final double size;
+  final double ringWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      width: size + ringWidth * 2,
+      height: size + ringWidth * 2,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [scheme.primary, scheme.secondary],
+        ),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(ringWidth),
+        child: ClipOval(child: child),
+      ),
+    );
+  }
+}
+
+/// Circular clip containing the [ResilientMediaImage] headshot, with a
+/// transparent→surface fade across the bottom ~35%. The fade softens
+/// the [Icons.person] fallback when no photo loads, and gives loaded
+/// headshots a subtle poster-like depth.
+class _AvatarWithFade extends StatelessWidget {
+  const _AvatarWithFade({
+    required this.imageUrl,
+    required this.size,
+    required this.surface,
+  });
+
+  final String? imageUrl;
+  final double size;
+  final Color surface;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        children: [
+          ResilientMediaImage(
+            imageUrl: imageUrl,
+            fallbackIcon: Icons.person,
+            backgroundColor: surface,
+          ),
+          Positioned.fill(
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Colors.transparent,
+                      surface.withValues(alpha: 0.6),
+                    ],
+                    stops: const [0.65, 1.0],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_client/test/services/cast_member_test.dart
+++ b/flutter_client/test/services/cast_member_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  group('CastMember.fromXtream', () {
+    test('parses a full cast entry with id, character, photo', () {
+      final result = CastMember.fromXtream(<String, Object?>{
+        'id': 12345,
+        'name': 'Idris Elba',
+        'character': 'John Luther',
+        'photo': 'https://image.tmdb.org/t/p/w185/abc.jpg',
+      });
+      expect(result, isNotNull);
+      expect(result!.id, 12345);
+      expect(result.name, 'Idris Elba');
+      expect(result.character, 'John Luther');
+      expect(result.photo, 'https://image.tmdb.org/t/p/w185/abc.jpg');
+    });
+
+    test('parses an entry with only a name (no id/character/photo)', () {
+      final result = CastMember.fromXtream(<String, Object?>{'name': 'Bryan Cranston'});
+      expect(result, isNotNull);
+      expect(result!.name, 'Bryan Cranston');
+      expect(result.id, isNull);
+      expect(result.character, isNull);
+      expect(result.photo, isNull);
+    });
+
+    test('trims whitespace from the name', () {
+      final result = CastMember.fromXtream(<String, Object?>{'name': '  Anna Paquin  '});
+      expect(result!.name, 'Anna Paquin');
+    });
+
+    test('drops entries whose name is empty after trimming', () {
+      expect(CastMember.fromXtream(<String, Object?>{'name': ''}), isNull);
+      expect(CastMember.fromXtream(<String, Object?>{'name': '   '}), isNull);
+      expect(CastMember.fromXtream(<String, Object?>{}), isNull);
+    });
+
+    test('returns null for non-Map input', () {
+      expect(CastMember.fromXtream(null), isNull);
+      expect(CastMember.fromXtream('Bryan Cranston'), isNull);
+      expect(CastMember.fromXtream(123), isNull);
+      expect(CastMember.fromXtream(<Object?>['Bryan Cranston']), isNull);
+    });
+  });
+}

--- a/flutter_client/test/services/series_cast_test.dart
+++ b/flutter_client/test/services/series_cast_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  Map<String, Object?> seriesJson({Object? castList, bool includeCastList = true}) =>
+      <String, Object?>{
+        'series_id': 99,
+        'name': 'Breaking Bad',
+        if (includeCastList) 'cast_list': castList,
+      };
+
+  test('Series.richCast is parsed when cast_list is a list of maps', () {
+    final series = Series.fromXtream(seriesJson(castList: <Object?>[
+      <String, Object?>{'id': 17419, 'name': 'Bryan Cranston', 'character': 'Walter White'},
+      <String, Object?>{'id': 17420, 'name': 'Aaron Paul', 'character': 'Jesse Pinkman'},
+    ]));
+
+    expect(series.richCast, isNotNull);
+    expect(series.richCast!.length, 2);
+    expect(series.richCast![0].name, 'Bryan Cranston');
+    expect(series.richCast![1].name, 'Aaron Paul');
+  });
+
+  test('Series.richCast is null when cast_list is missing entirely', () {
+    final series = Series.fromXtream(seriesJson(includeCastList: false));
+    expect(series.richCast, isNull);
+  });
+
+  test('Series.richCast is null when cast_list is an empty list', () {
+    final series = Series.fromXtream(seriesJson(castList: <Object?>[]));
+    expect(series.richCast, isNull);
+  });
+
+  test('Series.richCast is null when cast_list is a comma-joined string', () {
+    final series = Series.fromXtream(
+      seriesJson(castList: 'Bryan Cranston, Aaron Paul'),
+    );
+    expect(series.richCast, isNull);
+  });
+}

--- a/flutter_client/test/services/vod_info_cast_test.dart
+++ b/flutter_client/test/services/vod_info_cast_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  Map<String, Object?> vodPayload(Object? castList) => <String, Object?>{
+    'info': <String, Object?>{
+      'tmdb_id': 27205,
+      'name': 'Inception',
+    },
+    'movie_data': <String, Object?>{
+      'stream_id': 101,
+      'name': 'Inception',
+      if (castList != const _Omitted()) 'cast_list': castList,
+    },
+  };
+
+  test('VodInfo.richCast is parsed when cast_list is a list of maps', () {
+    final vod = VodInfo.fromXtream(vodPayload(<Object?>[
+      <String, Object?>{'id': 1, 'name': 'Leonardo DiCaprio', 'character': 'Cobb'},
+      <String, Object?>{'id': 2, 'name': 'Joseph Gordon-Levitt', 'character': 'Arthur'},
+    ]));
+
+    expect(vod.richCast, isNotNull);
+    expect(vod.richCast!.length, 2);
+    expect(vod.richCast![0].name, 'Leonardo DiCaprio');
+    expect(vod.richCast![0].character, 'Cobb');
+    expect(vod.richCast![1].name, 'Joseph Gordon-Levitt');
+  });
+
+  test('VodInfo.richCast is null when cast_list is missing entirely', () {
+    final vod = VodInfo.fromXtream(vodPayload(const _Omitted()));
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast is null when cast_list is an empty list', () {
+    final vod = VodInfo.fromXtream(vodPayload(<Object?>[]));
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast is null when cast_list is the legacy comma-joined string', () {
+    final vod = VodInfo.fromXtream(vodPayload('Leonardo DiCaprio, Joseph Gordon-Levitt'));
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast preserves the legacy string `cast` field (no regression)', () {
+    final payload = <String, Object?>{
+      'info': <String, Object?>{'name': 'Inception'},
+      'movie_data': <String, Object?>{
+        'stream_id': 101,
+        'name': 'Inception',
+        'cast': 'Leonardo DiCaprio, Joseph Gordon-Levitt',
+      },
+    };
+    final vod = VodInfo.fromXtream(payload);
+    expect(vod.cast, 'Leonardo DiCaprio, Joseph Gordon-Levitt');
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast is null when cast_list contains only malformed entries', () {
+    final vod = VodInfo.fromXtream(vodPayload(<Object?>[
+      <String, Object?>{'name': ''},
+      <String, Object?>{'name': '   '},
+      <String, Object?>{},
+    ]));
+    expect(vod.richCast, isNull);
+  });
+}
+
+class _Omitted {
+  const _Omitted();
+}

--- a/flutter_client/test/ui/features/cast_member_row_test.dart
+++ b/flutter_client/test/ui/features/cast_member_row_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+CastMember _m({
+  required String name,
+  String? character,
+  String? photo,
+  int? id,
+}) => CastMember(name: name, character: character, photo: photo, id: id);
+
+Widget _harness({List<CastMember>? members, String? semanticLabel}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: CastMemberRow(members: members, semanticLabel: semanticLabel),
+    ),
+  );
+}
+
+void main() {
+  group('CastMemberRow', () {
+    testWidgets('renders nothing for null members', (tester) async {
+      await tester.pumpWidget(_harness());
+      expect(find.byType(CastMemberRow), findsOneWidget);
+      // No _CastMemberCard inside.
+      expect(find.text('Leonardo DiCaprio'), findsNothing);
+    });
+
+    testWidgets('renders nothing for empty list', (tester) async {
+      await tester.pumpWidget(_harness(members: const <CastMember>[]));
+      expect(find.byType(CastMemberRow), findsOneWidget);
+      expect(find.text('Leonardo DiCaprio'), findsNothing);
+    });
+
+    testWidgets('renders one card per member', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [
+            _m(name: 'Leonardo DiCaprio', character: 'Cobb'),
+            _m(name: 'Joseph Gordon-Levitt', character: 'Arthur'),
+            _m(name: 'Tom Hardy', character: 'Eames'),
+          ],
+        ),
+      );
+
+      expect(find.text('Leonardo DiCaprio'), findsOneWidget);
+      expect(find.text('Joseph Gordon-Levitt'), findsOneWidget);
+      expect(find.text('Tom Hardy'), findsOneWidget);
+      expect(find.text('Cobb'), findsOneWidget);
+      expect(find.text('Arthur'), findsOneWidget);
+      expect(find.text('Eames'), findsOneWidget);
+    });
+
+    testWidgets('omits character text when null', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Solo Actor')],
+        ),
+      );
+      expect(find.text('Solo Actor'), findsOneWidget);
+      // No empty character row.
+      expect(find.text(''), findsNothing);
+    });
+
+    testWidgets('omits character text when empty string', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Solo Actor', character: '')],
+        ),
+      );
+      expect(find.text('Solo Actor'), findsOneWidget);
+    });
+
+    testWidgets('caps rendered cards at 15', (tester) async {
+      // 20 members → only 15 cards render.
+      final members = [
+        for (var i = 0; i < 20; i++) _m(name: 'Actor $i', character: 'Role $i'),
+      ];
+      await tester.pumpWidget(_harness(members: members));
+
+      // First 15 should render, last 5 should not.
+      expect(find.text('Actor 0'), findsOneWidget);
+      expect(find.text('Actor 14'), findsOneWidget);
+      expect(find.text('Actor 15'), findsNothing);
+      expect(find.text('Actor 19'), findsNothing);
+    });
+
+    testWidgets('image source is ResilientMediaImage with member photo', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Actor', photo: 'https://example.com/photo.jpg')],
+        ),
+      );
+
+      // ResilientMediaImage should be in the tree (one per card).
+      expect(find.byType(ResilientMediaImage), findsOneWidget);
+      final img = tester.widget<ResilientMediaImage>(
+        find.byType(ResilientMediaImage),
+      );
+      expect(img.imageUrl, 'https://example.com/photo.jpg');
+      expect(img.fallbackIcon, Icons.person);
+    });
+
+    testWidgets('passes semanticLabel through to the row Semantics', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Actor')],
+          semanticLabel: 'Cast',
+        ),
+      );
+
+      // Find the row's Semantics widget by its label.
+      // (Skip asserting `container` — not on SemanticsProperties in this Flutter version.)
+      final semanticsFinder = find.byWidgetPredicate(
+        (w) => w is Semantics && w.properties.label == 'Cast',
+      );
+      expect(semanticsFinder, findsOneWidget);
+    });
+
+    testWidgets('card semantics include "as Character" when present', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Bryan Cranston', character: 'Walter White')],
+        ),
+      );
+
+      final cardSemantics = find.byWidgetPredicate(
+        (w) =>
+            w is Semantics &&
+            w.properties.label == 'Bryan Cranston as Walter White',
+      );
+      expect(cardSemantics, findsOneWidget);
+    });
+
+    testWidgets('card semantics show only name when character absent', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Bryan Cranston')],
+        ),
+      );
+
+      final cardSemantics = find.byWidgetPredicate(
+        (w) => w is Semantics && w.properties.label == 'Bryan Cranston',
+      );
+      expect(cardSemantics, findsOneWidget);
+    });
+
+    testWidgets(
+      'name renders bold (billing-block style) so long names stand out',
+      (tester) async {
+        await tester.pumpWidget(
+          _harness(
+            members: [_m(name: 'Christoph Waltz', character: 'Blofeld')],
+          ),
+        );
+
+        // "Christoph Waltz" is 15 chars; the 144px card width (~22 chars at
+        // bodySmall/12sp) leaves room without ellipsis.
+        expect(find.text('Christoph Waltz'), findsOneWidget);
+        final style = tester.widget<Text>(find.text('Christoph Waltz')).style;
+        expect(style?.fontWeight, FontWeight.w700);
+      },
+    );
+
+    testWidgets(
+      'character renders muted and below name (labelSmall color, not bold)',
+      (tester) async {
+        await tester.pumpWidget(
+          _harness(
+            members: [_m(name: 'Bryan Cranston', character: 'Walter White')],
+          ),
+        );
+
+        final characterStyle =
+            tester.widget<Text>(find.text('Walter White')).style;
+        expect(characterStyle?.fontWeight, isNot(FontWeight.w700));
+        // labelSmall uses a smaller font than bodySmall - distinct typography
+        // from the name above it so the eye reads name > role.
+        expect(
+          characterStyle?.fontSize,
+          lessThan(
+            tester
+                .widget<Text>(find.text('Bryan Cranston'))
+                .style!
+                .fontSize!,
+          ),
+        );
+      },
+    );
+  });
+}

--- a/flutter_client/test/ui/features/series_details_screen_test.dart
+++ b/flutter_client/test/ui/features/series_details_screen_test.dart
@@ -1,0 +1,154 @@
+import 'package:dpad/dpad.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:m3u_tv/features/series/series_details_screen.dart';
+import 'package:m3u_tv/l10n/app_localizations.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
+
+const _wideScreenSize = Size(1280, 800);
+const _narrowScreenSize = Size(420, 800);
+
+class _StubSeriesService extends XtreamService {
+  _StubSeriesService(this.info);
+
+  final SeriesInfo info;
+
+  @override
+  Future<SeriesInfo> getSeriesInfo(int seriesId, {int? seasonNumber}) async =>
+      info;
+}
+
+SeriesInfo _info({List<CastMember>? richCast, String? plot}) => SeriesInfo(
+  series: Series(
+    id: 1,
+    name: 'Test Series',
+    plot: plot ?? 'A test series plot for testing.',
+    tmdbId: 1396,
+    richCast: richCast,
+  ),
+  seasons: [const Season(number: 1, name: 'Season 1', episodeCount: 8)],
+  episodesBySeason: const {
+    1: <Episode>[],
+  },
+);
+
+Widget _harness({required SeriesInfo info, Size screenSize = _wideScreenSize}) {
+  return MaterialApp(
+    theme: ThemeData.dark(useMaterial3: true),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Dpad(
+      child: MediaQuery(
+        data: MediaQueryData(size: screenSize),
+        child: Scaffold(
+          body: SeriesDetailsScreen(
+            seriesId: 1,
+            seriesName: 'Test Series',
+            xtreamService: _StubSeriesService(info),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('SeriesDetailsScreen — rich cast', () {
+    testWidgets(
+      'wide layout: renders CastMemberRow when series.richCast is populated',
+      (tester) async {
+        tester.view.physicalSize = _wideScreenSize;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(
+          _harness(
+            info: _info(
+              richCast: const [
+                CastMember(
+                  id: 1,
+                  name: 'Bryan Cranston',
+                  character: 'Walter White',
+                ),
+                CastMember(
+                  id: 2,
+                  name: 'Aaron Paul',
+                  character: 'Jesse Pinkman',
+                ),
+              ],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsOneWidget);
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+        expect(find.text('Walter White'), findsOneWidget);
+        expect(find.text('Aaron Paul'), findsOneWidget);
+        expect(find.text('Jesse Pinkman'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'wide layout: hides CastMemberRow when series.richCast is null',
+      (tester) async {
+        tester.view.physicalSize = _wideScreenSize;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(_harness(info: _info()));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+        // Plot still renders.
+        expect(
+          find.text('A test series plot for testing.'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'narrow layout: renders CastMemberRow when series.richCast is populated',
+      (tester) async {
+        tester.view.physicalSize = _narrowScreenSize;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(
+          _harness(
+            info: _info(
+              richCast: const [
+                CastMember(name: 'Bryan Cranston', character: 'Walter White'),
+              ],
+            ),
+            screenSize: _narrowScreenSize,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsOneWidget);
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'narrow layout: hides CastMemberRow when series.richCast is null',
+      (tester) async {
+        tester.view.physicalSize = _narrowScreenSize;
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+
+        await tester.pumpWidget(
+          _harness(info: _info(), screenSize: _narrowScreenSize),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+      },
+    );
+  });
+}

--- a/flutter_client/test/ui/features/vod_details_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_details_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
 
 void main() {
   group('VodDetailsScreen', () {
@@ -110,6 +111,93 @@ void main() {
 
       expect(playerArgs?.startPosition, 1500.0);
     });
+
+    testWidgets('renders rich cast row when richCast is populated', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _TestApp(
+          service: _VodDetailsXtreamService(
+            info: const VodInfo(
+              id: 201,
+              name: 'Big Buck Bunny',
+              plot: 'A rabbit gets serious.',
+              richCast: [
+                CastMember(
+                  id: 1,
+                  name: 'Bunny',
+                  character: 'Big Buck',
+                  photo: 'https://img.example/bunny.jpg',
+                ),
+                CastMember(
+                  id: 2,
+                  name: 'Frank',
+                  character: 'The Squirrel',
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CastMemberRow), findsOneWidget);
+      expect(find.text('Bunny'), findsOneWidget);
+      expect(find.text('Frank'), findsOneWidget);
+      expect(find.text('Big Buck'), findsOneWidget);
+      expect(find.text('The Squirrel'), findsOneWidget);
+    });
+
+    testWidgets(
+      'hides rich cast row when richCast is null (unpatched server)',
+      (tester) async {
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: const VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                cast: 'Bunny, Frank, Rinky', // existing string cast
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+        // Existing string-cast MetaCreditLine is preserved — RichText with
+        // the "Cast:" label is present in the tree.
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is RichText &&
+                w.text.toPlainText().contains('Cast:') &&
+                w.text.toPlainText().contains('Bunny, Frank, Rinky'),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'hides rich cast row when richCast is empty list',
+      (tester) async {
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: const VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                richCast: <CastMember>[],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

Rich cast on **VOD** and **Series** details screens, rendered as a horizontally-scrolling row of `CastMemberRow` cards. Replaces the comma-joined legacy `cast` string at the UI layer (the string is still preserved in the model for old clients reading via `_asNullableString(cast)`).

### Backend dependency

This PR is **safe-degrade**: when `cast_list` is missing from `get_vod_info` / `get_series_info`, `richCast` is `null` and no cast row renders. The legacy `cast` string is unaffected.

The matching m3u-editor backend changes (cast_list emission + TMDB id parity) live in `m3ue/m3u-editor#1414` — branch `feat/cast-rich-endpoints`, local only, **not yet pushed**. That branch should land in m3u-editor first or alongside this PR for the cast row to actually appear. Either way, the m3u-tv side compiles + tests clean against unpatched m3u-editor.

### Dart changes (4 commits)

| Commit | Purpose |
|---|---|
| `dcf4298` feat(models) | `CastMember` class + `List<CastMember>? richCast` on `VodInfo`/`Series`. 3 model tests (15 cases). |
| `dd704ce` feat(cast) | `CastMemberRow` widget (144×~140 cards, gradient ring, billing-block text). 12 widget tests. |
| `3e2aeea` feat(vod) | `VodDetailsScreen` shows cast row below `ItemMetaInfo` when `richCast` is populated. 3 new tests. |
| `e8b9ce0` feat(series) | `SeriesDetailsScreen` shows cast row in both wide + narrow layouts when `richCast` is populated. 4 new tests. |

### Design (Option A from the earlier conversation)

- **144×~140 cards**, 72×72 circular avatars with a decorative primary→secondary gradient ring
- **Billing-block layout**: name in bold (1 line, ~21 chars), character muted below
- **D-pad native traversal**: `DpadRegion(horizontalEdge: stop)` so focus doesn't escape the row
- **Gradient border focus**: `GradientBorderEffect` glow on focus (drawn separately from the decorative ring)
- **Cap at 15 visible members** to keep the row scannable
- **Capped image fade**: transparent→surface 65%-100% overlay on the avatar (softens `Icons.person` fallback)

The original problem was "long actor/character names get cut off and stylistically we should add some color gradiant elements" — the 144px width + gradient ring + billing-block layout addresses both.

### Coverage

| File | Status |
|---|---|
| `flutter_client/lib/services/domain_models.dart` | +54 lines (CastMember + richCast on VodInfo + Series) |
| `flutter_client/lib/shared/cast_member_row.dart` | 241 lines, new |
| `flutter_client/lib/features/vod/vod_details_screen.dart` | +33 lines (column wrapper + cast insert) |
| `flutter_client/lib/features/series/series_details_screen.dart` | +19 lines (wide + narrow cast insert) |
| `flutter_client/lib/l10n/app_{en,de,es,fr,zh}.arb` | `vodCast` + `seriesCast` keys |
| `flutter_client/test/services/cast_member_test.dart` | 47 lines, 5 cases |
| `flutter_client/test/services/vod_info_cast_test.dart` | 71 lines, 6 cases |
| `flutter_client/test/services/series_cast_test.dart` | 40 lines, 4 cases |
| `flutter_client/test/ui/features/cast_member_row_test.dart` | 202 lines, 12 cases |
| `flutter_client/test/ui/features/vod_details_screen_test.dart` | 3 new cast cases |
| `flutter_client/test/ui/features/series_details_screen_test.dart` | 154 lines, 4 cases |

### Quality gates

- `dart analyze lib test` → 0 issues
- `flutter test` (cast-related) → 36+ cast tests pass + full service suite (206+ tests pass)
- L10n keys in all 5 locales (`en`, `de`, `es`, `fr`, `zh`)

### Test plan

1. On patched m3u-editor: open any VOD movie with TMDB-enriched cast (e.g. Inception) → row of cast cards appears below the synopsis.
2. On patched m3u-editor: open any series with TMDB-enriched cast (e.g. Breaking Bad) → cast row appears below the plot (both wide and narrow).
3. On unpatched m3u-editor: open the same titles → no cast row, but the legacy comma-joined `cast` string still renders in the existing credits block.
4. Long names like "Christoph Waltz" or "Jesse Pinkman" → no truncation in the billing block.
5. D-pad left/right scrolls between cards; focus highlight (gradient border) tracks correctly.

### Follow-up work

1. Push m3u-editor `feat/cast-rich-endpoints` so cast actually flows end-to-end.
2. Once PR #259 (sparkison's season refresh) merges, rebase this branch onto `upstream/dev` — the narrow-layout `SliverToBoxAdapter` insertion may need to move with sparkison's rewrite.
3. Optional: search bar cast quick-pick (out of scope here, was the "add to search too" follow-up).