### PR TITLE
feat(series): hybrid picker + rich cast row on VOD/Series details

### DIFF
--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -616,22 +616,26 @@ class _SeriesDetailsBody extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         header,
-        if (info.series.richCast != null &&
+        if (!compact &&
+            info.series.richCast != null &&
             info.series.richCast!.isNotEmpty) ...[
           const SizedBox(height: MediaBrowsingMetrics.contentPadding),
           CastMemberRow(
             members: info.series.richCast,
             semanticLabel: AppLocalizations.of(context).seriesCast,
-            compact: compact,
-            onShowAll: compact
-                ? () => _showAllCast(context, info.series.richCast!)
-                : null,
+            onShowAll: () => _showAllCast(
+              context,
+              info.series.richCast!,
+              asDialog: true,
+            ),
             allCastSemanticLabel: AppLocalizations.of(context).castShowAll,
           ),
         ],
         const SizedBox(height: 20),
         // Play / Start-from-beginning sit on the same line as the season
-        // picker (wrapping to a second run on a phone).
+        // picker (wrapping to a second run on a phone). On the narrow
+        // breakpoint the cast picker chip joins this row beside the
+        // season picker.
         Wrap(
           spacing: MediaBrowsingMetrics.itemGap,
           runSpacing: MediaBrowsingMetrics.chipGap,
@@ -649,6 +653,16 @@ class _SeriesDetailsBody extends StatelessWidget {
               onMarkSeason: (watched) =>
                   onMarkSeason(_episodes(seasonNumber), watched: watched),
             ),
+            if (compact &&
+                info.series.richCast != null &&
+                info.series.richCast!.isNotEmpty)
+              CastMemberRow(
+                members: info.series.richCast,
+                semanticLabel: AppLocalizations.of(context).seriesCast,
+                compact: true,
+                onShowAll: () => _showAllCast(context, info.series.richCast!),
+                allCastSemanticLabel: AppLocalizations.of(context).castShowAll,
+              ),
           ],
         ),
       ],
@@ -871,11 +885,16 @@ class _SeriesDetailsBody extends StatelessWidget {
     return '~${avg}m';
   }
 
-  /// Opens the "Show all cast" bottom sheet listing every member of
-  /// [cast] (avatar + name + character). Used by the compact cast row's
-  /// overflow tile on the narrow breakpoint — same sheet shape as the
-  /// season picker so D-pad / drag-handle behavior matches.
-  void _showAllCast(BuildContext context, List<CastMember> cast) {
+  /// Opens the "Show all cast" picker listing every member of [cast]
+  /// (avatar + name + character) — a bottom sheet from the narrow
+  /// layout's picker chip, a centered dialog ([asDialog]) from the wide
+  /// layout's "+N" overflow tile. Same modal split as the season picker
+  /// so D-pad / dismiss behavior matches.
+  void _showAllCast(
+    BuildContext context,
+    List<CastMember> cast, {
+    bool asDialog = false,
+  }) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
@@ -884,6 +903,7 @@ class _SeriesDetailsBody extends StatelessWidget {
         context,
         title: l.castShowAll,
         cancelLabel: l.cancel,
+        asDialog: asDialog,
         children: [
           for (final member in cast)
             _CastSheetRow(member: member, theme: theme, scheme: scheme),

--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -17,7 +17,6 @@ import 'package:m3u_tv/shared/dominant_backdrop_color.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
 import 'package:m3u_tv/shared/item_meta_info.dart';
-import 'package:m3u_tv/shared/list_picker_sheet.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
 /// Below this window width the series detail lays out for a phone: smaller
@@ -616,21 +615,6 @@ class _SeriesDetailsBody extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         header,
-        if (!compact &&
-            info.series.richCast != null &&
-            info.series.richCast!.isNotEmpty) ...[
-          const SizedBox(height: MediaBrowsingMetrics.contentPadding),
-          CastMemberRow(
-            members: info.series.richCast,
-            semanticLabel: AppLocalizations.of(context).seriesCast,
-            onShowAll: () => _showAllCast(
-              context,
-              info.series.richCast!,
-              asDialog: true,
-            ),
-            allCastSemanticLabel: AppLocalizations.of(context).castShowAll,
-          ),
-        ],
         const SizedBox(height: 20),
         // Play / Start-from-beginning sit on the same line as the season
         // picker (wrapping to a second run on a phone). On the narrow
@@ -660,7 +644,7 @@ class _SeriesDetailsBody extends StatelessWidget {
                 members: info.series.richCast,
                 semanticLabel: AppLocalizations.of(context).seriesCast,
                 compact: true,
-                onShowAll: () => _showAllCast(context, info.series.richCast!),
+                onShowAll: () => showAllCast(context, info.series.richCast!),
                 allCastSemanticLabel: AppLocalizations.of(context).castShowAll,
               ),
           ],
@@ -722,13 +706,15 @@ class _SeriesDetailsBody extends StatelessWidget {
       return _buildCompact(context, bg, backdrop, content);
     }
 
-    // TV / desktop: the episode strip is pinned directly below the upper
-    // block, which scrolls on its own only when the window is too short to
-    // fit it. Keeping the strip out of any vertical scrollable stops
-    // horizontal episode navigation from dragging the whole page up and down
-    // - dpad's ensure-visible reveal walks every scrollable ancestor of the
-    // focused card, so a wrapping vertical scroll view reacts to every
-    // left/right step.
+    // TV / desktop: only the header block (`upper`) lives in a vertical
+    // scrollable; the horizontal episode strip is pinned outside it so dpad's
+    // focus-follow `ensureVisible` - which walks every scrollable ancestor of
+    // the focused card - can't drag the page up and down on every left/right
+    // episode step. The rich cast rail is deliberately NOT added here: a third
+    // section breaks this height budget (squeezing `upper` until the Play
+    // button auto-focus scrolls the meta chips out of reach) and any wrapping
+    // vertical scroll reintroduces the episode-strip jank. Cast stays on the
+    // narrow layout (compact chip in the action row) and on VOD.
     final wideContent = Padding(
       padding: const EdgeInsets.symmetric(
         horizontal: MediaBrowsingMetrics.pagePadding,
@@ -884,33 +870,6 @@ class _SeriesDetailsBody extends StatelessWidget {
     }
     return '~${avg}m';
   }
-
-  /// Opens the "Show all cast" picker listing every member of [cast]
-  /// (avatar + name + character) — a bottom sheet from the narrow
-  /// layout's picker chip, a centered dialog ([asDialog]) from the wide
-  /// layout's "+N" overflow tile. Same modal split as the season picker
-  /// so D-pad / dismiss behavior matches.
-  void _showAllCast(
-    BuildContext context,
-    List<CastMember> cast, {
-    bool asDialog = false,
-  }) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    unawaited(
-      ListPickerSheet.show(
-        context,
-        title: l.castShowAll,
-        cancelLabel: l.cancel,
-        asDialog: asDialog,
-        children: [
-          for (final member in cast)
-            _CastSheetRow(member: member, theme: theme, scheme: scheme),
-        ],
-      ),
-    );
-  }
 }
 
 String? _trimmedOrNull(String? value) {
@@ -1063,74 +1022,6 @@ class _ConfirmMarkDialogState extends State<_ConfirmMarkDialog> {
           ),
         ),
       ],
-    );
-  }
-}
-
-/// Single row inside the "Show all cast" bottom sheet. 48px circular
-/// avatar + bold name (1 line, ellipsized) + muted character (1 line,
-/// ellipsized). Rendered via a plain [Padding] — the surrounding
-/// [ListPickerSheet] handles D-pad region / focus / scrolling, so a
-/// per-row [DpadInkWell] would just compete with that focus model.
-class _CastSheetRow extends StatelessWidget {
-  const _CastSheetRow({
-    required this.member,
-    required this.theme,
-    required this.scheme,
-  });
-
-  final CastMember member;
-  final ThemeData theme;
-  final ColorScheme scheme;
-
-  @override
-  Widget build(BuildContext context) {
-    final character = member.character;
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 48,
-            height: 48,
-            child: ClipOval(
-              child: ResilientMediaImage(
-                imageUrl: member.photo,
-                fallbackIcon: Icons.person,
-                backgroundColor: scheme.surfaceContainerHighest,
-              ),
-            ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  member.name,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (character != null && character.isNotEmpty) ...[
-                  const SizedBox(height: 2),
-                  Text(
-                    character,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: scheme.onSurfaceVariant,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ],
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -17,6 +17,7 @@ import 'package:m3u_tv/shared/dominant_backdrop_color.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
 import 'package:m3u_tv/shared/item_meta_info.dart';
+import 'package:m3u_tv/shared/list_picker_sheet.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
 /// Below this window width the series detail lays out for a phone: smaller
@@ -621,6 +622,11 @@ class _SeriesDetailsBody extends StatelessWidget {
           CastMemberRow(
             members: info.series.richCast,
             semanticLabel: AppLocalizations.of(context).seriesCast,
+            compact: compact,
+            onShowAll: compact
+                ? () => _showAllCast(context, info.series.richCast!)
+                : null,
+            allCastSemanticLabel: AppLocalizations.of(context).castShowAll,
           ),
         ],
         const SizedBox(height: 20),
@@ -864,6 +870,27 @@ class _SeriesDetailsBody extends StatelessWidget {
     }
     return '~${avg}m';
   }
+
+  /// Opens the "Show all cast" bottom sheet listing every member of
+  /// [cast] (avatar + name + character). Used by the compact cast row's
+  /// overflow tile on the narrow breakpoint — same sheet shape as the
+  /// season picker so D-pad / drag-handle behavior matches.
+  void _showAllCast(BuildContext context, List<CastMember> cast) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    unawaited(
+      ListPickerSheet.show(
+        context,
+        title: l.castShowAll,
+        cancelLabel: l.cancel,
+        children: [
+          for (final member in cast)
+            _CastSheetRow(member: member, theme: theme, scheme: scheme),
+        ],
+      ),
+    );
+  }
 }
 
 String? _trimmedOrNull(String? value) {
@@ -1016,6 +1043,74 @@ class _ConfirmMarkDialogState extends State<_ConfirmMarkDialog> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Single row inside the "Show all cast" bottom sheet. 48px circular
+/// avatar + bold name (1 line, ellipsized) + muted character (1 line,
+/// ellipsized). Rendered via a plain [Padding] — the surrounding
+/// [ListPickerSheet] handles D-pad region / focus / scrolling, so a
+/// per-row [DpadInkWell] would just compete with that focus model.
+class _CastSheetRow extends StatelessWidget {
+  const _CastSheetRow({
+    required this.member,
+    required this.theme,
+    required this.scheme,
+  });
+
+  final CastMember member;
+  final ThemeData theme;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final character = member.character;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 48,
+            height: 48,
+            child: ClipOval(
+              child: ResilientMediaImage(
+                imageUrl: member.photo,
+                fallbackIcon: Icons.person,
+                backgroundColor: scheme.surfaceContainerHighest,
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  member.name,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (character != null && character.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    character,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -12,6 +12,7 @@ import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/backdrop_detail_hero.dart';
 import 'package:m3u_tv/shared/cached_backdrop_image.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/dominant_backdrop_color.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
@@ -614,6 +615,14 @@ class _SeriesDetailsBody extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         header,
+        if (info.series.richCast != null &&
+            info.series.richCast!.isNotEmpty) ...[
+          const SizedBox(height: MediaBrowsingMetrics.contentPadding),
+          CastMemberRow(
+            members: info.series.richCast,
+            semanticLabel: AppLocalizations.of(context).seriesCast,
+          ),
+        ],
         const SizedBox(height: 20),
         // Play / Start-from-beginning sit on the same line as the season
         // picker (wrapping to a second run on a phone).

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -7,6 +7,7 @@ import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
 import 'package:m3u_tv/shared/backdrop_detail_hero.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/dominant_backdrop_color.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
 import 'package:m3u_tv/shared/item_meta_info.dart';
@@ -269,32 +270,42 @@ class _VodDetailsBody extends StatelessWidget {
     final buttonLabel = progress == null
         ? l.vodPlayMovie
         : (_timeLeftLabel(context, progress) ?? l.vodContinueMovie);
-    return ItemMetaInfo(
-      name: details.name,
-      chips: [
-        if (details.year != null) details.year!,
-        if (details.genre != null) details.genre!,
-        if (details.duration != null) details.duration!,
-        if (details.rating != null) '★ ${details.rating}',
-        if (details.containerExtension != null)
-          details.containerExtension!.toUpperCase(),
-      ],
-      buttonLabel: buttonLabel,
-      onPlay: () =>
-          _play(details, startPosition: progress?.positionSeconds.toDouble()),
-      onStartOver: progress == null
-          ? null
-          // ignore: prefer_int_literals
-          : () => _play(details, startPosition: 0.0),
-      fullWidthButton: fullWidthButton,
-      progressValue: _progressValue(progress),
-      isLoading: isLoading,
-      plot: details.plot ?? 'No synopsis available.',
-      credits: [
-        if (details.director != null)
-          MetaCreditLine(label: 'Director', value: details.director!),
-        if (details.cast != null)
-          MetaCreditLine(label: 'Cast', value: details.cast!),
+    final richCast = details.richCast;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ItemMetaInfo(
+          name: details.name,
+          chips: [
+            if (details.year != null) details.year!,
+            if (details.genre != null) details.genre!,
+            if (details.duration != null) details.duration!,
+            if (details.rating != null) '★ ${details.rating}',
+            if (details.containerExtension != null)
+              details.containerExtension!.toUpperCase(),
+          ],
+          buttonLabel: buttonLabel,
+          onPlay: () =>
+              _play(details, startPosition: progress?.positionSeconds.toDouble()),
+          onStartOver: progress == null
+              ? null
+              // ignore: prefer_int_literals
+              : () => _play(details, startPosition: 0.0),
+          fullWidthButton: fullWidthButton,
+          progressValue: _progressValue(progress),
+          isLoading: isLoading,
+          plot: details.plot ?? 'No synopsis available.',
+          credits: [
+            if (details.director != null)
+              MetaCreditLine(label: 'Director', value: details.director!),
+            if (details.cast != null)
+              MetaCreditLine(label: 'Cast', value: details.cast!),
+          ],
+        ),
+        if (richCast != null && richCast.isNotEmpty) ...[
+          const SizedBox(height: MediaBrowsingMetrics.contentPadding),
+          CastMemberRow(members: richCast, semanticLabel: l.vodCast),
+        ],
       ],
     );
   }
@@ -354,6 +365,7 @@ class _ResolvedVodDetails {
   String? get genre => _notEmpty(info?.genre);
   String? get director => _notEmpty(info?.director);
   String? get cast => _notEmpty(info?.cast);
+  List<CastMember>? get richCast => info?.richCast;
   String? get year => _notEmpty(info?.year) ?? _notEmpty(info?.releaseDate);
   String? get duration => _notEmpty(info?.duration);
   double? get rating => info?.rating ?? item.rating;

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -11,6 +11,7 @@ import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/dominant_backdrop_color.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
 import 'package:m3u_tv/shared/item_meta_info.dart';
+import 'package:m3u_tv/shared/list_picker_sheet.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
 class VodDetailsScreen extends StatefulWidget {
@@ -232,7 +233,14 @@ class _VodDetailsBody extends StatelessWidget {
         children: [
           poster,
           const SizedBox(height: 16),
-          _infoColumn(context, theme, details, progress, fullWidthButton: true),
+          _infoColumn(
+            context,
+            theme,
+            details,
+            progress,
+            fullWidthButton: true,
+            compact: true,
+          ),
         ],
       ),
     );
@@ -265,6 +273,7 @@ class _VodDetailsBody extends StatelessWidget {
     _ResolvedVodDetails details,
     Progress? progress, {
     bool fullWidthButton = false,
+    bool compact = false,
   }) {
     final l = AppLocalizations.of(context);
     final buttonLabel = progress == null
@@ -304,9 +313,38 @@ class _VodDetailsBody extends StatelessWidget {
         ),
         if (richCast != null && richCast.isNotEmpty) ...[
           const SizedBox(height: MediaBrowsingMetrics.contentPadding),
-          CastMemberRow(members: richCast, semanticLabel: l.vodCast),
+          CastMemberRow(
+            members: richCast,
+            semanticLabel: l.vodCast,
+            compact: compact,
+            onShowAll: compact
+                ? () => _showAllCast(context, richCast)
+                : null,
+            allCastSemanticLabel: l.castShowAll,
+          ),
         ],
       ],
+    );
+  }
+
+  /// Opens the "Show all cast" bottom sheet listing every member of
+  /// [cast] (avatar + name + character). Used by the compact cast row's
+  /// overflow tile on the narrow breakpoint — same sheet shape as the
+  /// season picker so D-pad / drag-handle behavior matches.
+  void _showAllCast(BuildContext context, List<CastMember> cast) {
+    final l = AppLocalizations.of(context);
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    unawaited(
+      ListPickerSheet.show(
+        context,
+        title: l.castShowAll,
+        cancelLabel: l.cancel,
+        children: [
+          for (final member in cast)
+            _VodCastSheetRow(member: member, theme: theme, scheme: scheme),
+        ],
+      ),
     );
   }
 
@@ -349,6 +387,75 @@ class _VodDetailsBody extends StatelessWidget {
           if (details.plot != null) 'plot': details.plot,
           if (details.edlUrl != null) 'edl_url': details.edlUrl,
         },
+      ),
+    );
+  }
+}
+
+/// Single row inside the VOD "Show all cast" bottom sheet. 48px
+/// circular avatar + bold name (1 line, ellipsized) + muted character
+/// (1 line, ellipsized). Rendered via a plain [Padding] — the
+/// surrounding ListPickerSheet handles D-pad region / focus /
+/// scrolling, so a per-row DpadInkWell would just compete with that
+/// focus model.
+class _VodCastSheetRow extends StatelessWidget {
+  const _VodCastSheetRow({
+    required this.member,
+    required this.theme,
+    required this.scheme,
+  });
+
+  final CastMember member;
+  final ThemeData theme;
+  final ColorScheme scheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final character = member.character;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 48,
+            height: 48,
+            child: ClipOval(
+              child: ResilientMediaImage(
+                imageUrl: member.photo,
+                fallbackIcon: Icons.person,
+                backgroundColor: scheme.surfaceContainerHighest,
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  member.name,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (character != null && character.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    character,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -11,7 +11,6 @@ import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/dominant_backdrop_color.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart';
 import 'package:m3u_tv/shared/item_meta_info.dart';
-import 'package:m3u_tv/shared/list_picker_sheet.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
 class VodDetailsScreen extends StatefulWidget {
@@ -162,35 +161,56 @@ class _VodDetailsBody extends StatelessWidget {
     Progress? progress,
   ) {
     final backdrop = details.backdropUrl;
+    final richCast = details.richCast;
+    final l = AppLocalizations.of(context);
+    // The poster + details Row fills the available height (its own info column
+    // scrolls); the rich cast row is pinned full-width below it, kept out of
+    // that vertical scrollable so left/right card navigation never drags the
+    // page. Mirrors the Series detail layout.
     final content = Padding(
       padding: const EdgeInsets.all(MediaBrowsingMetrics.pagePadding),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.end,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          SizedBox(
-            width: 220,
-            child: AspectRatio(
-              aspectRatio: 0.68,
-              child: ResilientMediaImage(
-                imageUrl: details.coverUrl,
-                fallbackIcon: Icons.movie,
-                borderRadius: MediaBrowsingMetrics.cardRadius,
-                fallbackTitle: details.name,
-              ),
-            ),
-          ),
-          const SizedBox(width: MediaBrowsingMetrics.pagePadding),
           Expanded(
-            child: SingleChildScrollView(
-              child: _infoColumn(context, theme, details, progress),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                SizedBox(
+                  width: 220,
+                  child: AspectRatio(
+                    aspectRatio: 0.68,
+                    child: ResilientMediaImage(
+                      imageUrl: details.coverUrl,
+                      fallbackIcon: Icons.movie,
+                      borderRadius: MediaBrowsingMetrics.cardRadius,
+                      fallbackTitle: details.name,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: MediaBrowsingMetrics.pagePadding),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: _infoColumn(context, theme, details, progress),
+                  ),
+                ),
+              ],
             ),
           ),
+          if (richCast != null && richCast.isNotEmpty) ...[
+            const SizedBox(height: MediaBrowsingMetrics.contentPadding),
+            CastMemberRow(
+              members: richCast,
+              semanticLabel: l.vodCast,
+              onShowAll: () => showAllCast(context, richCast, asDialog: true),
+              allCastSemanticLabel: l.castShowAll,
+            ),
+          ],
         ],
       ),
     );
 
-    // Always use the backdrop Stack layout so the poster stays bottom-aligned
-    // before and after the backdrop URL loads in, avoiding a layout jump.
     // Colour-matched scrim, same treatment as the Series detail page.
     return BackdropDetailHero(
       backdropUrl: backdrop,
@@ -198,9 +218,7 @@ class _VodDetailsBody extends StatelessWidget {
       showBackgroundColorLayer: true,
       backgroundColor: bg,
       scrimColors: [bg.withValues(alpha: 0.35), bg.withValues(alpha: 0.92), bg],
-      contentPadding: EdgeInsets.only(
-        bottom: MediaQuery.sizeOf(context).height * 0.1,
-      ),
+      contentPadding: const EdgeInsets.only(top: 24, bottom: 24),
       content: content,
     );
   }
@@ -313,45 +331,20 @@ class _VodDetailsBody extends StatelessWidget {
               MetaCreditLine(label: 'Cast', value: details.cast!),
           ],
         ),
-        if (richCast != null && richCast.isNotEmpty) ...[
+        // Wide layout renders the cast row full-width below the poster +
+        // details block (see _buildWide); only the narrow layout keeps it
+        // inline here, as a compact picker chip under the synopsis.
+        if (compact && richCast != null && richCast.isNotEmpty) ...[
           const SizedBox(height: MediaBrowsingMetrics.contentPadding),
           CastMemberRow(
             members: richCast,
             semanticLabel: l.vodCast,
-            compact: compact,
-            onShowAll: () =>
-                _showAllCast(context, richCast, asDialog: !compact),
+            compact: true,
+            onShowAll: () => showAllCast(context, richCast),
             allCastSemanticLabel: l.castShowAll,
           ),
         ],
       ],
-    );
-  }
-
-  /// Opens the "Show all cast" picker listing every member of [cast]
-  /// (avatar + name + character) — a bottom sheet from the narrow
-  /// layout's picker chip, a centered dialog ([asDialog]) from the wide
-  /// layout's "+N" overflow tile. Same modal split as the season picker
-  /// so D-pad / dismiss behavior matches.
-  void _showAllCast(
-    BuildContext context,
-    List<CastMember> cast, {
-    bool asDialog = false,
-  }) {
-    final l = AppLocalizations.of(context);
-    final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    unawaited(
-      ListPickerSheet.show(
-        context,
-        title: l.castShowAll,
-        cancelLabel: l.cancel,
-        asDialog: asDialog,
-        children: [
-          for (final member in cast)
-            _VodCastSheetRow(member: member, theme: theme, scheme: scheme),
-        ],
-      ),
     );
   }
 
@@ -394,75 +387,6 @@ class _VodDetailsBody extends StatelessWidget {
           if (details.plot != null) 'plot': details.plot,
           if (details.edlUrl != null) 'edl_url': details.edlUrl,
         },
-      ),
-    );
-  }
-}
-
-/// Single row inside the VOD "Show all cast" bottom sheet. 48px
-/// circular avatar + bold name (1 line, ellipsized) + muted character
-/// (1 line, ellipsized). Rendered via a plain [Padding] — the
-/// surrounding ListPickerSheet handles D-pad region / focus /
-/// scrolling, so a per-row DpadInkWell would just compete with that
-/// focus model.
-class _VodCastSheetRow extends StatelessWidget {
-  const _VodCastSheetRow({
-    required this.member,
-    required this.theme,
-    required this.scheme,
-  });
-
-  final CastMember member;
-  final ThemeData theme;
-  final ColorScheme scheme;
-
-  @override
-  Widget build(BuildContext context) {
-    final character = member.character;
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 48,
-            height: 48,
-            child: ClipOval(
-              child: ResilientMediaImage(
-                imageUrl: member.photo,
-                fallbackIcon: Icons.person,
-                backgroundColor: scheme.surfaceContainerHighest,
-              ),
-            ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  member.name,
-                  style: theme.textTheme.bodyLarge?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (character != null && character.isNotEmpty) ...[
-                  const SizedBox(height: 2),
-                  Text(
-                    character,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: scheme.onSurfaceVariant,
-                    ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
-              ],
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -294,8 +294,10 @@ class _VodDetailsBody extends StatelessWidget {
               details.containerExtension!.toUpperCase(),
           ],
           buttonLabel: buttonLabel,
-          onPlay: () =>
-              _play(details, startPosition: progress?.positionSeconds.toDouble()),
+          onPlay: () => _play(
+            details,
+            startPosition: progress?.positionSeconds.toDouble(),
+          ),
           onStartOver: progress == null
               ? null
               // ignore: prefer_int_literals
@@ -317,9 +319,8 @@ class _VodDetailsBody extends StatelessWidget {
             members: richCast,
             semanticLabel: l.vodCast,
             compact: compact,
-            onShowAll: compact
-                ? () => _showAllCast(context, richCast)
-                : null,
+            onShowAll: () =>
+                _showAllCast(context, richCast, asDialog: !compact),
             allCastSemanticLabel: l.castShowAll,
           ),
         ],
@@ -327,11 +328,16 @@ class _VodDetailsBody extends StatelessWidget {
     );
   }
 
-  /// Opens the "Show all cast" bottom sheet listing every member of
-  /// [cast] (avatar + name + character). Used by the compact cast row's
-  /// overflow tile on the narrow breakpoint — same sheet shape as the
-  /// season picker so D-pad / drag-handle behavior matches.
-  void _showAllCast(BuildContext context, List<CastMember> cast) {
+  /// Opens the "Show all cast" picker listing every member of [cast]
+  /// (avatar + name + character) — a bottom sheet from the narrow
+  /// layout's picker chip, a centered dialog ([asDialog]) from the wide
+  /// layout's "+N" overflow tile. Same modal split as the season picker
+  /// so D-pad / dismiss behavior matches.
+  void _showAllCast(
+    BuildContext context,
+    List<CastMember> cast, {
+    bool asDialog = false,
+  }) {
     final l = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final scheme = theme.colorScheme;
@@ -340,6 +346,7 @@ class _VodDetailsBody extends StatelessWidget {
         context,
         title: l.castShowAll,
         cancelLabel: l.cancel,
+        asDialog: asDialog,
         children: [
           for (final member in cast)
             _VodCastSheetRow(member: member, theme: theme, scheme: scheme),

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -341,6 +341,7 @@
     }
   },
   "seriesSeasons": "Staffeln",
+  "seriesCast": "Besetzung",
   "seriesEpisodeCount": "{count, plural, =1{1 Folge} other{{count} Folgen}}",
   "@seriesEpisodeCount": {
     "placeholders": {
@@ -410,6 +411,7 @@
   "searchTypeToSearch": "Zum Suchen tippen",
   "vodPlayMovie": "Film abspielen",
   "vodContinueMovie": "Film fortsetzen",
+  "vodCast": "Besetzung",
   "vodTimeLeftMinutes": "{minutes, plural, =1{noch 1 Min.} other{noch {minutes} Min.}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -412,6 +412,7 @@
   "vodPlayMovie": "Film abspielen",
   "vodContinueMovie": "Film fortsetzen",
   "vodCast": "Besetzung",
+  "castShowAll": "Alle Darsteller anzeigen",
   "vodTimeLeftMinutes": "{minutes, plural, =1{noch 1 Min.} other{noch {minutes} Min.}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -413,6 +413,7 @@
   "vodPlayMovie": "Play movie",
   "vodContinueMovie": "Continue movie",
   "vodCast": "Cast",
+  "castShowAll": "Show all cast",
   "vodTimeLeftMinutes": "{minutes, plural, =1{1 min left} other{{minutes} min left}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -342,6 +342,7 @@
     }
   },
   "seriesSeasons": "Seasons",
+  "seriesCast": "Cast",
   "seriesEpisodeCount": "{count, plural, =1{1 episode} other{{count} episodes}}",
   "@seriesEpisodeCount": {
     "placeholders": {
@@ -411,6 +412,7 @@
   "searchTypeToSearch": "Type to search",
   "vodPlayMovie": "Play movie",
   "vodContinueMovie": "Continue movie",
+  "vodCast": "Cast",
   "vodTimeLeftMinutes": "{minutes, plural, =1{1 min left} other{{minutes} min left}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -341,6 +341,7 @@
     }
   },
   "seriesSeasons": "Temporadas",
+  "seriesCast": "Reparto",
   "seriesEpisodeCount": "{count, plural, =1{1 episodio} other{{count} episodios}}",
   "@seriesEpisodeCount": {
     "placeholders": {
@@ -410,6 +411,7 @@
   "searchTypeToSearch": "Escribe para buscar",
   "vodPlayMovie": "Reproducir película",
   "vodContinueMovie": "Continuar película",
+  "vodCast": "Reparto",
   "vodTimeLeftMinutes": "{minutes, plural, =1{Queda 1 min} other{Quedan {minutes} min}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -412,6 +412,7 @@
   "vodPlayMovie": "Reproducir película",
   "vodContinueMovie": "Continuar película",
   "vodCast": "Reparto",
+  "castShowAll": "Ver todo el reparto",
   "vodTimeLeftMinutes": "{minutes, plural, =1{Queda 1 min} other{Quedan {minutes} min}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -412,6 +412,7 @@
   "vodPlayMovie": "Lire le film",
   "vodContinueMovie": "Continuer le film",
   "vodCast": "Casting",
+  "castShowAll": "Voir tout le casting",
   "vodTimeLeftMinutes": "{minutes, plural, =1{Il reste 1 min} other{Il reste {minutes} min}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -341,6 +341,7 @@
     }
   },
   "seriesSeasons": "Saisons",
+  "seriesCast": "Casting",
   "seriesEpisodeCount": "{count, plural, =1{1 épisode} other{{count} épisodes}}",
   "@seriesEpisodeCount": {
     "placeholders": {
@@ -410,6 +411,7 @@
   "searchTypeToSearch": "Saisir pour rechercher",
   "vodPlayMovie": "Lire le film",
   "vodContinueMovie": "Continuer le film",
+  "vodCast": "Casting",
   "vodTimeLeftMinutes": "{minutes, plural, =1{Il reste 1 min} other{Il reste {minutes} min}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -1328,6 +1328,12 @@ abstract class AppLocalizations {
   /// **'Seasons'**
   String get seriesSeasons;
 
+  /// No description provided for @seriesCast.
+  ///
+  /// In en, this message translates to:
+  /// **'Cast'**
+  String get seriesCast;
+
   /// No description provided for @seriesEpisodeCount.
   ///
   /// In en, this message translates to:
@@ -1495,6 +1501,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Continue movie'**
   String get vodContinueMovie;
+
+  /// No description provided for @vodCast.
+  ///
+  /// In en, this message translates to:
+  /// **'Cast'**
+  String get vodCast;
 
   /// Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.
   ///

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -1508,6 +1508,12 @@ abstract class AppLocalizations {
   /// **'Cast'**
   String get vodCast;
 
+  /// No description provided for @castShowAll.
+  ///
+  /// In en, this message translates to:
+  /// **'Show all cast'**
+  String get castShowAll;
+
   /// Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -691,6 +691,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get seriesSeasons => 'Staffeln';
 
   @override
+  String get seriesCast => 'Besetzung';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -794,6 +797,9 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get vodContinueMovie => 'Film fortsetzen';
+
+  @override
+  String get vodCast => 'Besetzung';
 
   @override
   String vodTimeLeftMinutes(int minutes) {

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -802,6 +802,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get vodCast => 'Besetzung';
 
   @override
+  String get castShowAll => 'Alle Darsteller anzeigen';
+
+  @override
   String vodTimeLeftMinutes(int minutes) {
     String _temp0 = intl.Intl.pluralLogic(
       minutes,

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -797,6 +797,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get vodCast => 'Cast';
 
   @override
+  String get castShowAll => 'Show all cast';
+
+  @override
   String vodTimeLeftMinutes(int minutes) {
     String _temp0 = intl.Intl.pluralLogic(
       minutes,

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -687,6 +687,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get seriesSeasons => 'Seasons';
 
   @override
+  String get seriesCast => 'Cast';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -789,6 +792,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get vodContinueMovie => 'Continue movie';
+
+  @override
+  String get vodCast => 'Cast';
 
   @override
   String vodTimeLeftMinutes(int minutes) {

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -803,6 +803,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get vodCast => 'Reparto';
 
   @override
+  String get castShowAll => 'Ver todo el reparto';
+
+  @override
   String vodTimeLeftMinutes(int minutes) {
     String _temp0 = intl.Intl.pluralLogic(
       minutes,

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -692,6 +692,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get seriesSeasons => 'Temporadas';
 
   @override
+  String get seriesCast => 'Reparto';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -795,6 +798,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get vodContinueMovie => 'Continuar película';
+
+  @override
+  String get vodCast => 'Reparto';
 
   @override
   String vodTimeLeftMinutes(int minutes) {

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -693,6 +693,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get seriesSeasons => 'Saisons';
 
   @override
+  String get seriesCast => 'Casting';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -796,6 +799,9 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get vodContinueMovie => 'Continuer le film';
+
+  @override
+  String get vodCast => 'Casting';
 
   @override
   String vodTimeLeftMinutes(int minutes) {

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -804,6 +804,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get vodCast => 'Casting';
 
   @override
+  String get castShowAll => 'Voir tout le casting';
+
+  @override
   String vodTimeLeftMinutes(int minutes) {
     String _temp0 = intl.Intl.pluralLogic(
       minutes,

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -661,6 +661,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get seriesSeasons => '剧集季';
 
   @override
+  String get seriesCast => '演员阵容';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,
@@ -760,6 +763,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get vodContinueMovie => '继续播放';
+
+  @override
+  String get vodCast => '演员阵容';
 
   @override
   String vodTimeLeftMinutes(int minutes) {

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -768,6 +768,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get vodCast => '演员阵容';
 
   @override
+  String get castShowAll => '查看全部演员';
+
+  @override
   String vodTimeLeftMinutes(int minutes) {
     String _temp0 = intl.Intl.pluralLogic(
       minutes,

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -341,6 +341,7 @@
     }
   },
   "seriesSeasons": "剧集季",
+  "seriesCast": "演员阵容",
   "seriesEpisodeCount": "{count, plural, =1{1 集} other{{count} 集}}",
   "@seriesEpisodeCount": {
     "placeholders": {
@@ -410,6 +411,7 @@
   "searchTypeToSearch": "输入以搜索",
   "vodPlayMovie": "播放电影",
   "vodContinueMovie": "继续播放",
+  "vodCast": "演员阵容",
   "vodTimeLeftMinutes": "{minutes, plural, other{还剩{minutes}分钟}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -412,6 +412,7 @@
   "vodPlayMovie": "播放电影",
   "vodContinueMovie": "继续播放",
   "vodCast": "演员阵容",
+  "castShowAll": "查看全部演员",
   "vodTimeLeftMinutes": "{minutes, plural, other{还剩{minutes}分钟}}",
   "@vodTimeLeftMinutes": {
     "description": "Trailing label inside the resume button on a VOD detail screen, showing time remaining under an hour.",

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -165,6 +165,7 @@ class VodInfo {
     this.genre,
     this.director,
     this.cast,
+    this.richCast,
     this.releaseDate,
     this.year,
     this.duration,
@@ -182,6 +183,7 @@ class VodInfo {
   final String? genre;
   final String? director;
   final String? cast;
+  final List<CastMember>? richCast;
   final String? releaseDate;
   final String? year;
   final String? duration;
@@ -218,6 +220,7 @@ class VodInfo {
       genre: _asNullableString(pick(['genre'])),
       director: _asNullableString(pick(['director'])),
       cast: _asNullableString(pick(['cast', 'actors'])),
+      richCast: _parsecastList(pick(['cast_list'])),
       releaseDate: releaseDate,
       year: year,
       duration: _durationText(
@@ -242,6 +245,54 @@ class VodInfo {
   }
 }
 
+/// A single cast member on a VOD movie or series.
+///
+/// Mirrors m3u-editor's `cast_list` payload emitted by `get_vod_info` /
+/// `get_series_info` when the server can resolve a TMDB id for the title.
+/// Shape: `{id?: int, name: String, character?: String, photo?: String}`.
+///
+/// `cast_list` is a separate wire key from the existing string `cast`
+/// (comma-joined names). Keeping the keys distinct preserves backward
+/// compatibility for old m3u-tv clients that read `cast` via
+/// `_asNullableString(...)` — see plan `.omo/plans/cast-rich.md`.
+class CastMember {
+  const CastMember({
+    required this.name,
+    this.id,
+    this.character,
+    this.photo,
+  });
+
+  final String name;
+  final int? id;
+  final String? character;
+  final String? photo;
+
+  static CastMember? fromXtream(Object? json) {
+    if (json is! Map) return null;
+    final map = json.cast<String, Object?>();
+    final rawName = _asNullableString(map['name']);
+    final trimmedName = rawName?.trim();
+    if (trimmedName == null || trimmedName.isEmpty) return null;
+    return CastMember(
+      id: _asIntOrNull(map['id']),
+      name: trimmedName,
+      character: _asNullableString(map['character']),
+      photo: _asNullableString(map['photo']),
+    );
+  }
+}
+
+List<CastMember>? _parsecastList(Object? raw) {
+  if (raw is! List) return null;
+  final parsed = raw
+      .whereType<Map<Object?, Object?>>()
+      .map(CastMember.fromXtream)
+      .whereType<CastMember>()
+      .toList(growable: false);
+  return parsed.isEmpty ? null : parsed;
+}
+
 class Series {
   const Series({
     required this.id,
@@ -253,6 +304,7 @@ class Series {
     this.plot,
     this.rating,
     this.tmdbId,
+    this.richCast,
   });
 
   final int id;
@@ -268,6 +320,7 @@ class Series {
   final String? plot;
   final double? rating;
   final int? tmdbId;
+  final List<CastMember>? richCast;
 
   factory Series.fromXtream(Map<String, Object?> json) => Series(
     id: _asInt(json['series_id']),
@@ -279,6 +332,7 @@ class Series {
     plot: _asNullableString(json['plot']),
     rating: _asDoubleOrNull(json['rating'] ?? json['rating_5based']),
     tmdbId: _asIntOrNull(json['tmdb_id'] ?? json['tmdb']),
+    richCast: _parsecastList(json['cast_list']),
   );
 }
 

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -220,7 +220,7 @@ class VodInfo {
       genre: _asNullableString(pick(['genre'])),
       director: _asNullableString(pick(['director'])),
       cast: _asNullableString(pick(['cast', 'actors'])),
-      richCast: _parsecastList(pick(['cast_list'])),
+      richCast: _parseCastList(pick(['cast_list'])),
       releaseDate: releaseDate,
       year: year,
       duration: _durationText(
@@ -254,7 +254,7 @@ class VodInfo {
 /// `cast_list` is a separate wire key from the existing string `cast`
 /// (comma-joined names). Keeping the keys distinct preserves backward
 /// compatibility for old m3u-tv clients that read `cast` via
-/// `_asNullableString(...)` — see plan `.omo/plans/cast-rich.md`.
+/// `_asNullableString(...)` - see plan `.omo/plans/cast-rich.md`.
 class CastMember {
   const CastMember({
     required this.name,
@@ -268,6 +268,9 @@ class CastMember {
   final String? character;
   final String? photo;
 
+  /// A static method rather than a `factory` because it returns null for
+  /// a malformed or nameless entry instead of throwing - callers filter
+  /// those out with `whereType<CastMember>()`.
   static CastMember? fromXtream(Object? json) {
     if (json is! Map) return null;
     final map = json.cast<String, Object?>();
@@ -283,7 +286,7 @@ class CastMember {
   }
 }
 
-List<CastMember>? _parsecastList(Object? raw) {
+List<CastMember>? _parseCastList(Object? raw) {
   if (raw is! List) return null;
   final parsed = raw
       .whereType<Map<Object?, Object?>>()
@@ -332,7 +335,7 @@ class Series {
     plot: _asNullableString(json['plot']),
     rating: _asDoubleOrNull(json['rating'] ?? json['rating_5based']),
     tmdbId: _asIntOrNull(json['tmdb_id'] ?? json['tmdb']),
-    richCast: _parsecastList(json['cast_list']),
+    richCast: _parseCastList(json['cast_list']),
   );
 }
 

--- a/flutter_client/lib/shared/cast_member_row.dart
+++ b/flutter_client/lib/shared/cast_member_row.dart
@@ -1,12 +1,15 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 
+import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
+import 'package:m3u_tv/shared/list_picker_sheet.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
 /// Cast row used on the VOD movie detail and Series detail screens to
@@ -17,20 +20,20 @@ import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 /// **Wide layout** (`compact = false`, the default): a horizontal scroll
 /// row of 144×~140 cards. Each card is a 72×72 circular avatar with
 /// name (bold, 1 line) and character (muted, 1 line) in a billing-block
-/// layout — 144px fits ~21 characters so names like "Christoph Waltz"
+/// layout - 144px fits ~21 characters so names like "Christoph Waltz"
 /// and "Jesse Pinkman" don't truncate. When more members exist than
 /// cards fit the available width (and [onShowAll] is set), the last
 /// visible slot becomes a "+N / show all" tile that fires [onShowAll]
-/// — callers wire it to the same picker modal the season picker uses.
+/// - callers wire it to the same picker modal the season picker uses.
 /// Without [onShowAll] the row falls back to a plain horizontal scroll
 /// capped at [_maxMembers] (15). D-pad traversal is native: left/right
 /// moves focus between cards; the row stops at its edges so focus
 /// doesn't escape into the surrounding column. Focused cards get the
 /// canonical project-wide [GradientBorderEffect] glow. Member cards
-/// have no tap action — cast is informational on wide layouts.
+/// have no tap action - cast is informational on wide layouts.
 ///
 /// **Compact mode** (`compact = true`, phone breakpoint): a pill-shaped
-/// picker button mirroring the season picker's chrome — the localized
+/// picker button mirroring the season picker's chrome - the localized
 /// "Cast" label, a down-chevron, and a count badge showing how many cast
 /// members are in [members]. Tapping the button fires [onShowAll],
 /// which callers wire to the same bottom-drawer picker used by the
@@ -74,9 +77,16 @@ class CastMemberRow extends StatelessWidget {
 
   static const double _cardWidth = 144;
   static const double _avatarSize = 72;
-  static const double _cardHeight = 140;
+  static const double _cardHeight = 144;
   static const double _cardGap = 12;
   static const int _maxMembers = 15;
+
+  /// Padding between a card's focus border and its content, so the
+  /// [GradientBorderEffect] glow never hugs the avatar or a long name.
+  static const EdgeInsets _cardInset = EdgeInsets.symmetric(
+    vertical: 4,
+    horizontal: 3,
+  );
 
   @override
   Widget build(BuildContext context) {
@@ -164,7 +174,7 @@ class CastMemberRow extends StatelessWidget {
 /// Pill-shaped picker button matching the season picker's chrome:
 /// `label` text, a count badge, a down-chevron, focused via
 /// [GradientBorderEffect]. Tap fires [onTap]. Renders nothing different
-/// when [badgeCount] is 0 or 1 — the season picker shows the badge for
+/// when [badgeCount] is 0 or 1 - the season picker shows the badge for
 /// any positive count.
 class _CastPickerButton extends StatelessWidget {
   const _CastPickerButton({
@@ -184,7 +194,7 @@ class _CastPickerButton extends StatelessWidget {
       label: label,
       icon: Icons.arrow_drop_down,
       badgeCount: badgeCount > 0 ? badgeCount : null,
-      // Muted, not the default error red — this is a count, not an
+      // Muted, not the default error red - this is a count, not an
       // unwatched / new alert (matches how the season picker styles its
       // episode-count badge).
       badgeColor: scheme.surfaceContainerHighest,
@@ -225,31 +235,34 @@ class _ShowAllCastCard extends StatelessWidget {
             borderRadius: BorderRadius.all(Radius.circular(8)),
           ),
         ],
-        child: Column(
-          children: [
-            SizedBox(
-              width: CastMemberRow._avatarSize,
-              height: CastMemberRow._avatarSize,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: scheme.surfaceContainerHighest,
-                ),
-                child: Center(
-                  child: Text(
-                    '+$hiddenCount',
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      color: scheme.onSurfaceVariant,
-                      fontWeight: FontWeight.w700,
+        // Inset the content so the focus border has breathing room on every
+        // side, not just the text baseline.
+        child: Padding(
+          padding: CastMemberRow._cardInset,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: CastMemberRow._avatarSize,
+                height: CastMemberRow._avatarSize,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: scheme.surfaceContainerHighest,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '+$hiddenCount',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: Text(
+              const SizedBox(height: 8),
+              Text(
                 label,
                 style: theme.textTheme.bodySmall?.copyWith(
                   fontWeight: FontWeight.w700,
@@ -258,8 +271,8 @@ class _ShowAllCastCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -283,28 +296,37 @@ class _CastMemberCard extends StatelessWidget {
           ? '$name as $character'
           : name,
       child: DpadInkWell(
-        // No tap action — cast is informational in v1.
+        // No tap action - cast is informational in v1.
         borderRadius: const BorderRadius.all(Radius.circular(8)),
         effects: const [
           GradientBorderEffect(
             borderRadius: BorderRadius.all(Radius.circular(8)),
           ),
         ],
-        child: Column(
-          children: [
-            // Decorative gradient ring + circular avatar + bottom-fade.
-            _GradientRingAvatar(
-              size: CastMemberRow._avatarSize,
-              child: _AvatarWithFade(
-                imageUrl: member.photo,
-                size: CastMemberRow._avatarSize,
-                surface: scheme.surface,
+        // Inset the content so the focus border has breathing room on every
+        // side, not just the text baseline.
+        child: Padding(
+          padding: CastMemberRow._cardInset,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Circular headshot. No decorative ring or fade - a gradient
+              // ring and a bottom-to-top surface fade were both tried here
+              // and left visible dark artifacts on avatars in dark theme.
+              // Focus is the card-level [GradientBorderEffect] only.
+              SizedBox(
+                width: CastMemberRow._avatarSize,
+                height: CastMemberRow._avatarSize,
+                child: ClipOval(
+                  child: ResilientMediaImage(
+                    imageUrl: member.photo,
+                    fallbackIcon: Icons.person,
+                    backgroundColor: scheme.surface,
+                  ),
+                ),
               ),
-            ),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: Text(
+              const SizedBox(height: 8),
+              Text(
                 name,
                 style: theme.textTheme.bodySmall?.copyWith(
                   fontWeight: FontWeight.w700,
@@ -313,12 +335,9 @@ class _CastMemberCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
                 textAlign: TextAlign.center,
               ),
-            ),
-            if (character != null && character.isNotEmpty) ...[
-              const SizedBox(height: 2),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: Text(
+              if (character != null && character.isNotEmpty) ...[
+                const SizedBox(height: 2),
+                Text(
                   character,
                   style: theme.textTheme.labelSmall?.copyWith(
                     color: scheme.onSurfaceVariant,
@@ -327,61 +346,98 @@ class _CastMemberCard extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.center,
                 ),
-              ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );
   }
 }
 
-/// Circular clip around the avatar child. No decorative ring — focus is
-/// handled by [GradientBorderEffect] at the card level.
-class _GradientRingAvatar extends StatelessWidget {
-  const _GradientRingAvatar({
-    required this.child,
-    required this.size,
-  });
-
-  final Widget child;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: size,
-      height: size,
-      child: ClipOval(child: child),
-    );
-  }
+/// Opens the "Show all cast" picker listing every [cast] member (avatar +
+/// name + character). A drag-handle bottom sheet on the narrow
+/// breakpoint, a centered dialog when [asDialog] is true - the same modal
+/// split the season picker uses so D-pad / dismiss behavior matches.
+/// Shared by the VOD and Series detail screens.
+void showAllCast(
+  BuildContext context,
+  List<CastMember> cast, {
+  bool asDialog = false,
+}) {
+  final l = AppLocalizations.of(context);
+  unawaited(
+    ListPickerSheet.show(
+      context,
+      title: l.castShowAll,
+      cancelLabel: l.cancel,
+      asDialog: asDialog,
+      children: [
+        for (final member in cast) CastSheetRow(member: member),
+      ],
+    ),
+  );
 }
 
-/// Circular clip containing the [ResilientMediaImage] headshot. No
-/// decorative overlay — a bottom→top surface fade was tried here and
-/// produced a visible dark half-circle on every avatar in dark theme.
-class _AvatarWithFade extends StatelessWidget {
-  const _AvatarWithFade({
-    required this.imageUrl,
-    required this.size,
-    required this.surface,
-  });
+/// Single row inside the "Show all cast" picker: a 48px circular avatar,
+/// a bold name and a muted character line, both ellipsized to one line.
+/// Rendered as a plain [Padding] - the enclosing [ListPickerSheet] owns
+/// the D-pad region, focus and scrolling, so a per-row [DpadInkWell]
+/// would only compete with that focus model.
+class CastSheetRow extends StatelessWidget {
+  const CastSheetRow({super.key, required this.member});
 
-  final String? imageUrl;
-  final double size;
-  final Color surface;
+  final CastMember member;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: size,
-      height: size,
-      child: ClipOval(
-        child: ResilientMediaImage(
-          imageUrl: imageUrl,
-          fallbackIcon: Icons.person,
-          backgroundColor: surface,
-        ),
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final character = member.character;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 48,
+            height: 48,
+            child: ClipOval(
+              child: ResilientMediaImage(
+                imageUrl: member.photo,
+                fallbackIcon: Icons.person,
+                backgroundColor: scheme.surfaceContainerHighest,
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  member.name,
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (character != null && character.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(
+                    character,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/flutter_client/lib/shared/cast_member_row.dart
+++ b/flutter_client/lib/shared/cast_member_row.dart
@@ -112,7 +112,6 @@ class _CastMemberCard extends StatelessWidget {
             // Decorative gradient ring + circular avatar + bottom-fade.
             _GradientRingAvatar(
               size: CastMemberRow._avatarSize,
-              ringWidth: 2,
               child: _AvatarWithFade(
                 imageUrl: member.photo,
                 size: CastMemberRow._avatarSize,
@@ -154,46 +153,30 @@ class _CastMemberCard extends StatelessWidget {
   }
 }
 
-/// Decorative primary→secondary gradient ring painted around a circular
-/// child (the avatar). Unfocused; focus is handled by [GradientBorderEffect]
-/// at the card level.
+/// Circular clip around the avatar child. No decorative ring — focus is
+/// handled by [GradientBorderEffect] at the card level.
 class _GradientRingAvatar extends StatelessWidget {
   const _GradientRingAvatar({
     required this.child,
     required this.size,
-    required this.ringWidth,
   });
 
   final Widget child;
   final double size;
-  final double ringWidth;
 
   @override
   Widget build(BuildContext context) {
-    final scheme = Theme.of(context).colorScheme;
-    return Container(
-      width: size + ringWidth * 2,
-      height: size + ringWidth * 2,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        gradient: LinearGradient(
-          begin: Alignment.topRight,
-          end: Alignment.bottomLeft,
-          colors: [scheme.primary, scheme.secondary],
-        ),
-      ),
-      child: Padding(
-        padding: EdgeInsets.all(ringWidth),
-        child: ClipOval(child: child),
-      ),
+    return SizedBox(
+      width: size,
+      height: size,
+      child: ClipOval(child: child),
     );
   }
 }
 
-/// Circular clip containing the [ResilientMediaImage] headshot, with a
-/// transparent→surface fade across the bottom ~35%. The fade softens
-/// the [Icons.person] fallback when no photo loads, and gives loaded
-/// headshots a subtle poster-like depth.
+/// Circular clip containing the [ResilientMediaImage] headshot. No
+/// decorative overlay — a bottom→top surface fade was tried here and
+/// produced a visible dark half-circle on every avatar in dark theme.
 class _AvatarWithFade extends StatelessWidget {
   const _AvatarWithFade({
     required this.imageUrl,
@@ -210,31 +193,12 @@ class _AvatarWithFade extends StatelessWidget {
     return SizedBox(
       width: size,
       height: size,
-      child: Stack(
-        children: [
-          ResilientMediaImage(
-            imageUrl: imageUrl,
-            fallbackIcon: Icons.person,
-            backgroundColor: surface,
-          ),
-          Positioned.fill(
-            child: IgnorePointer(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      Colors.transparent,
-                      surface.withValues(alpha: 0.6),
-                    ],
-                    stops: const [0.65, 1.0],
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
+      child: ClipOval(
+        child: ResilientMediaImage(
+          imageUrl: imageUrl,
+          fallbackIcon: Icons.person,
+          backgroundColor: surface,
+        ),
       ),
     );
   }

--- a/flutter_client/lib/shared/cast_member_row.dart
+++ b/flutter_client/lib/shared/cast_member_row.dart
@@ -1,40 +1,42 @@
+import 'dart:math' as math;
+
 import 'package:dpad/dpad.dart';
 import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/gradient_border_effect.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
-/// Horizontally scrolling row of cast member cards. Used on the VOD movie
-/// detail and Series detail screens to display the rich cast emitted by
-/// m3u-editor's `cast_list` payload. Returns [SizedBox.shrink] when
-/// [members] is null or empty so callers can drop it inline without a
-/// null check.
+/// Cast row used on the VOD movie detail and Series detail screens to
+/// display the rich cast emitted by m3u-editor's `cast_list` payload.
+/// Returns [SizedBox.shrink] when [members] is null or empty so callers
+/// can drop it inline without a null check.
 ///
-/// Each card is 144×~140: a 72×72 circular avatar wrapped in a subtle
-/// primary→secondary gradient ring (decorative even when unfocused),
-/// with a transparent→black bottom-fade overlay inside the ring so the
-/// `Icons.person` fallback blends with the surface. Name (bold, 1 line)
-/// and character (muted, 1 line) sit below in a billing-block layout —
-/// 144px of width fits ~21 characters so names like "Christoph Waltz"
-/// and "Jesse Pinkman" don't truncate.
+/// **Wide layout** (`compact = false`, the default): a horizontal scroll
+/// row of 144×~140 cards. Each card is a 72×72 circular avatar with
+/// name (bold, 1 line) and character (muted, 1 line) in a billing-block
+/// layout — 144px fits ~21 characters so names like "Christoph Waltz"
+/// and "Jesse Pinkman" don't truncate. When more members exist than
+/// cards fit the available width (and [onShowAll] is set), the last
+/// visible slot becomes a "+N / show all" tile that fires [onShowAll]
+/// — callers wire it to the same picker modal the season picker uses.
+/// Without [onShowAll] the row falls back to a plain horizontal scroll
+/// capped at [_maxMembers] (15). D-pad traversal is native: left/right
+/// moves focus between cards; the row stops at its edges so focus
+/// doesn't escape into the surrounding column. Focused cards get the
+/// canonical project-wide [GradientBorderEffect] glow. Member cards
+/// have no tap action — cast is informational on wide layouts.
 ///
-/// D-pad traversal is native: left/right moves focus between cards; the
-/// row stops at its edges so focus doesn't escape into the surrounding
-/// column. Focused cards get the canonical project-wide
-/// [GradientBorderEffect] glow (drawn separately from the decorative
-/// ring). Tapping does nothing in v1 — cast is informational.
-///
-/// **Compact mode** (`compact = true`) shrinks the visible member count
-/// to [compactVisibleCount] and appends an "all cast" tile — the m3u-tv
-/// favicon in the same 72×72 avatar circle, with a `_` glyph in the
-/// lower-right corner — which fires [onShowAll] on tap. Used on the
-/// narrow breakpoint of the VOD / Series detail screens, where three
-/// cast cards plus the overflow tile is all the row can fit without
-/// truncating names. The tile only renders when both `compact` is true,
-/// [onShowAll] is non-null, and the cast list is longer than
-/// [compactVisibleCount]; with ≤ 3 members there's nothing to expand to.
+/// **Compact mode** (`compact = true`, phone breakpoint): a pill-shaped
+/// picker button mirroring the season picker's chrome — the localized
+/// "Cast" label, a down-chevron, and a count badge showing how many cast
+/// members are in [members]. Tapping the button fires [onShowAll],
+/// which callers wire to the same bottom-drawer picker used by the
+/// season picker. The picker button is hidden when [onShowAll] is null,
+/// allowing narrow callers (e.g. a search results card) to opt out of
+/// the cast UI entirely.
 class CastMemberRow extends StatelessWidget {
   const CastMemberRow({
     super.key,
@@ -47,35 +49,34 @@ class CastMemberRow extends StatelessWidget {
 
   final List<CastMember>? members;
 
-  /// Optional accessibility label for the row (e.g. "Cast"). Spoken by
-  /// screen readers when focus enters the row; localized at the call
-  /// site so the row itself stays locale-agnostic.
+  /// Accessibility label for the row in wide layout, and the visible
+  /// button label in compact layout. Localized at the call site (the
+  /// VOD/Series detail screens pass `AppLocalizations.of(context)
+  /// .vodCast` / `.seriesCast`). The row itself stays
+  /// locale-agnostic.
   final String? semanticLabel;
 
-  /// Narrow-breakpoint layout. Caps the visible cards and appends the
-  /// "all cast" overflow tile (see [onShowAll]).
+  /// Phone-breakpoint layout. Renders a single picker button instead of
+  /// the wide horizontal scroll row. See class doc.
   final bool compact;
 
-  /// Tap handler for the overflow tile. Only invoked when `compact` is
-  /// true and [members] has more entries than
-  /// [CastMemberRow.compactVisibleCount]. Typically
-  /// opens a bottom sheet listing the full cast (matches the season
-  /// picker shape — same DpadRegion, Scrollbar, ListView).
+  /// Tap handler for the compact picker chip and the wide layout's
+  /// "+N / show all" overflow tile. Typically opens the full cast in
+  /// the same modal shape the season picker uses (bottom sheet on the
+  /// narrow breakpoint, centered dialog on the wide one). When null,
+  /// the compact widget renders nothing and the wide row falls back to
+  /// a plain scroll without an overflow tile.
   final VoidCallback? onShowAll;
 
-  /// Accessibility label spoken for the overflow tile ("Show all
-  /// cast"). Localized at the call site.
+  /// Accessibility / visible label for the sheet when the picker is
+  /// tapped (e.g. "Show all cast"). Localized at the call site.
   final String? allCastSemanticLabel;
 
   static const double _cardWidth = 144;
   static const double _avatarSize = 72;
   static const double _cardHeight = 140;
+  static const double _cardGap = 12;
   static const int _maxMembers = 15;
-
-  /// Number of cast cards shown in compact mode before the overflow tile.
-  /// Three cards + one tile fits inside a 720-wide narrow layout with
-  /// the standard page padding without truncating names.
-  static const int compactVisibleCount = 3;
 
   @override
   Widget build(BuildContext context) {
@@ -83,41 +84,17 @@ class CastMemberRow extends StatelessWidget {
     if (visible == null || visible.isEmpty) {
       return const SizedBox.shrink();
     }
-    final compactLimit = compact ? compactVisibleCount : _maxMembers;
-    final shown = visible.length > compactLimit
-        ? visible.sublist(0, compactLimit)
-        : visible;
-    final showOverflowTile =
-        compact && onShowAll != null && visible.length > compactVisibleCount;
 
-    final row = SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      padding: EdgeInsets.zero,
-      child: Row(
-        children: [
-          for (var i = 0; i < shown.length; i++) ...[
-            if (i > 0) const SizedBox(width: 12),
-            SizedBox(
-              width: _cardWidth,
-              height: _cardHeight,
-              child: _CastMemberCard(member: shown[i]),
-            ),
-          ],
-          if (showOverflowTile) ...[
-            const SizedBox(width: 12),
-            SizedBox(
-              width: _cardWidth,
-              height: _cardHeight,
-              child: _ShowAllCastCard(
-                onTap: onShowAll!,
-                nameLabel: allCastSemanticLabel ?? 'Show all',
-                semanticLabel: allCastSemanticLabel,
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
+    if (compact) {
+      // Compact callers without a sheet set onShowAll=null → render
+      // nothing. Avoids a tap target that would no-op.
+      if (onShowAll == null) return const SizedBox.shrink();
+      return _CastPickerButton(
+        label: semanticLabel ?? 'Cast',
+        badgeCount: visible.length,
+        onTap: onShowAll!,
+      );
+    }
 
     return Semantics(
       label: semanticLabel,
@@ -125,7 +102,165 @@ class CastMemberRow extends StatelessWidget {
       child: DpadRegion(
         memoryKey: 'cast-member-row',
         horizontalEdge: DpadEdgeBehavior.stop,
-        child: row,
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final capped = visible.length > _maxMembers
+                ? visible.sublist(0, _maxMembers)
+                : visible;
+            // Card slots that fit the available width without scrolling
+            // (n × 144 + (n−1) × 12 ≤ maxWidth). Unbounded width (e.g.
+            // an ancestor horizontal scroller) fits everything.
+            final maxWidth = constraints.maxWidth;
+            final fit = maxWidth.isFinite
+                ? math.max(
+                    1,
+                    (maxWidth + _cardGap) ~/ (_cardWidth + _cardGap),
+                  )
+                : capped.length;
+            // With onShowAll wired, members beyond what fits collapse
+            // into a trailing "+N / show all" tile instead of scrolling
+            // off-screen. Without it, keep the plain capped scroll row.
+            final overflows = onShowAll != null && visible.length > fit;
+            final shown = overflows
+                ? capped.sublist(0, math.min(fit - 1, capped.length))
+                : capped;
+            final hiddenCount = visible.length - shown.length;
+
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              padding: EdgeInsets.zero,
+              child: Row(
+                children: [
+                  for (var i = 0; i < shown.length; i++) ...[
+                    if (i > 0) const SizedBox(width: _cardGap),
+                    SizedBox(
+                      width: _cardWidth,
+                      height: _cardHeight,
+                      child: _CastMemberCard(member: shown[i]),
+                    ),
+                  ],
+                  if (overflows) ...[
+                    if (shown.isNotEmpty) const SizedBox(width: _cardGap),
+                    SizedBox(
+                      width: _cardWidth,
+                      height: _cardHeight,
+                      child: _ShowAllCastCard(
+                        hiddenCount: hiddenCount,
+                        label: allCastSemanticLabel ?? 'Show all',
+                        onTap: onShowAll!,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Pill-shaped picker button matching the season picker's chrome:
+/// `label` text, a count badge, a down-chevron, focused via
+/// [GradientBorderEffect]. Tap fires [onTap]. Renders nothing different
+/// when [badgeCount] is 0 or 1 — the season picker shows the badge for
+/// any positive count.
+class _CastPickerButton extends StatelessWidget {
+  const _CastPickerButton({
+    required this.label,
+    required this.badgeCount,
+    required this.onTap,
+  });
+
+  final String label;
+  final int badgeCount;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return AppButton(
+      label: label,
+      icon: Icons.arrow_drop_down,
+      badgeCount: badgeCount > 0 ? badgeCount : null,
+      // Muted, not the default error red — this is a count, not an
+      // unwatched / new alert (matches how the season picker styles its
+      // episode-count badge).
+      badgeColor: scheme.surfaceContainerHighest,
+      badgeTextColor: scheme.onSurfaceVariant,
+      onPressed: onTap,
+    );
+  }
+}
+
+/// Trailing wide-layout tile shown when more members exist than fit
+/// the row: a "+N" circle where the avatar sits and the localized
+/// "Show all" label in the name slot. Tap opens the full cast in the
+/// caller's picker modal.
+class _ShowAllCastCard extends StatelessWidget {
+  const _ShowAllCastCard({
+    required this.hiddenCount,
+    required this.label,
+    required this.onTap,
+  });
+
+  final int hiddenCount;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+
+    return Semantics(
+      label: label,
+      button: true,
+      child: DpadInkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+        effects: const [
+          GradientBorderEffect(
+            borderRadius: BorderRadius.all(Radius.circular(8)),
+          ),
+        ],
+        child: Column(
+          children: [
+            SizedBox(
+              width: CastMemberRow._avatarSize,
+              height: CastMemberRow._avatarSize,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: scheme.surfaceContainerHighest,
+                ),
+                child: Center(
+                  child: Text(
+                    '+$hiddenCount',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -195,138 +330,6 @@ class _CastMemberCard extends StatelessWidget {
               ),
             ],
           ],
-        ),
-      ),
-    );
-  }
-}
-
-/// "All cast" overflow tile used in compact mode. Avatar circle shows
-/// the m3u-tv favicon (no photo) with a `_` glyph anchored to the
-/// lower-right corner of the circle. Name slot reads "Show all cast"
-/// (localized at the call site via [CastMemberRow.allCastSemanticLabel]
-/// is the screen-reader label; the visible text below is set by the
-/// tile's own [nameLabel]).
-class _ShowAllCastCard extends StatelessWidget {
-  const _ShowAllCastCard({
-    required this.onTap,
-    required this.nameLabel,
-    this.semanticLabel,
-  });
-
-  final VoidCallback onTap;
-  final String nameLabel;
-  final String? semanticLabel;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final scheme = theme.colorScheme;
-    return Semantics(
-      label: semanticLabel,
-      button: true,
-      child: DpadInkWell(
-        onTap: onTap,
-        borderRadius: const BorderRadius.all(Radius.circular(8)),
-        effects: const [
-          GradientBorderEffect(
-            borderRadius: BorderRadius.all(Radius.circular(8)),
-          ),
-        ],
-        child: Column(
-          children: [
-            // Same avatar size as a regular cast card.
-            SizedBox(
-              width: CastMemberRow._avatarSize,
-              height: CastMemberRow._avatarSize,
-              child: Stack(
-                children: [
-                  Positioned.fill(
-                    child: ClipOval(
-                      child: ColoredBox(
-                        color: scheme.surfaceContainerHighest,
-                        child: Padding(
-                          padding: const EdgeInsets.all(12),
-                          child: Image.asset(
-                            'assets/icons/favicon.png',
-                            fit: BoxFit.contain,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  Positioned(
-                    right: 0,
-                    bottom: 0,
-                    child: _UnderscoreBadge(
-                      color: scheme.primary,
-                      onColor: scheme.onPrimary,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 8),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: Text(
-                nameLabel,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                textAlign: TextAlign.center,
-              ),
-            ),
-            const SizedBox(height: 2),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4),
-              child: Text(
-                '…',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: scheme.onSurfaceVariant,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.clip,
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-/// Small circular badge holding a single `_` glyph. Anchored to the
-/// lower-right of the favicon avatar circle in [CastMemberRow]. Reads
-/// as "more items" — the underscore is the project's standard "tap to
-/// expand" affordance (also used in the inline season picker row).
-class _UnderscoreBadge extends StatelessWidget {
-  const _UnderscoreBadge({required this.color, required this.onColor});
-
-  final Color color;
-  final Color onColor;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: 22,
-      height: 22,
-      decoration: BoxDecoration(
-        color: color,
-        shape: BoxShape.circle,
-        border: Border.all(color: Colors.black87, width: 1.5),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        '_',
-        style: TextStyle(
-          color: onColor,
-          fontSize: 14,
-          fontWeight: FontWeight.w900,
-          height: 1,
         ),
       ),
     );

--- a/flutter_client/lib/shared/cast_member_row.dart
+++ b/flutter_client/lib/shared/cast_member_row.dart
@@ -25,11 +25,24 @@ import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 /// column. Focused cards get the canonical project-wide
 /// [GradientBorderEffect] glow (drawn separately from the decorative
 /// ring). Tapping does nothing in v1 — cast is informational.
+///
+/// **Compact mode** (`compact = true`) shrinks the visible member count
+/// to [compactVisibleCount] and appends an "all cast" tile — the m3u-tv
+/// favicon in the same 72×72 avatar circle, with a `_` glyph in the
+/// lower-right corner — which fires [onShowAll] on tap. Used on the
+/// narrow breakpoint of the VOD / Series detail screens, where three
+/// cast cards plus the overflow tile is all the row can fit without
+/// truncating names. The tile only renders when both `compact` is true,
+/// [onShowAll] is non-null, and the cast list is longer than
+/// [compactVisibleCount]; with ≤ 3 members there's nothing to expand to.
 class CastMemberRow extends StatelessWidget {
   const CastMemberRow({
     super.key,
     required this.members,
     this.semanticLabel,
+    this.compact = false,
+    this.onShowAll,
+    this.allCastSemanticLabel,
   });
 
   final List<CastMember>? members;
@@ -39,10 +52,30 @@ class CastMemberRow extends StatelessWidget {
   /// site so the row itself stays locale-agnostic.
   final String? semanticLabel;
 
+  /// Narrow-breakpoint layout. Caps the visible cards and appends the
+  /// "all cast" overflow tile (see [onShowAll]).
+  final bool compact;
+
+  /// Tap handler for the overflow tile. Only invoked when `compact` is
+  /// true and [members] has more entries than
+  /// [CastMemberRow.compactVisibleCount]. Typically
+  /// opens a bottom sheet listing the full cast (matches the season
+  /// picker shape — same DpadRegion, Scrollbar, ListView).
+  final VoidCallback? onShowAll;
+
+  /// Accessibility label spoken for the overflow tile ("Show all
+  /// cast"). Localized at the call site.
+  final String? allCastSemanticLabel;
+
   static const double _cardWidth = 144;
   static const double _avatarSize = 72;
   static const double _cardHeight = 140;
   static const int _maxMembers = 15;
+
+  /// Number of cast cards shown in compact mode before the overflow tile.
+  /// Three cards + one tile fits inside a 720-wide narrow layout with
+  /// the standard page padding without truncating names.
+  static const int compactVisibleCount = 3;
 
   @override
   Widget build(BuildContext context) {
@@ -50,9 +83,12 @@ class CastMemberRow extends StatelessWidget {
     if (visible == null || visible.isEmpty) {
       return const SizedBox.shrink();
     }
-    final shown = visible.length > _maxMembers
-        ? visible.sublist(0, _maxMembers)
+    final compactLimit = compact ? compactVisibleCount : _maxMembers;
+    final shown = visible.length > compactLimit
+        ? visible.sublist(0, compactLimit)
         : visible;
+    final showOverflowTile =
+        compact && onShowAll != null && visible.length > compactVisibleCount;
 
     final row = SingleChildScrollView(
       scrollDirection: Axis.horizontal,
@@ -65,6 +101,18 @@ class CastMemberRow extends StatelessWidget {
               width: _cardWidth,
               height: _cardHeight,
               child: _CastMemberCard(member: shown[i]),
+            ),
+          ],
+          if (showOverflowTile) ...[
+            const SizedBox(width: 12),
+            SizedBox(
+              width: _cardWidth,
+              height: _cardHeight,
+              child: _ShowAllCastCard(
+                onTap: onShowAll!,
+                nameLabel: allCastSemanticLabel ?? 'Show all',
+                semanticLabel: allCastSemanticLabel,
+              ),
             ),
           ],
         ],
@@ -147,6 +195,138 @@ class _CastMemberCard extends StatelessWidget {
               ),
             ],
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// "All cast" overflow tile used in compact mode. Avatar circle shows
+/// the m3u-tv favicon (no photo) with a `_` glyph anchored to the
+/// lower-right corner of the circle. Name slot reads "Show all cast"
+/// (localized at the call site via [CastMemberRow.allCastSemanticLabel]
+/// is the screen-reader label; the visible text below is set by the
+/// tile's own [nameLabel]).
+class _ShowAllCastCard extends StatelessWidget {
+  const _ShowAllCastCard({
+    required this.onTap,
+    required this.nameLabel,
+    this.semanticLabel,
+  });
+
+  final VoidCallback onTap;
+  final String nameLabel;
+  final String? semanticLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return Semantics(
+      label: semanticLabel,
+      button: true,
+      child: DpadInkWell(
+        onTap: onTap,
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+        effects: const [
+          GradientBorderEffect(
+            borderRadius: BorderRadius.all(Radius.circular(8)),
+          ),
+        ],
+        child: Column(
+          children: [
+            // Same avatar size as a regular cast card.
+            SizedBox(
+              width: CastMemberRow._avatarSize,
+              height: CastMemberRow._avatarSize,
+              child: Stack(
+                children: [
+                  Positioned.fill(
+                    child: ClipOval(
+                      child: ColoredBox(
+                        color: scheme.surfaceContainerHighest,
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: Image.asset(
+                            'assets/icons/favicon.png',
+                            fit: BoxFit.contain,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    right: 0,
+                    bottom: 0,
+                    child: _UnderscoreBadge(
+                      color: scheme.primary,
+                      onColor: scheme.onPrimary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                nameLabel,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 2),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                '…',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: scheme.onSurfaceVariant,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.clip,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Small circular badge holding a single `_` glyph. Anchored to the
+/// lower-right of the favicon avatar circle in [CastMemberRow]. Reads
+/// as "more items" — the underscore is the project's standard "tap to
+/// expand" affordance (also used in the inline season picker row).
+class _UnderscoreBadge extends StatelessWidget {
+  const _UnderscoreBadge({required this.color, required this.onColor});
+
+  final Color color;
+  final Color onColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 22,
+      height: 22,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+        border: Border.all(color: Colors.black87, width: 1.5),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '_',
+        style: TextStyle(
+          color: onColor,
+          fontSize: 14,
+          fontWeight: FontWeight.w900,
+          height: 1,
         ),
       ),
     );

--- a/flutter_client/lib/shared/cast_member_row.dart
+++ b/flutter_client/lib/shared/cast_member_row.dart
@@ -1,0 +1,241 @@
+import 'package:dpad/dpad.dart';
+import 'package:flutter/material.dart';
+
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/dpad_ink_well.dart';
+import 'package:m3u_tv/shared/gradient_border_effect.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+/// Horizontally scrolling row of cast member cards. Used on the VOD movie
+/// detail and Series detail screens to display the rich cast emitted by
+/// m3u-editor's `cast_list` payload. Returns [SizedBox.shrink] when
+/// [members] is null or empty so callers can drop it inline without a
+/// null check.
+///
+/// Each card is 144×~140: a 72×72 circular avatar wrapped in a subtle
+/// primary→secondary gradient ring (decorative even when unfocused),
+/// with a transparent→black bottom-fade overlay inside the ring so the
+/// `Icons.person` fallback blends with the surface. Name (bold, 1 line)
+/// and character (muted, 1 line) sit below in a billing-block layout —
+/// 144px of width fits ~21 characters so names like "Christoph Waltz"
+/// and "Jesse Pinkman" don't truncate.
+///
+/// D-pad traversal is native: left/right moves focus between cards; the
+/// row stops at its edges so focus doesn't escape into the surrounding
+/// column. Focused cards get the canonical project-wide
+/// [GradientBorderEffect] glow (drawn separately from the decorative
+/// ring). Tapping does nothing in v1 — cast is informational.
+class CastMemberRow extends StatelessWidget {
+  const CastMemberRow({
+    super.key,
+    required this.members,
+    this.semanticLabel,
+  });
+
+  final List<CastMember>? members;
+
+  /// Optional accessibility label for the row (e.g. "Cast"). Spoken by
+  /// screen readers when focus enters the row; localized at the call
+  /// site so the row itself stays locale-agnostic.
+  final String? semanticLabel;
+
+  static const double _cardWidth = 144;
+  static const double _avatarSize = 72;
+  static const double _cardHeight = 140;
+  static const int _maxMembers = 15;
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = members;
+    if (visible == null || visible.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    final shown = visible.length > _maxMembers
+        ? visible.sublist(0, _maxMembers)
+        : visible;
+
+    final row = SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      padding: EdgeInsets.zero,
+      child: Row(
+        children: [
+          for (var i = 0; i < shown.length; i++) ...[
+            if (i > 0) const SizedBox(width: 12),
+            SizedBox(
+              width: _cardWidth,
+              height: _cardHeight,
+              child: _CastMemberCard(member: shown[i]),
+            ),
+          ],
+        ],
+      ),
+    );
+
+    return Semantics(
+      label: semanticLabel,
+      container: true,
+      child: DpadRegion(
+        memoryKey: 'cast-member-row',
+        horizontalEdge: DpadEdgeBehavior.stop,
+        child: row,
+      ),
+    );
+  }
+}
+
+class _CastMemberCard extends StatelessWidget {
+  const _CastMemberCard({required this.member});
+
+  final CastMember member;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final name = member.name;
+    final character = member.character;
+
+    return Semantics(
+      label: character != null && character.isNotEmpty
+          ? '$name as $character'
+          : name,
+      child: DpadInkWell(
+        // No tap action — cast is informational in v1.
+        borderRadius: const BorderRadius.all(Radius.circular(8)),
+        effects: const [
+          GradientBorderEffect(
+            borderRadius: BorderRadius.all(Radius.circular(8)),
+          ),
+        ],
+        child: Column(
+          children: [
+            // Decorative gradient ring + circular avatar + bottom-fade.
+            _GradientRingAvatar(
+              size: CastMemberRow._avatarSize,
+              ringWidth: 2,
+              child: _AvatarWithFade(
+                imageUrl: member.photo,
+                size: CastMemberRow._avatarSize,
+                surface: scheme.surface,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Text(
+                name,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            if (character != null && character.isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4),
+                child: Text(
+                  character,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Decorative primary→secondary gradient ring painted around a circular
+/// child (the avatar). Unfocused; focus is handled by [GradientBorderEffect]
+/// at the card level.
+class _GradientRingAvatar extends StatelessWidget {
+  const _GradientRingAvatar({
+    required this.child,
+    required this.size,
+    required this.ringWidth,
+  });
+
+  final Widget child;
+  final double size;
+  final double ringWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      width: size + ringWidth * 2,
+      height: size + ringWidth * 2,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          begin: Alignment.topRight,
+          end: Alignment.bottomLeft,
+          colors: [scheme.primary, scheme.secondary],
+        ),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(ringWidth),
+        child: ClipOval(child: child),
+      ),
+    );
+  }
+}
+
+/// Circular clip containing the [ResilientMediaImage] headshot, with a
+/// transparent→surface fade across the bottom ~35%. The fade softens
+/// the [Icons.person] fallback when no photo loads, and gives loaded
+/// headshots a subtle poster-like depth.
+class _AvatarWithFade extends StatelessWidget {
+  const _AvatarWithFade({
+    required this.imageUrl,
+    required this.size,
+    required this.surface,
+  });
+
+  final String? imageUrl;
+  final double size;
+  final Color surface;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        children: [
+          ResilientMediaImage(
+            imageUrl: imageUrl,
+            fallbackIcon: Icons.person,
+            backgroundColor: surface,
+          ),
+          Positioned.fill(
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: [
+                      Colors.transparent,
+                      surface.withValues(alpha: 0.6),
+                    ],
+                    stops: const [0.65, 1.0],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/shared/list_picker_sheet.dart
+++ b/flutter_client/lib/shared/list_picker_sheet.dart
@@ -1,0 +1,124 @@
+import 'package:dpad/dpad.dart';
+import 'package:flutter/material.dart';
+
+import 'package:m3u_tv/shared/app_button.dart';
+
+/// Generic bottom-sheet picker for "show all X" overflow scenarios on
+/// the narrow breakpoint. Mirrors the season picker's mobile form
+/// (one [DpadRegion] containing a title row + capped ListView, sheet
+/// anchored at the bottom with a drag handle).
+///
+/// Used by the cast "Show all" overflow tile on VOD and Series detail
+/// screens; also a natural fit for any future "more items" affordance
+/// that needs a scrollable mobile sheet. The picker's contents are
+/// caller-supplied via [children] — this widget owns only the modal
+/// chrome.
+///
+/// Focus lands on the [autofocusIndex] child (default 0) so the list is
+/// immediately drivable by D-pad. The list is height-capped with a
+/// [ConstrainedBox] (not a [Flexible]) so the layout stays
+/// deterministic inside the modal's intrinsic sizing — a Flexible
+/// there lets rows overflow the sheet's clip and drop out of
+/// hit-testing.
+class ListPickerSheet extends StatelessWidget {
+  const ListPickerSheet({
+    super.key,
+    required this.title,
+    required this.children,
+    this.autofocusIndex = 0,
+    this.cancelLabel,
+  });
+
+  /// Header text in the sheet's title row.
+  final String title;
+
+  /// Scrollable row widgets. Caller owns their layout — typically one
+  /// ListTile or DpadInkWell per item.
+  final List<Widget> children;
+
+  /// Index of the child that receives initial focus when the sheet
+  /// opens. Pass -1 to disable autofocus.
+  final int autofocusIndex;
+
+  /// Tooltip / semantics label for the close icon button. Falls back
+  /// to "Cancel" if null (callers should localize).
+  final String? cancelLabel;
+
+  /// Show the sheet. Convenience wrapper that opens a drag-handle
+  /// bottom sheet (modally, anchored to the root navigator) sized to
+  /// the supplied [children]. The inner list caps at 70% of the
+  /// viewport so long lists scroll inside the sheet instead of
+  /// pushing it off-screen.
+  static Future<void> show(
+    BuildContext context, {
+    required String title,
+    required List<Widget> children,
+    int autofocusIndex = 0,
+    String? cancelLabel,
+  }) {
+    return showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (sheetContext) => SafeArea(
+        child: ListPickerSheet(
+          title: title,
+          autofocusIndex: autofocusIndex,
+          cancelLabel: cancelLabel,
+          children: children,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewportHeight = MediaQuery.sizeOf(context).height;
+    final scheme = Theme.of(context).colorScheme;
+    final titleStyle = Theme.of(context).textTheme.titleLarge?.copyWith(
+          color: scheme.onSurface,
+        );
+    final maxListHeight = viewportHeight * 0.7;
+
+    return DpadRegion(
+      verticalEdge: DpadEdgeBehavior.stop,
+      horizontalEdge: DpadEdgeBehavior.stop,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(24, 0, 12, 4),
+            child: Row(
+              children: [
+                Expanded(child: Text(title, style: titleStyle)),
+                AppIconButton(
+                  icon: Icons.close,
+                  dense: true,
+                  tooltip: cancelLabel ?? 'Cancel',
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+          ),
+          ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: maxListHeight),
+            child: Scrollbar(
+              child: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.fromLTRB(12, 4, 12, 12),
+                children: [
+                  for (var i = 0; i < children.length; i++)
+                    if (i == autofocusIndex)
+                      Focus(autofocus: true, child: children[i])
+                    else
+                      children[i],
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/flutter_client/lib/shared/list_picker_sheet.dart
+++ b/flutter_client/lib/shared/list_picker_sheet.dart
@@ -3,14 +3,16 @@ import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/shared/app_button.dart';
 
-/// Generic bottom-sheet picker for "show all X" overflow scenarios on
-/// the narrow breakpoint. Mirrors the season picker's mobile form
-/// (one [DpadRegion] containing a title row + capped ListView, sheet
-/// anchored at the bottom with a drag handle).
+/// Generic picker for "show all X" overflow scenarios. Mirrors the
+/// season picker's two modal forms: a drag-handle bottom sheet on the
+/// narrow breakpoint ([show] with `asDialog: false`, the default) and a
+/// centered [AlertDialog] on the wide/TV breakpoint (`asDialog: true`).
+/// Either way it is one [DpadRegion] containing a title row + capped
+/// ListView.
 ///
-/// Used by the cast "Show all" overflow tile on VOD and Series detail
+/// Used by the cast "Show all" affordances on VOD and Series detail
 /// screens; also a natural fit for any future "more items" affordance
-/// that needs a scrollable mobile sheet. The picker's contents are
+/// that needs a scrollable picker. The picker's contents are
 /// caller-supplied via [children] — this widget owns only the modal
 /// chrome.
 ///
@@ -27,6 +29,7 @@ class ListPickerSheet extends StatelessWidget {
     required this.children,
     this.autofocusIndex = 0,
     this.cancelLabel,
+    this.asDialog = false,
   });
 
   /// Header text in the sheet's title row.
@@ -44,18 +47,44 @@ class ListPickerSheet extends StatelessWidget {
   /// to "Cancel" if null (callers should localize).
   final String? cancelLabel;
 
-  /// Show the sheet. Convenience wrapper that opens a drag-handle
-  /// bottom sheet (modally, anchored to the root navigator) sized to
-  /// the supplied [children]. The inner list caps at 70% of the
-  /// viewport so long lists scroll inside the sheet instead of
-  /// pushing it off-screen.
+  /// Dialog chrome instead of sheet chrome: tighter list metrics, a
+  /// slightly lower height cap and an always-visible scrollbar thumb —
+  /// matching the season picker's wide-layout dialog.
+  final bool asDialog;
+
+  /// Show the picker. Opens a drag-handle bottom sheet by default
+  /// (narrow breakpoint), or a centered 460px [AlertDialog] when
+  /// [asDialog] is true (wide/TV breakpoint) — the same split the
+  /// season picker uses. Either way the inner list is height-capped so
+  /// long lists scroll inside the modal instead of pushing it
+  /// off-screen.
   static Future<void> show(
     BuildContext context, {
     required String title,
     required List<Widget> children,
     int autofocusIndex = 0,
     String? cancelLabel,
+    bool asDialog = false,
   }) {
+    if (asDialog) {
+      return showDialog<void>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          clipBehavior: Clip.antiAlias,
+          contentPadding: const EdgeInsets.fromLTRB(0, 16, 0, 12),
+          content: SizedBox(
+            width: 460,
+            child: ListPickerSheet(
+              title: title,
+              autofocusIndex: autofocusIndex,
+              cancelLabel: cancelLabel,
+              asDialog: true,
+              children: children,
+            ),
+          ),
+        ),
+      );
+    }
     return showModalBottomSheet<void>(
       context: context,
       showDragHandle: true,
@@ -76,9 +105,14 @@ class ListPickerSheet extends StatelessWidget {
     final viewportHeight = MediaQuery.sizeOf(context).height;
     final scheme = Theme.of(context).colorScheme;
     final titleStyle = Theme.of(context).textTheme.titleLarge?.copyWith(
-          color: scheme.onSurface,
-        );
-    final maxListHeight = viewportHeight * 0.7;
+      color: scheme.onSurface,
+    );
+    // Same metric split as the season picker: 70% cap in the sheet,
+    // 65% + visible thumb + tighter bottom padding in the dialog.
+    final maxListHeight = viewportHeight * (asDialog ? 0.65 : 0.7);
+    final listPadding = asDialog
+        ? const EdgeInsets.fromLTRB(12, 4, 12, 4)
+        : const EdgeInsets.fromLTRB(12, 4, 12, 12);
 
     return DpadRegion(
       verticalEdge: DpadEdgeBehavior.stop,
@@ -104,9 +138,10 @@ class ListPickerSheet extends StatelessWidget {
           ConstrainedBox(
             constraints: BoxConstraints(maxHeight: maxListHeight),
             child: Scrollbar(
+              thumbVisibility: asDialog,
               child: ListView(
                 shrinkWrap: true,
-                padding: const EdgeInsets.fromLTRB(12, 4, 12, 12),
+                padding: listPadding,
                 children: [
                   for (var i = 0; i < children.length; i++)
                     if (i == autofocusIndex)

--- a/flutter_client/lib/shared/list_picker_sheet.dart
+++ b/flutter_client/lib/shared/list_picker_sheet.dart
@@ -13,15 +13,16 @@ import 'package:m3u_tv/shared/app_button.dart';
 /// Used by the cast "Show all" affordances on VOD and Series detail
 /// screens; also a natural fit for any future "more items" affordance
 /// that needs a scrollable picker. The picker's contents are
-/// caller-supplied via [children] — this widget owns only the modal
+/// caller-supplied via [children] - this widget owns only the modal
 /// chrome.
 ///
-/// Focus lands on the [autofocusIndex] child (default 0) so the list is
-/// immediately drivable by D-pad. The list is height-capped with a
-/// [ConstrainedBox] (not a [Flexible]) so the layout stays
-/// deterministic inside the modal's intrinsic sizing — a Flexible
-/// there lets rows overflow the sheet's clip and drop out of
-/// hit-testing.
+/// Focus lands on the [autofocusIndex] child (default 0) so D-pad input
+/// starts inside the list rather than on the surrounding scrim; when the
+/// children are non-interactive (e.g. cast rows) this just seats the
+/// scroll position. The list is height-capped with a [ConstrainedBox]
+/// (not a [Flexible]) so the layout stays deterministic inside the
+/// modal's intrinsic sizing - a Flexible there lets rows overflow the
+/// sheet's clip and drop out of hit-testing.
 class ListPickerSheet extends StatelessWidget {
   const ListPickerSheet({
     super.key,
@@ -35,7 +36,7 @@ class ListPickerSheet extends StatelessWidget {
   /// Header text in the sheet's title row.
   final String title;
 
-  /// Scrollable row widgets. Caller owns their layout — typically one
+  /// Scrollable row widgets. Caller owns their layout - typically one
   /// ListTile or DpadInkWell per item.
   final List<Widget> children;
 
@@ -48,13 +49,13 @@ class ListPickerSheet extends StatelessWidget {
   final String? cancelLabel;
 
   /// Dialog chrome instead of sheet chrome: tighter list metrics, a
-  /// slightly lower height cap and an always-visible scrollbar thumb —
+  /// slightly lower height cap and an always-visible scrollbar thumb -
   /// matching the season picker's wide-layout dialog.
   final bool asDialog;
 
   /// Show the picker. Opens a drag-handle bottom sheet by default
   /// (narrow breakpoint), or a centered 460px [AlertDialog] when
-  /// [asDialog] is true (wide/TV breakpoint) — the same split the
+  /// [asDialog] is true (wide/TV breakpoint) - the same split the
   /// season picker uses. Either way the inner list is height-capped so
   /// long lists scroll inside the modal instead of pushing it
   /// off-screen.

--- a/flutter_client/test/features/series/series_details_screen_test.dart
+++ b/flutter_client/test/features/series/series_details_screen_test.dart
@@ -639,7 +639,9 @@ void main() {
                 ],
               ),
               seasons: const [Season(number: 1, name: 'Season 1')],
-              episodesBySeason: {1: [_ep(1, 1)]},
+              episodesBySeason: {
+                1: [_ep(1, 1)],
+              },
             ),
           ),
         );
@@ -684,14 +686,43 @@ void main() {
                 ],
               ),
               seasons: const [Season(number: 1, name: 'Season 1')],
-              episodesBySeason: {1: [_ep(1, 1)]},
+              episodesBySeason: {
+                1: [_ep(1, 1)],
+              },
             ),
           ),
         );
         await tester.pumpAndSettle();
 
+        // Compact layout is a single picker chip — only the "Cast"
+        // label and a count badge render; member names live inside
+        // the bottom sheet, not inline.
         expect(find.byType(CastMemberRow), findsOneWidget);
-        expect(find.text('Bryan Cranston'), findsOneWidget);
+        expect(find.text('Cast'), findsOneWidget);
+        // Scoped to the cast row — the season picker's episode-count
+        // badge also renders "1" for this single-episode fixture.
+        expect(
+          find.descendant(
+            of: find.byType(CastMemberRow),
+            matching: find.text('1'),
+          ),
+          findsOneWidget,
+        );
+        // No member name bleeds into the inline compact layout.
+        expect(find.text('Bryan Cranston'), findsNothing);
+        // The chip lives in the same Wrap as the season picker — beside
+        // it, not on its own row above the action buttons.
+        final actionWrap = find.ancestor(
+          of: find.text('Season 1'),
+          matching: find.byType(Wrap),
+        );
+        expect(
+          find.descendant(
+            of: actionWrap.first,
+            matching: find.byType(CastMemberRow),
+          ),
+          findsOneWidget,
+        );
       },
     );
 
@@ -711,14 +742,14 @@ void main() {
     );
 
     testWidgets(
-      'narrow layout: rich cast overflow tile opens bottom sheet listing all members',
+      'narrow layout: rich cast picker button opens bottom sheet listing all members',
       (tester) async {
         tester.view.physicalSize = const Size(420, 800);
         tester.view.devicePixelRatio = 1.0;
         addTearDown(tester.view.resetPhysicalSize);
         addTearDown(tester.view.resetDevicePixelRatio);
 
-        // 5 members → narrow layout caps to 3 + overflow tile.
+        // 5 members → compact layout shows one chip with a "5" badge.
         final richCast = <CastMember>[
           const CastMember(name: 'Bryan Cranston', character: 'Walter White'),
           const CastMember(name: 'Aaron Paul', character: 'Jesse Pinkman'),
@@ -731,51 +762,40 @@ void main() {
             SeriesInfo(
               series: Series(id: 7, name: 'Rich Cast Show', richCast: richCast),
               seasons: const [Season(number: 1, name: 'Season 1')],
-              episodesBySeason: {1: [_ep(1, 1)]},
+              episodesBySeason: {
+                1: [_ep(1, 1)],
+              },
             ),
           ),
         );
         await tester.pumpAndSettle();
 
-        // The overflow tile uses the localized "Show all cast" label.
-        final l = AppLocalizations.of(
-          tester.element(find.byType(CastMemberRow)),
-        );
-        expect(find.text(l.castShowAll), findsOneWidget);
+        // The picker is the visible inline compact control — a button
+        // labelled "Cast" with a count badge showing all 5 members.
+        expect(find.text('Cast'), findsOneWidget);
+        expect(find.text('5'), findsOneWidget);
 
-        // The overflow tile is past the visible viewport on a 420-wide
-        // phone (4 × 144 + gaps = 612). Scroll it into view before tapping.
-        await tester.scrollUntilVisible(
-          find.text(l.castShowAll),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
+        // Tap the picker → bottom sheet opens with every member
+        // listed (5 rows). Compact layout keeps member names inside
+        // the sheet only — no inline duplication.
+        await tester.tap(find.text('Cast'));
         await tester.pumpAndSettle();
 
-        // Tap → bottom sheet opens with every member (5 rows).
-        await tester.tap(find.text(l.castShowAll));
-        await tester.pumpAndSettle();
-
-        // Sheet title and all 5 names rendered (members beyond the 3
-        // visible in the inline row are now reachable). The inline row
-        // shows the first 3 cast cards, so those names appear twice
-        // (inline + sheet); only the trailing two are sheet-only.
-        expect(find.text(l.castShowAll), findsAtLeast(1));
-        expect(find.text('Bryan Cranston'), findsNWidgets(2));
-        expect(find.text('Aaron Paul'), findsNWidgets(2));
-        expect(find.text('Anna Gunn'), findsNWidgets(2));
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+        expect(find.text('Aaron Paul'), findsOneWidget);
+        expect(find.text('Anna Gunn'), findsOneWidget);
         expect(find.text('Dean Norris'), findsOneWidget);
         expect(find.text('Betsy Brandt'), findsOneWidget);
-        // Character names are also rendered for each row (sheet-only
-        // for the trailing two members; inline ones show too).
+        expect(find.text('Walter White'), findsOneWidget);
+        expect(find.text('Jesse Pinkman'), findsOneWidget);
+        expect(find.text('Skyler White'), findsOneWidget);
+        expect(find.text('Hank Schrader'), findsOneWidget);
         expect(find.text('Marie Schrader'), findsOneWidget);
-        expect(find.text('Walter White'), findsNWidgets(2));
       },
     );
 
     testWidgets(
-      'wide layout: rich cast never renders the overflow tile '
-      '(all cast visible inline)',
+      'wide layout: no overflow tile when every cast card fits',
       (tester) async {
         final richCast = <CastMember>[
           const CastMember(name: 'Bryan Cranston', character: 'Walter White'),
@@ -788,20 +808,76 @@ void main() {
             SeriesInfo(
               series: Series(id: 7, name: 'Rich Cast Show', richCast: richCast),
               seasons: const [Season(number: 1, name: 'Season 1')],
-              episodesBySeason: {1: [_ep(1, 1)]},
+              episodesBySeason: {
+                1: [_ep(1, 1)],
+              },
             ),
           ),
         );
         await tester.pumpAndSettle();
 
-        // All 4 names visible inline.
+        // All 4 names visible inline — 4 cards fit the 800px surface.
         expect(find.text('Bryan Cranston'), findsOneWidget);
         expect(find.text('Dean Norris'), findsOneWidget);
-        // No overflow tile on wide layout, regardless of member count.
         final l = AppLocalizations.of(
           tester.element(find.byType(CastMemberRow)),
         );
         expect(find.text(l.castShowAll), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'wide layout: overflow tile opens the season-picker-style dialog '
+      'listing all members',
+      (tester) async {
+        final richCast = <CastMember>[
+          for (var i = 1; i <= 9; i++)
+            CastMember(name: 'Cast Member $i', character: 'Role $i'),
+        ];
+        await tester.pumpWidget(
+          _app(
+            SeriesInfo(
+              series: Series(id: 7, name: 'Rich Cast Show', richCast: richCast),
+              seasons: const [Season(number: 1, name: 'Season 1')],
+              episodesBySeason: {
+                1: [_ep(1, 1)],
+              },
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // 9 members overflow the default 800px test surface, so the
+        // last slot is the "+N / show all" tile and later members stay
+        // out of the inline row.
+        final l = AppLocalizations.of(
+          tester.element(find.byType(CastMemberRow)),
+        );
+        expect(find.text(l.castShowAll), findsOneWidget);
+        expect(find.text('Cast Member 9'), findsNothing);
+
+        await tester.tap(find.text(l.castShowAll));
+        await tester.pumpAndSettle();
+
+        // Wide layout opens a centered dialog (season-picker chrome),
+        // not a bottom sheet, listing every member.
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(find.byType(BottomSheet), findsNothing);
+        expect(find.text('Cast Member 1'), findsWidgets);
+        // The dialog's list is lazy and height-capped — scroll the last
+        // member into view before asserting on it.
+        await tester.scrollUntilVisible(
+          find.text('Cast Member 9'),
+          200,
+          scrollable: find
+              .descendant(
+                of: find.byType(AlertDialog),
+                matching: find.byType(Scrollable),
+              )
+              .first,
+        );
+        expect(find.text('Cast Member 9'), findsOneWidget);
+        expect(find.text('Role 9'), findsOneWidget);
       },
     );
   });

--- a/flutter_client/test/features/series/series_details_screen_test.dart
+++ b/flutter_client/test/features/series/series_details_screen_test.dart
@@ -614,9 +614,10 @@ void main() {
     expect(find.text('Marked as watched'), findsNothing);
   });
 
-  group('SeriesDetailsScreen — rich cast', () {
+  group('SeriesDetailsScreen - rich cast', () {
     testWidgets(
-      'wide layout: renders CastMemberRow when series.richCast is populated',
+      'wide layout: never renders the cast rail (would break the episode '
+      'strip / height budget - cast is narrow-layout + VOD only)',
       (tester) async {
         await tester.pumpWidget(
           _app(
@@ -631,11 +632,6 @@ void main() {
                     name: 'Bryan Cranston',
                     character: 'Walter White',
                   ),
-                  CastMember(
-                    id: 2,
-                    name: 'Aaron Paul',
-                    character: 'Jesse Pinkman',
-                  ),
                 ],
               ),
               seasons: const [Season(number: 1, name: 'Season 1')],
@@ -647,23 +643,12 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.byType(CastMemberRow), findsOneWidget);
-        expect(find.text('Bryan Cranston'), findsOneWidget);
-        expect(find.text('Walter White'), findsOneWidget);
-        expect(find.text('Aaron Paul'), findsOneWidget);
-        expect(find.text('Jesse Pinkman'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'wide layout: hides CastMemberRow when series.richCast is null',
-      (tester) async {
-        await tester.pumpWidget(_app(_info()));
-        await tester.pumpAndSettle();
-
         expect(find.byType(CastMemberRow), findsNothing);
-        // Plot still renders.
-        expect(find.text('First season synopsis'), findsOneWidget);
+        // The legacy string-cast line in the meta block is untouched.
+        expect(
+          find.text('A series with a populated rich cast.'),
+          findsOneWidget,
+        );
       },
     );
 
@@ -694,12 +679,12 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // Compact layout is a single picker chip — only the "Cast"
+        // Compact layout is a single picker chip - only the "Cast"
         // label and a count badge render; member names live inside
         // the bottom sheet, not inline.
         expect(find.byType(CastMemberRow), findsOneWidget);
         expect(find.text('Cast'), findsOneWidget);
-        // Scoped to the cast row — the season picker's episode-count
+        // Scoped to the cast row - the season picker's episode-count
         // badge also renders "1" for this single-episode fixture.
         expect(
           find.descendant(
@@ -710,7 +695,7 @@ void main() {
         );
         // No member name bleeds into the inline compact layout.
         expect(find.text('Bryan Cranston'), findsNothing);
-        // The chip lives in the same Wrap as the season picker — beside
+        // The chip lives in the same Wrap as the season picker - beside
         // it, not on its own row above the action buttons.
         final actionWrap = find.ancestor(
           of: find.text('Season 1'),
@@ -770,14 +755,14 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // The picker is the visible inline compact control — a button
+        // The picker is the visible inline compact control - a button
         // labelled "Cast" with a count badge showing all 5 members.
         expect(find.text('Cast'), findsOneWidget);
         expect(find.text('5'), findsOneWidget);
 
         // Tap the picker → bottom sheet opens with every member
         // listed (5 rows). Compact layout keeps member names inside
-        // the sheet only — no inline duplication.
+        // the sheet only - no inline duplication.
         await tester.tap(find.text('Cast'));
         await tester.pumpAndSettle();
 
@@ -791,93 +776,6 @@ void main() {
         expect(find.text('Skyler White'), findsOneWidget);
         expect(find.text('Hank Schrader'), findsOneWidget);
         expect(find.text('Marie Schrader'), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'wide layout: no overflow tile when every cast card fits',
-      (tester) async {
-        final richCast = <CastMember>[
-          const CastMember(name: 'Bryan Cranston', character: 'Walter White'),
-          const CastMember(name: 'Aaron Paul', character: 'Jesse Pinkman'),
-          const CastMember(name: 'Anna Gunn', character: 'Skyler White'),
-          const CastMember(name: 'Dean Norris', character: 'Hank Schrader'),
-        ];
-        await tester.pumpWidget(
-          _app(
-            SeriesInfo(
-              series: Series(id: 7, name: 'Rich Cast Show', richCast: richCast),
-              seasons: const [Season(number: 1, name: 'Season 1')],
-              episodesBySeason: {
-                1: [_ep(1, 1)],
-              },
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        // All 4 names visible inline — 4 cards fit the 800px surface.
-        expect(find.text('Bryan Cranston'), findsOneWidget);
-        expect(find.text('Dean Norris'), findsOneWidget);
-        final l = AppLocalizations.of(
-          tester.element(find.byType(CastMemberRow)),
-        );
-        expect(find.text(l.castShowAll), findsNothing);
-      },
-    );
-
-    testWidgets(
-      'wide layout: overflow tile opens the season-picker-style dialog '
-      'listing all members',
-      (tester) async {
-        final richCast = <CastMember>[
-          for (var i = 1; i <= 9; i++)
-            CastMember(name: 'Cast Member $i', character: 'Role $i'),
-        ];
-        await tester.pumpWidget(
-          _app(
-            SeriesInfo(
-              series: Series(id: 7, name: 'Rich Cast Show', richCast: richCast),
-              seasons: const [Season(number: 1, name: 'Season 1')],
-              episodesBySeason: {
-                1: [_ep(1, 1)],
-              },
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        // 9 members overflow the default 800px test surface, so the
-        // last slot is the "+N / show all" tile and later members stay
-        // out of the inline row.
-        final l = AppLocalizations.of(
-          tester.element(find.byType(CastMemberRow)),
-        );
-        expect(find.text(l.castShowAll), findsOneWidget);
-        expect(find.text('Cast Member 9'), findsNothing);
-
-        await tester.tap(find.text(l.castShowAll));
-        await tester.pumpAndSettle();
-
-        // Wide layout opens a centered dialog (season-picker chrome),
-        // not a bottom sheet, listing every member.
-        expect(find.byType(AlertDialog), findsOneWidget);
-        expect(find.byType(BottomSheet), findsNothing);
-        expect(find.text('Cast Member 1'), findsWidgets);
-        // The dialog's list is lazy and height-capped — scroll the last
-        // member into view before asserting on it.
-        await tester.scrollUntilVisible(
-          find.text('Cast Member 9'),
-          200,
-          scrollable: find
-              .descendant(
-                of: find.byType(AlertDialog),
-                matching: find.byType(Scrollable),
-              )
-              .first,
-        );
-        expect(find.text('Cast Member 9'), findsOneWidget);
-        expect(find.text('Role 9'), findsOneWidget);
       },
     );
   });

--- a/flutter_client/test/features/series/series_details_screen_test.dart
+++ b/flutter_client/test/features/series/series_details_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/dpad_ink_well.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
@@ -611,5 +612,102 @@ void main() {
     expect(writes, 3); // sequential, one per episode
     expect(find.text("Couldn't sync watched status"), findsOneWidget);
     expect(find.text('Marked as watched'), findsNothing);
+  });
+
+  group('SeriesDetailsScreen — rich cast', () {
+    testWidgets(
+      'wide layout: renders CastMemberRow when series.richCast is populated',
+      (tester) async {
+        await tester.pumpWidget(
+          _app(
+            SeriesInfo(
+              series: const Series(
+                id: 7,
+                name: 'Rich Cast Show',
+                plot: 'A series with a populated rich cast.',
+                richCast: <CastMember>[
+                  CastMember(
+                    id: 1,
+                    name: 'Bryan Cranston',
+                    character: 'Walter White',
+                  ),
+                  CastMember(
+                    id: 2,
+                    name: 'Aaron Paul',
+                    character: 'Jesse Pinkman',
+                  ),
+                ],
+              ),
+              seasons: const [Season(number: 1, name: 'Season 1')],
+              episodesBySeason: {1: [_ep(1, 1)]},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsOneWidget);
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+        expect(find.text('Walter White'), findsOneWidget);
+        expect(find.text('Aaron Paul'), findsOneWidget);
+        expect(find.text('Jesse Pinkman'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'wide layout: hides CastMemberRow when series.richCast is null',
+      (tester) async {
+        await tester.pumpWidget(_app(_info()));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+        // Plot still renders.
+        expect(find.text('First season synopsis'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'narrow layout: renders CastMemberRow when series.richCast is populated',
+      (tester) async {
+        tester.view.physicalSize = const Size(420, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(
+          _app(
+            SeriesInfo(
+              series: const Series(
+                id: 7,
+                name: 'Rich Cast Show',
+                richCast: <CastMember>[
+                  CastMember(name: 'Bryan Cranston', character: 'Walter White'),
+                ],
+              ),
+              seasons: const [Season(number: 1, name: 'Season 1')],
+              episodesBySeason: {1: [_ep(1, 1)]},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsOneWidget);
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'narrow layout: hides CastMemberRow when series.richCast is null',
+      (tester) async {
+        tester.view.physicalSize = const Size(420, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        await tester.pumpWidget(_app(_info()));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+      },
+    );
   });
 }

--- a/flutter_client/test/features/series/series_details_screen_test.dart
+++ b/flutter_client/test/features/series/series_details_screen_test.dart
@@ -709,5 +709,100 @@ void main() {
         expect(find.byType(CastMemberRow), findsNothing);
       },
     );
+
+    testWidgets(
+      'narrow layout: rich cast overflow tile opens bottom sheet listing all members',
+      (tester) async {
+        tester.view.physicalSize = const Size(420, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        // 5 members → narrow layout caps to 3 + overflow tile.
+        final richCast = <CastMember>[
+          const CastMember(name: 'Bryan Cranston', character: 'Walter White'),
+          const CastMember(name: 'Aaron Paul', character: 'Jesse Pinkman'),
+          const CastMember(name: 'Anna Gunn', character: 'Skyler White'),
+          const CastMember(name: 'Dean Norris', character: 'Hank Schrader'),
+          const CastMember(name: 'Betsy Brandt', character: 'Marie Schrader'),
+        ];
+        await tester.pumpWidget(
+          _app(
+            SeriesInfo(
+              series: Series(id: 7, name: 'Rich Cast Show', richCast: richCast),
+              seasons: const [Season(number: 1, name: 'Season 1')],
+              episodesBySeason: {1: [_ep(1, 1)]},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The overflow tile uses the localized "Show all cast" label.
+        final l = AppLocalizations.of(
+          tester.element(find.byType(CastMemberRow)),
+        );
+        expect(find.text(l.castShowAll), findsOneWidget);
+
+        // The overflow tile is past the visible viewport on a 420-wide
+        // phone (4 × 144 + gaps = 612). Scroll it into view before tapping.
+        await tester.scrollUntilVisible(
+          find.text(l.castShowAll),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.pumpAndSettle();
+
+        // Tap → bottom sheet opens with every member (5 rows).
+        await tester.tap(find.text(l.castShowAll));
+        await tester.pumpAndSettle();
+
+        // Sheet title and all 5 names rendered (members beyond the 3
+        // visible in the inline row are now reachable). The inline row
+        // shows the first 3 cast cards, so those names appear twice
+        // (inline + sheet); only the trailing two are sheet-only.
+        expect(find.text(l.castShowAll), findsAtLeast(1));
+        expect(find.text('Bryan Cranston'), findsNWidgets(2));
+        expect(find.text('Aaron Paul'), findsNWidgets(2));
+        expect(find.text('Anna Gunn'), findsNWidgets(2));
+        expect(find.text('Dean Norris'), findsOneWidget);
+        expect(find.text('Betsy Brandt'), findsOneWidget);
+        // Character names are also rendered for each row (sheet-only
+        // for the trailing two members; inline ones show too).
+        expect(find.text('Marie Schrader'), findsOneWidget);
+        expect(find.text('Walter White'), findsNWidgets(2));
+      },
+    );
+
+    testWidgets(
+      'wide layout: rich cast never renders the overflow tile '
+      '(all cast visible inline)',
+      (tester) async {
+        final richCast = <CastMember>[
+          const CastMember(name: 'Bryan Cranston', character: 'Walter White'),
+          const CastMember(name: 'Aaron Paul', character: 'Jesse Pinkman'),
+          const CastMember(name: 'Anna Gunn', character: 'Skyler White'),
+          const CastMember(name: 'Dean Norris', character: 'Hank Schrader'),
+        ];
+        await tester.pumpWidget(
+          _app(
+            SeriesInfo(
+              series: Series(id: 7, name: 'Rich Cast Show', richCast: richCast),
+              seasons: const [Season(number: 1, name: 'Season 1')],
+              episodesBySeason: {1: [_ep(1, 1)]},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // All 4 names visible inline.
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+        expect(find.text('Dean Norris'), findsOneWidget);
+        // No overflow tile on wide layout, regardless of member count.
+        final l = AppLocalizations.of(
+          tester.element(find.byType(CastMemberRow)),
+        );
+        expect(find.text(l.castShowAll), findsNothing);
+      },
+    );
   });
 }

--- a/flutter_client/test/services/cast_member_test.dart
+++ b/flutter_client/test/services/cast_member_test.dart
@@ -18,7 +18,9 @@ void main() {
     });
 
     test('parses an entry with only a name (no id/character/photo)', () {
-      final result = CastMember.fromXtream(<String, Object?>{'name': 'Bryan Cranston'});
+      final result = CastMember.fromXtream(<String, Object?>{
+        'name': 'Bryan Cranston',
+      });
       expect(result, isNotNull);
       expect(result!.name, 'Bryan Cranston');
       expect(result.id, isNull);
@@ -27,7 +29,9 @@ void main() {
     });
 
     test('trims whitespace from the name', () {
-      final result = CastMember.fromXtream(<String, Object?>{'name': '  Anna Paquin  '});
+      final result = CastMember.fromXtream(<String, Object?>{
+        'name': '  Anna Paquin  ',
+      });
       expect(result!.name, 'Anna Paquin');
     });
 

--- a/flutter_client/test/services/cast_member_test.dart
+++ b/flutter_client/test/services/cast_member_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  group('CastMember.fromXtream', () {
+    test('parses a full cast entry with id, character, photo', () {
+      final result = CastMember.fromXtream(<String, Object?>{
+        'id': 12345,
+        'name': 'Idris Elba',
+        'character': 'John Luther',
+        'photo': 'https://image.tmdb.org/t/p/w185/abc.jpg',
+      });
+      expect(result, isNotNull);
+      expect(result!.id, 12345);
+      expect(result.name, 'Idris Elba');
+      expect(result.character, 'John Luther');
+      expect(result.photo, 'https://image.tmdb.org/t/p/w185/abc.jpg');
+    });
+
+    test('parses an entry with only a name (no id/character/photo)', () {
+      final result = CastMember.fromXtream(<String, Object?>{'name': 'Bryan Cranston'});
+      expect(result, isNotNull);
+      expect(result!.name, 'Bryan Cranston');
+      expect(result.id, isNull);
+      expect(result.character, isNull);
+      expect(result.photo, isNull);
+    });
+
+    test('trims whitespace from the name', () {
+      final result = CastMember.fromXtream(<String, Object?>{'name': '  Anna Paquin  '});
+      expect(result!.name, 'Anna Paquin');
+    });
+
+    test('drops entries whose name is empty after trimming', () {
+      expect(CastMember.fromXtream(<String, Object?>{'name': ''}), isNull);
+      expect(CastMember.fromXtream(<String, Object?>{'name': '   '}), isNull);
+      expect(CastMember.fromXtream(<String, Object?>{}), isNull);
+    });
+
+    test('returns null for non-Map input', () {
+      expect(CastMember.fromXtream(null), isNull);
+      expect(CastMember.fromXtream('Bryan Cranston'), isNull);
+      expect(CastMember.fromXtream(123), isNull);
+      expect(CastMember.fromXtream(<Object?>['Bryan Cranston']), isNull);
+    });
+  });
+}

--- a/flutter_client/test/services/series_cast_test.dart
+++ b/flutter_client/test/services/series_cast_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  Map<String, Object?> seriesJson({Object? castList, bool includeCastList = true}) =>
+      <String, Object?>{
+        'series_id': 99,
+        'name': 'Breaking Bad',
+        if (includeCastList) 'cast_list': castList,
+      };
+
+  test('Series.richCast is parsed when cast_list is a list of maps', () {
+    final series = Series.fromXtream(seriesJson(castList: <Object?>[
+      <String, Object?>{'id': 17419, 'name': 'Bryan Cranston', 'character': 'Walter White'},
+      <String, Object?>{'id': 17420, 'name': 'Aaron Paul', 'character': 'Jesse Pinkman'},
+    ]));
+
+    expect(series.richCast, isNotNull);
+    expect(series.richCast!.length, 2);
+    expect(series.richCast![0].name, 'Bryan Cranston');
+    expect(series.richCast![1].name, 'Aaron Paul');
+  });
+
+  test('Series.richCast is null when cast_list is missing entirely', () {
+    final series = Series.fromXtream(seriesJson(includeCastList: false));
+    expect(series.richCast, isNull);
+  });
+
+  test('Series.richCast is null when cast_list is an empty list', () {
+    final series = Series.fromXtream(seriesJson(castList: <Object?>[]));
+    expect(series.richCast, isNull);
+  });
+
+  test('Series.richCast is null when cast_list is a comma-joined string', () {
+    final series = Series.fromXtream(
+      seriesJson(castList: 'Bryan Cranston, Aaron Paul'),
+    );
+    expect(series.richCast, isNull);
+  });
+}

--- a/flutter_client/test/services/series_cast_test.dart
+++ b/flutter_client/test/services/series_cast_test.dart
@@ -2,18 +2,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 
 void main() {
-  Map<String, Object?> seriesJson({Object? castList, bool includeCastList = true}) =>
-      <String, Object?>{
-        'series_id': 99,
-        'name': 'Breaking Bad',
-        if (includeCastList) 'cast_list': castList,
-      };
+  Map<String, Object?> seriesJson({
+    Object? castList,
+    bool includeCastList = true,
+  }) => <String, Object?>{
+    'series_id': 99,
+    'name': 'Breaking Bad',
+    if (includeCastList) 'cast_list': castList,
+  };
 
   test('Series.richCast is parsed when cast_list is a list of maps', () {
-    final series = Series.fromXtream(seriesJson(castList: <Object?>[
-      <String, Object?>{'id': 17419, 'name': 'Bryan Cranston', 'character': 'Walter White'},
-      <String, Object?>{'id': 17420, 'name': 'Aaron Paul', 'character': 'Jesse Pinkman'},
-    ]));
+    final series = Series.fromXtream(
+      seriesJson(
+        castList: <Object?>[
+          <String, Object?>{
+            'id': 17419,
+            'name': 'Bryan Cranston',
+            'character': 'Walter White',
+          },
+          <String, Object?>{
+            'id': 17420,
+            'name': 'Aaron Paul',
+            'character': 'Jesse Pinkman',
+          },
+        ],
+      ),
+    );
 
     expect(series.richCast, isNotNull);
     expect(series.richCast!.length, 2);

--- a/flutter_client/test/services/vod_info_cast_test.dart
+++ b/flutter_client/test/services/vod_info_cast_test.dart
@@ -15,10 +15,20 @@ void main() {
   };
 
   test('VodInfo.richCast is parsed when cast_list is a list of maps', () {
-    final vod = VodInfo.fromXtream(vodPayload(<Object?>[
-      <String, Object?>{'id': 1, 'name': 'Leonardo DiCaprio', 'character': 'Cobb'},
-      <String, Object?>{'id': 2, 'name': 'Joseph Gordon-Levitt', 'character': 'Arthur'},
-    ]));
+    final vod = VodInfo.fromXtream(
+      vodPayload(<Object?>[
+        <String, Object?>{
+          'id': 1,
+          'name': 'Leonardo DiCaprio',
+          'character': 'Cobb',
+        },
+        <String, Object?>{
+          'id': 2,
+          'name': 'Joseph Gordon-Levitt',
+          'character': 'Arthur',
+        },
+      ]),
+    );
 
     expect(vod.richCast, isNotNull);
     expect(vod.richCast!.length, 2);
@@ -37,33 +47,46 @@ void main() {
     expect(vod.richCast, isNull);
   });
 
-  test('VodInfo.richCast is null when cast_list is the legacy comma-joined string', () {
-    final vod = VodInfo.fromXtream(vodPayload('Leonardo DiCaprio, Joseph Gordon-Levitt'));
-    expect(vod.richCast, isNull);
-  });
+  test(
+    'VodInfo.richCast is null when cast_list is the legacy comma-joined string',
+    () {
+      final vod = VodInfo.fromXtream(
+        vodPayload('Leonardo DiCaprio, Joseph Gordon-Levitt'),
+      );
+      expect(vod.richCast, isNull);
+    },
+  );
 
-  test('VodInfo.richCast preserves the legacy string `cast` field (no regression)', () {
-    final payload = <String, Object?>{
-      'info': <String, Object?>{'name': 'Inception'},
-      'movie_data': <String, Object?>{
-        'stream_id': 101,
-        'name': 'Inception',
-        'cast': 'Leonardo DiCaprio, Joseph Gordon-Levitt',
-      },
-    };
-    final vod = VodInfo.fromXtream(payload);
-    expect(vod.cast, 'Leonardo DiCaprio, Joseph Gordon-Levitt');
-    expect(vod.richCast, isNull);
-  });
+  test(
+    'VodInfo.richCast preserves the legacy string `cast` field (no regression)',
+    () {
+      final payload = <String, Object?>{
+        'info': <String, Object?>{'name': 'Inception'},
+        'movie_data': <String, Object?>{
+          'stream_id': 101,
+          'name': 'Inception',
+          'cast': 'Leonardo DiCaprio, Joseph Gordon-Levitt',
+        },
+      };
+      final vod = VodInfo.fromXtream(payload);
+      expect(vod.cast, 'Leonardo DiCaprio, Joseph Gordon-Levitt');
+      expect(vod.richCast, isNull);
+    },
+  );
 
-  test('VodInfo.richCast is null when cast_list contains only malformed entries', () {
-    final vod = VodInfo.fromXtream(vodPayload(<Object?>[
-      <String, Object?>{'name': ''},
-      <String, Object?>{'name': '   '},
-      <String, Object?>{},
-    ]));
-    expect(vod.richCast, isNull);
-  });
+  test(
+    'VodInfo.richCast is null when cast_list contains only malformed entries',
+    () {
+      final vod = VodInfo.fromXtream(
+        vodPayload(<Object?>[
+          <String, Object?>{'name': ''},
+          <String, Object?>{'name': '   '},
+          <String, Object?>{},
+        ]),
+      );
+      expect(vod.richCast, isNull);
+    },
+  );
 }
 
 class _Omitted {

--- a/flutter_client/test/services/vod_info_cast_test.dart
+++ b/flutter_client/test/services/vod_info_cast_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m3u_tv/services/domain_models.dart';
+
+void main() {
+  Map<String, Object?> vodPayload(Object? castList) => <String, Object?>{
+    'info': <String, Object?>{
+      'tmdb_id': 27205,
+      'name': 'Inception',
+    },
+    'movie_data': <String, Object?>{
+      'stream_id': 101,
+      'name': 'Inception',
+      if (castList != const _Omitted()) 'cast_list': castList,
+    },
+  };
+
+  test('VodInfo.richCast is parsed when cast_list is a list of maps', () {
+    final vod = VodInfo.fromXtream(vodPayload(<Object?>[
+      <String, Object?>{'id': 1, 'name': 'Leonardo DiCaprio', 'character': 'Cobb'},
+      <String, Object?>{'id': 2, 'name': 'Joseph Gordon-Levitt', 'character': 'Arthur'},
+    ]));
+
+    expect(vod.richCast, isNotNull);
+    expect(vod.richCast!.length, 2);
+    expect(vod.richCast![0].name, 'Leonardo DiCaprio');
+    expect(vod.richCast![0].character, 'Cobb');
+    expect(vod.richCast![1].name, 'Joseph Gordon-Levitt');
+  });
+
+  test('VodInfo.richCast is null when cast_list is missing entirely', () {
+    final vod = VodInfo.fromXtream(vodPayload(const _Omitted()));
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast is null when cast_list is an empty list', () {
+    final vod = VodInfo.fromXtream(vodPayload(<Object?>[]));
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast is null when cast_list is the legacy comma-joined string', () {
+    final vod = VodInfo.fromXtream(vodPayload('Leonardo DiCaprio, Joseph Gordon-Levitt'));
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast preserves the legacy string `cast` field (no regression)', () {
+    final payload = <String, Object?>{
+      'info': <String, Object?>{'name': 'Inception'},
+      'movie_data': <String, Object?>{
+        'stream_id': 101,
+        'name': 'Inception',
+        'cast': 'Leonardo DiCaprio, Joseph Gordon-Levitt',
+      },
+    };
+    final vod = VodInfo.fromXtream(payload);
+    expect(vod.cast, 'Leonardo DiCaprio, Joseph Gordon-Levitt');
+    expect(vod.richCast, isNull);
+  });
+
+  test('VodInfo.richCast is null when cast_list contains only malformed entries', () {
+    final vod = VodInfo.fromXtream(vodPayload(<Object?>[
+      <String, Object?>{'name': ''},
+      <String, Object?>{'name': '   '},
+      <String, Object?>{},
+    ]));
+    expect(vod.richCast, isNull);
+  });
+}
+
+class _Omitted {
+  const _Omitted();
+}

--- a/flutter_client/test/ui/features/cast_member_row_test.dart
+++ b/flutter_client/test/ui/features/cast_member_row_test.dart
@@ -137,7 +137,7 @@ void main() {
       );
 
       // Find the row's Semantics widget by its label.
-      // (Skip asserting `container` — not on SemanticsProperties in this Flutter version.)
+      // (Skip asserting `container` - not on SemanticsProperties in this Flutter version.)
       final semanticsFinder = find.byWidgetPredicate(
         (w) => w is Semantics && w.properties.label == 'Cast',
       );
@@ -333,7 +333,7 @@ void main() {
           );
 
           // The button label is the row's semanticLabel ("Cast"),
-          // localized by the caller — never a hard-coded English fallback
+          // localized by the caller - never a hard-coded English fallback
           // pulled from inside the widget.
           expect(find.text('Cast'), findsOneWidget);
           // The chevron icon indicates the button opens a picker.
@@ -401,7 +401,7 @@ void main() {
           );
 
           // The AppButton's label is in the tree (it's the visible text
-          // of the button). Tapping it fires the callback — that's the
+          // of the button). Tapping it fires the callback - that's the
           // practical a11y contract. (AppButton internally wires its own
           // Semantics node with button=true; we don't assert on the
           // exact Semantics widget to keep the test resilient to the
@@ -452,7 +452,7 @@ void main() {
           expect(buttonFinder, findsOneWidget);
           expect(
             tester.getSize(buttonFinder).height,
-            // AppButton's default height — wider tolerance for future
+            // AppButton's default height - wider tolerance for future
             // updates as long as the assertion catches 0 / negative
             // regressions.
             greaterThan(0),

--- a/flutter_client/test/ui/features/cast_member_row_test.dart
+++ b/flutter_client/test/ui/features/cast_member_row_test.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+
+CastMember _m({
+  required String name,
+  String? character,
+  String? photo,
+  int? id,
+}) => CastMember(name: name, character: character, photo: photo, id: id);
+
+Widget _harness({List<CastMember>? members, String? semanticLabel}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: CastMemberRow(members: members, semanticLabel: semanticLabel),
+    ),
+  );
+}
+
+void main() {
+  group('CastMemberRow', () {
+    testWidgets('renders nothing for null members', (tester) async {
+      await tester.pumpWidget(_harness());
+      expect(find.byType(CastMemberRow), findsOneWidget);
+      // No _CastMemberCard inside.
+      expect(find.text('Leonardo DiCaprio'), findsNothing);
+    });
+
+    testWidgets('renders nothing for empty list', (tester) async {
+      await tester.pumpWidget(_harness(members: const <CastMember>[]));
+      expect(find.byType(CastMemberRow), findsOneWidget);
+      expect(find.text('Leonardo DiCaprio'), findsNothing);
+    });
+
+    testWidgets('renders one card per member', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [
+            _m(name: 'Leonardo DiCaprio', character: 'Cobb'),
+            _m(name: 'Joseph Gordon-Levitt', character: 'Arthur'),
+            _m(name: 'Tom Hardy', character: 'Eames'),
+          ],
+        ),
+      );
+
+      expect(find.text('Leonardo DiCaprio'), findsOneWidget);
+      expect(find.text('Joseph Gordon-Levitt'), findsOneWidget);
+      expect(find.text('Tom Hardy'), findsOneWidget);
+      expect(find.text('Cobb'), findsOneWidget);
+      expect(find.text('Arthur'), findsOneWidget);
+      expect(find.text('Eames'), findsOneWidget);
+    });
+
+    testWidgets('omits character text when null', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Solo Actor')],
+        ),
+      );
+      expect(find.text('Solo Actor'), findsOneWidget);
+      // No empty character row.
+      expect(find.text(''), findsNothing);
+    });
+
+    testWidgets('omits character text when empty string', (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Solo Actor', character: '')],
+        ),
+      );
+      expect(find.text('Solo Actor'), findsOneWidget);
+    });
+
+    testWidgets('caps rendered cards at 15', (tester) async {
+      // 20 members → only 15 cards render.
+      final members = [
+        for (var i = 0; i < 20; i++) _m(name: 'Actor $i', character: 'Role $i'),
+      ];
+      await tester.pumpWidget(_harness(members: members));
+
+      // First 15 should render, last 5 should not.
+      expect(find.text('Actor 0'), findsOneWidget);
+      expect(find.text('Actor 14'), findsOneWidget);
+      expect(find.text('Actor 15'), findsNothing);
+      expect(find.text('Actor 19'), findsNothing);
+    });
+
+    testWidgets('image source is ResilientMediaImage with member photo', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Actor', photo: 'https://example.com/photo.jpg')],
+        ),
+      );
+
+      // ResilientMediaImage should be in the tree (one per card).
+      expect(find.byType(ResilientMediaImage), findsOneWidget);
+      final img = tester.widget<ResilientMediaImage>(
+        find.byType(ResilientMediaImage),
+      );
+      expect(img.imageUrl, 'https://example.com/photo.jpg');
+      expect(img.fallbackIcon, Icons.person);
+    });
+
+    testWidgets('passes semanticLabel through to the row Semantics', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Actor')],
+          semanticLabel: 'Cast',
+        ),
+      );
+
+      // Find the row's Semantics widget by its label.
+      // (Skip asserting `container` — not on SemanticsProperties in this Flutter version.)
+      final semanticsFinder = find.byWidgetPredicate(
+        (w) => w is Semantics && w.properties.label == 'Cast',
+      );
+      expect(semanticsFinder, findsOneWidget);
+    });
+
+    testWidgets('card semantics include "as Character" when present', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Bryan Cranston', character: 'Walter White')],
+        ),
+      );
+
+      final cardSemantics = find.byWidgetPredicate(
+        (w) =>
+            w is Semantics &&
+            w.properties.label == 'Bryan Cranston as Walter White',
+      );
+      expect(cardSemantics, findsOneWidget);
+    });
+
+    testWidgets('card semantics show only name when character absent', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          members: [_m(name: 'Bryan Cranston')],
+        ),
+      );
+
+      final cardSemantics = find.byWidgetPredicate(
+        (w) => w is Semantics && w.properties.label == 'Bryan Cranston',
+      );
+      expect(cardSemantics, findsOneWidget);
+    });
+
+    testWidgets(
+      'name renders bold (billing-block style) so long names stand out',
+      (tester) async {
+        await tester.pumpWidget(
+          _harness(
+            members: [_m(name: 'Christoph Waltz', character: 'Blofeld')],
+          ),
+        );
+
+        // "Christoph Waltz" is 15 chars; the 144px card width (~22 chars at
+        // bodySmall/12sp) leaves room without ellipsis.
+        expect(find.text('Christoph Waltz'), findsOneWidget);
+        final style = tester.widget<Text>(find.text('Christoph Waltz')).style;
+        expect(style?.fontWeight, FontWeight.w700);
+      },
+    );
+
+    testWidgets(
+      'character renders muted and below name (labelSmall color, not bold)',
+      (tester) async {
+        await tester.pumpWidget(
+          _harness(
+            members: [_m(name: 'Bryan Cranston', character: 'Walter White')],
+          ),
+        );
+
+        final characterStyle =
+            tester.widget<Text>(find.text('Walter White')).style;
+        expect(characterStyle?.fontWeight, isNot(FontWeight.w700));
+        // labelSmall uses a smaller font than bodySmall - distinct typography
+        // from the name above it so the eye reads name > role.
+        expect(
+          characterStyle?.fontSize,
+          lessThan(
+            tester
+                .widget<Text>(find.text('Bryan Cranston'))
+                .style!
+                .fontSize!,
+          ),
+        );
+      },
+    );
+  });
+}

--- a/flutter_client/test/ui/features/cast_member_row_test.dart
+++ b/flutter_client/test/ui/features/cast_member_row_test.dart
@@ -12,10 +12,22 @@ CastMember _m({
   int? id,
 }) => CastMember(name: name, character: character, photo: photo, id: id);
 
-Widget _harness({List<CastMember>? members, String? semanticLabel}) {
+Widget _harness({
+  List<CastMember>? members,
+  String? semanticLabel,
+  bool compact = false,
+  VoidCallback? onShowAll,
+  String? allCastSemanticLabel,
+}) {
   return MaterialApp(
     home: Scaffold(
-      body: CastMemberRow(members: members, semanticLabel: semanticLabel),
+      body: CastMemberRow(
+        members: members,
+        semanticLabel: semanticLabel,
+        compact: compact,
+        onShowAll: onShowAll,
+        allCastSemanticLabel: allCastSemanticLabel,
+      ),
     ),
   );
 }
@@ -198,5 +210,130 @@ void main() {
         );
       },
     );
+
+    group('compact mode', () {
+      testWidgets(
+        'renders only 3 cast cards + the overflow tile when more than 3',
+        (tester) async {
+          final members = [
+            for (var i = 0; i < 8; i++) _m(name: 'Actor $i', character: 'Role $i'),
+          ];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              onShowAll: () {},
+              allCastSemanticLabel: 'Show all cast',
+            ),
+          );
+
+          // First 3 render, others don't.
+          expect(find.text('Actor 0'), findsOneWidget);
+          expect(find.text('Actor 2'), findsOneWidget);
+          expect(find.text('Actor 3'), findsNothing);
+          expect(find.text('Actor 7'), findsNothing);
+          // The overflow tile's name label.
+          expect(find.text('Show all cast'), findsOneWidget);
+          // Underscore glyph on the badge.
+          expect(find.text('_'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'hides overflow tile when 3 or fewer members (nothing to expand to)',
+        (tester) async {
+          await tester.pumpWidget(
+            _harness(
+              members: [_m(name: 'Only One'), _m(name: 'Only Two')],
+              compact: true,
+              onShowAll: () {},
+              allCastSemanticLabel: 'Show all cast',
+            ),
+          );
+
+          expect(find.text('Only One'), findsOneWidget);
+          expect(find.text('Only Two'), findsOneWidget);
+          expect(find.text('Show all cast'), findsNothing);
+          expect(find.text('_'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'hides overflow tile when onShowAll is null even if members overflow',
+        (tester) async {
+          // Callers pass null when they don't want a sheet (e.g. compact
+          // disabled, or wide layout). No tile should appear regardless.
+          final members = [
+            for (var i = 0; i < 8; i++) _m(name: 'Actor $i'),
+          ];
+          await tester.pumpWidget(_harness(members: members, compact: true));
+
+          expect(find.text('Actor 7'), findsNothing);
+          expect(find.text('_'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'overflow tile fires onShowAll callback on tap',
+        (tester) async {
+          var tapCount = 0;
+          final members = [
+            for (var i = 0; i < 5; i++) _m(name: 'Actor $i'),
+          ];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              onShowAll: () => tapCount++,
+              allCastSemanticLabel: 'Show all cast',
+            ),
+          );
+
+          await tester.tap(find.text('Show all cast'));
+          await tester.pump();
+          expect(tapCount, 1);
+        },
+      );
+
+      testWidgets(
+        'overflow tile sets Semantics button=true for screen readers',
+        (tester) async {
+          final members = [
+            for (var i = 0; i < 5; i++) _m(name: 'Actor $i'),
+          ];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              onShowAll: () {},
+              allCastSemanticLabel: 'Show all cast',
+            ),
+          );
+
+          final buttonFinder = find.byWidgetPredicate(
+            (w) =>
+                w is Semantics &&
+                w.properties.label == 'Show all cast' &&
+                w.properties.button == true,
+          );
+          expect(buttonFinder, findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'wide layout shows full cast up to 15 without overflow tile',
+        (tester) async {
+          final members = [
+            for (var i = 0; i < 5; i++) _m(name: 'Actor $i', character: 'Role $i'),
+          ];
+          await tester.pumpWidget(_harness(members: members));
+
+          // All 5 render.
+          expect(find.text('Actor 4'), findsOneWidget);
+          expect(find.text('Show all cast'), findsNothing);
+          expect(find.text('_'), findsNothing);
+        },
+      );
+    });
   });
 }

--- a/flutter_client/test/ui/features/cast_member_row_test.dart
+++ b/flutter_client/test/ui/features/cast_member_row_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/app_button.dart';
 import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 
@@ -18,16 +19,23 @@ Widget _harness({
   bool compact = false,
   VoidCallback? onShowAll,
   String? allCastSemanticLabel,
+  double? width,
 }) {
+  final row = CastMemberRow(
+    members: members,
+    semanticLabel: semanticLabel,
+    compact: compact,
+    onShowAll: onShowAll,
+    allCastSemanticLabel: allCastSemanticLabel,
+  );
   return MaterialApp(
     home: Scaffold(
-      body: CastMemberRow(
-        members: members,
-        semanticLabel: semanticLabel,
-        compact: compact,
-        onShowAll: onShowAll,
-        allCastSemanticLabel: allCastSemanticLabel,
-      ),
+      body: width == null
+          ? row
+          : Align(
+              alignment: Alignment.topLeft,
+              child: SizedBox(width: width, child: row),
+            ),
     ),
   );
 }
@@ -194,87 +202,55 @@ void main() {
           ),
         );
 
-        final characterStyle =
-            tester.widget<Text>(find.text('Walter White')).style;
+        final characterStyle = tester
+            .widget<Text>(find.text('Walter White'))
+            .style;
         expect(characterStyle?.fontWeight, isNot(FontWeight.w700));
         // labelSmall uses a smaller font than bodySmall - distinct typography
         // from the name above it so the eye reads name > role.
         expect(
           characterStyle?.fontSize,
           lessThan(
-            tester
-                .widget<Text>(find.text('Bryan Cranston'))
-                .style!
-                .fontSize!,
+            tester.widget<Text>(find.text('Bryan Cranston')).style!.fontSize!,
           ),
         );
       },
     );
 
-    group('compact mode', () {
+    group('wide overflow tile', () {
+      // At 480px, 3 card slots fit (3 × 144 + 2 × 12 = 456; a 4th
+      // needs 612). With more members than slots, the last slot
+      // becomes the "+N / show all" tile.
+      const fitsThree = 480.0;
+
       testWidgets(
-        'renders only 3 cast cards + the overflow tile when more than 3',
+        'more members than fit → last slot is a "+N" show-all tile',
         (tester) async {
           final members = [
-            for (var i = 0; i < 8; i++) _m(name: 'Actor $i', character: 'Role $i'),
+            for (var i = 0; i < 5; i++) _m(name: 'Actor $i'),
           ];
           await tester.pumpWidget(
             _harness(
               members: members,
-              compact: true,
+              width: fitsThree,
               onShowAll: () {},
               allCastSemanticLabel: 'Show all cast',
             ),
           );
 
-          // First 3 render, others don't.
+          // 2 cards + the tile occupy the 3 slots.
           expect(find.text('Actor 0'), findsOneWidget);
-          expect(find.text('Actor 2'), findsOneWidget);
-          expect(find.text('Actor 3'), findsNothing);
-          expect(find.text('Actor 7'), findsNothing);
-          // The overflow tile's name label.
+          expect(find.text('Actor 1'), findsOneWidget);
+          expect(find.text('Actor 2'), findsNothing);
+          expect(find.text('Actor 4'), findsNothing);
+          // Tile shows the hidden-member count and the localized label.
+          expect(find.text('+3'), findsOneWidget);
           expect(find.text('Show all cast'), findsOneWidget);
-          // Underscore glyph on the badge.
-          expect(find.text('_'), findsOneWidget);
         },
       );
 
       testWidgets(
-        'hides overflow tile when 3 or fewer members (nothing to expand to)',
-        (tester) async {
-          await tester.pumpWidget(
-            _harness(
-              members: [_m(name: 'Only One'), _m(name: 'Only Two')],
-              compact: true,
-              onShowAll: () {},
-              allCastSemanticLabel: 'Show all cast',
-            ),
-          );
-
-          expect(find.text('Only One'), findsOneWidget);
-          expect(find.text('Only Two'), findsOneWidget);
-          expect(find.text('Show all cast'), findsNothing);
-          expect(find.text('_'), findsNothing);
-        },
-      );
-
-      testWidgets(
-        'hides overflow tile when onShowAll is null even if members overflow',
-        (tester) async {
-          // Callers pass null when they don't want a sheet (e.g. compact
-          // disabled, or wide layout). No tile should appear regardless.
-          final members = [
-            for (var i = 0; i < 8; i++) _m(name: 'Actor $i'),
-          ];
-          await tester.pumpWidget(_harness(members: members, compact: true));
-
-          expect(find.text('Actor 7'), findsNothing);
-          expect(find.text('_'), findsNothing);
-        },
-      );
-
-      testWidgets(
-        'overflow tile fires onShowAll callback on tap',
+        'tapping the show-all tile fires onShowAll',
         (tester) async {
           var tapCount = 0;
           final members = [
@@ -283,7 +259,7 @@ void main() {
           await tester.pumpWidget(
             _harness(
               members: members,
-              compact: true,
+              width: fitsThree,
               onShowAll: () => tapCount++,
               allCastSemanticLabel: 'Show all cast',
             ),
@@ -296,7 +272,53 @@ void main() {
       );
 
       testWidgets(
-        'overflow tile sets Semantics button=true for screen readers',
+        'no tile when every member fits the available width',
+        (tester) async {
+          final members = [
+            for (var i = 0; i < 3; i++) _m(name: 'Actor $i'),
+          ];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              width: fitsThree,
+              onShowAll: () {},
+              allCastSemanticLabel: 'Show all cast',
+            ),
+          );
+
+          expect(find.text('Actor 0'), findsOneWidget);
+          expect(find.text('Actor 2'), findsOneWidget);
+          expect(find.text('Show all cast'), findsNothing);
+          expect(find.textContaining('+'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'without onShowAll the row keeps the plain scroll (no tile)',
+        (tester) async {
+          final members = [
+            for (var i = 0; i < 5; i++) _m(name: 'Actor $i'),
+          ];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              width: fitsThree,
+              allCastSemanticLabel: 'Show all cast',
+            ),
+          );
+
+          // All 5 cards are in the (horizontally scrollable) row.
+          expect(find.text('Actor 0'), findsOneWidget);
+          expect(find.text('Actor 4'), findsOneWidget);
+          expect(find.text('Show all cast'), findsNothing);
+          expect(find.text('+2'), findsNothing);
+        },
+      );
+    });
+
+    group('compact mode', () {
+      testWidgets(
+        'renders a Cast picker button with the localized "Cast" label',
         (tester) async {
           final members = [
             for (var i = 0; i < 5; i++) _m(name: 'Actor $i'),
@@ -306,32 +328,152 @@ void main() {
               members: members,
               compact: true,
               onShowAll: () {},
-              allCastSemanticLabel: 'Show all cast',
+              semanticLabel: 'Cast',
             ),
           );
 
-          final buttonFinder = find.byWidgetPredicate(
-            (w) =>
-                w is Semantics &&
-                w.properties.label == 'Show all cast' &&
-                w.properties.button == true,
-          );
-          expect(buttonFinder, findsOneWidget);
+          // The button label is the row's semanticLabel ("Cast"),
+          // localized by the caller — never a hard-coded English fallback
+          // pulled from inside the widget.
+          expect(find.text('Cast'), findsOneWidget);
+          // The chevron icon indicates the button opens a picker.
+          expect(find.byIcon(Icons.arrow_drop_down), findsOneWidget);
+          // No cast member names bleed into compact mode.
+          expect(find.text('Actor 0'), findsNothing);
+          expect(find.text('Actor 4'), findsNothing);
         },
       );
 
       testWidgets(
-        'wide layout shows full cast up to 15 without overflow tile',
+        'shows the cast count in a muted badge',
         (tester) async {
           final members = [
-            for (var i = 0; i < 5; i++) _m(name: 'Actor $i', character: 'Role $i'),
+            for (var i = 0; i < 7; i++) _m(name: 'Actor $i'),
+          ];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              onShowAll: () {},
+              semanticLabel: 'Cast',
+            ),
+          );
+
+          // Badge text renders the count (7).
+          expect(find.text('7'), findsOneWidget);
+          // The button label still says "Cast".
+          expect(find.text('Cast'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'fires onShowAll when the picker button is tapped',
+        (tester) async {
+          var tapCount = 0;
+          final members = [_m(name: 'Solo'), _m(name: 'Duet')];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              onShowAll: () => tapCount++,
+              semanticLabel: 'Cast',
+            ),
+          );
+
+          // Tap via the localized label (the visible button content).
+          await tester.tap(find.text('Cast'));
+          await tester.pump();
+          expect(tapCount, 1);
+        },
+      );
+
+      testWidgets(
+        'button exposes its label and is discoverable as a tappable',
+        (tester) async {
+          final members = [_m(name: 'Solo')];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              onShowAll: () {},
+              semanticLabel: 'Cast',
+            ),
+          );
+
+          // The AppButton's label is in the tree (it's the visible text
+          // of the button). Tapping it fires the callback — that's the
+          // practical a11y contract. (AppButton internally wires its own
+          // Semantics node with button=true; we don't assert on the
+          // exact Semantics widget to keep the test resilient to the
+          // AppButton implementation evolving.)
+          expect(find.text('Cast'), findsOneWidget);
+          expect(find.byType(AppButton), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'renders nothing when onShowAll is null (caller opts out)',
+        (tester) async {
+          final members = [
+            for (var i = 0; i < 5; i++) _m(name: 'Actor $i'),
+          ];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              // onShowAll intentionally null.
+            ),
+          );
+
+          // No button label, no chevron, no badge, no member names.
+          expect(find.text('Cast'), findsNothing);
+          expect(find.byIcon(Icons.arrow_drop_down), findsNothing);
+          expect(find.text('Actor 0'), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'compact button matches the season picker height',
+        (tester) async {
+          final members = [_m(name: 'Solo')];
+          await tester.pumpWidget(
+            _harness(
+              members: members,
+              compact: true,
+              onShowAll: () {},
+              semanticLabel: 'Cast',
+            ),
+          );
+
+          // The picker shares the AppButton's intrinsic metrics so it
+          // lines up with the play / season-picker buttons in the same
+          // row (mirrors how the season picker comments at line ~1153).
+          final buttonFinder = find.byType(AppButton);
+          expect(buttonFinder, findsOneWidget);
+          expect(
+            tester.getSize(buttonFinder).height,
+            // AppButton's default height — wider tolerance for future
+            // updates as long as the assertion catches 0 / negative
+            // regressions.
+            greaterThan(0),
+          );
+        },
+      );
+
+      testWidgets(
+        'wide layout shows full cast up to 15 without a picker button',
+        (tester) async {
+          final members = [
+            for (var i = 0; i < 5; i++)
+              _m(name: 'Actor $i', character: 'Role $i'),
           ];
           await tester.pumpWidget(_harness(members: members));
 
-          // All 5 render.
+          // All 5 render as cards.
           expect(find.text('Actor 4'), findsOneWidget);
-          expect(find.text('Show all cast'), findsNothing);
-          expect(find.text('_'), findsNothing);
+          // No picker button in wide layout.
+          expect(find.byIcon(Icons.arrow_drop_down), findsNothing);
+          expect(find.text('Cast'), findsNothing);
         },
       );
     });

--- a/flutter_client/test/ui/features/vod_details_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_details_screen_test.dart
@@ -205,6 +205,94 @@ void main() {
         expect(find.byType(CastMemberRow), findsNothing);
       },
     );
+
+    testWidgets(
+      'narrow layout: rich cast overflow tile opens bottom sheet listing all members',
+      (tester) async {
+        // Phone width (below the 600px wide breakpoint).
+        tester.view.physicalSize = const Size(420, 800);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final richCast = <CastMember>[
+          const CastMember(name: 'Bryan Cranston', character: 'Walter White'),
+          const CastMember(name: 'Aaron Paul', character: 'Jesse Pinkman'),
+          const CastMember(name: 'Anna Gunn', character: 'Skyler White'),
+          const CastMember(name: 'Dean Norris', character: 'Hank Schrader'),
+          const CastMember(name: 'Betsy Brandt', character: 'Marie Schrader'),
+        ];
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: VodInfo(id: 201, name: 'Big Buck Bunny', richCast: richCast),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l = AppLocalizations.of(
+          tester.element(find.byType(CastMemberRow)),
+        );
+        expect(find.text(l.castShowAll), findsOneWidget);
+
+        // Tile is past the visible viewport (4 × 144 + gaps > 420).
+        await tester.scrollUntilVisible(
+          find.text(l.castShowAll),
+          200,
+          scrollable: find.byType(Scrollable).first,
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(l.castShowAll));
+        await tester.pumpAndSettle();
+
+        // Sheet shows all 5 names; inline row duplicates the first 3.
+        expect(find.text(l.castShowAll), findsAtLeast(1));
+        expect(find.text('Bryan Cranston'), findsNWidgets(2));
+        expect(find.text('Aaron Paul'), findsNWidgets(2));
+        expect(find.text('Anna Gunn'), findsNWidgets(2));
+        expect(find.text('Dean Norris'), findsOneWidget);
+        expect(find.text('Betsy Brandt'), findsOneWidget);
+        expect(find.text('Marie Schrader'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'wide layout: rich cast never renders the overflow tile '
+      '(all cast visible inline)',
+      (tester) async {
+        // Wide window: 1600×900, the LayoutBuilder's wide branch renders.
+        tester.view.physicalSize = const Size(1600, 900);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final richCast = <CastMember>[
+          const CastMember(name: 'Bryan Cranston', character: 'Walter White'),
+          const CastMember(name: 'Aaron Paul', character: 'Jesse Pinkman'),
+          const CastMember(name: 'Anna Gunn', character: 'Skyler White'),
+          const CastMember(name: 'Dean Norris', character: 'Hank Schrader'),
+        ];
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: VodInfo(id: 201, name: 'Big Buck Bunny', richCast: richCast),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // All 4 names visible inline.
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+        expect(find.text('Dean Norris'), findsOneWidget);
+        // No overflow tile on wide layout, regardless of member count.
+        final l = AppLocalizations.of(
+          tester.element(find.byType(CastMemberRow)),
+        );
+        expect(find.text(l.castShowAll), findsNothing);
+      },
+    );
   });
 }
 

--- a/flutter_client/test/ui/features/vod_details_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_details_screen_test.dart
@@ -126,7 +126,7 @@ void main() {
     });
   });
 
-  group('VodDetailsScreen — rich cast', () {
+  group('VodDetailsScreen - rich cast', () {
     testWidgets(
       'renders rich cast row when richCast is populated',
       (tester) async {
@@ -172,7 +172,7 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(CastMemberRow), findsNothing);
-        // Existing string-cast MetaCreditLine is preserved — RichText with
+        // Existing string-cast MetaCreditLine is preserved - RichText with
         // the "Cast:" label is present in the tree.
         expect(
           find.byWidgetPredicate(

--- a/flutter_client/test/ui/features/vod_details_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_details_screen_test.dart
@@ -207,7 +207,7 @@ void main() {
     );
 
     testWidgets(
-      'narrow layout: rich cast overflow tile opens bottom sheet listing all members',
+      'narrow layout: rich cast picker chip opens bottom sheet listing all members',
       (tester) async {
         // Phone width (below the 600px wide breakpoint).
         tester.view.physicalSize = const Size(420, 800);
@@ -225,33 +225,32 @@ void main() {
         await tester.pumpWidget(
           _TestApp(
             service: _VodDetailsXtreamService(
-              info: VodInfo(id: 201, name: 'Big Buck Bunny', richCast: richCast),
+              info: VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                richCast: richCast,
+              ),
             ),
           ),
         );
         await tester.pumpAndSettle();
 
+        // Compact layout renders a single picker chip: the localized
+        // "Cast" label + a count badge. Member names live in the sheet.
         final l = AppLocalizations.of(
           tester.element(find.byType(CastMemberRow)),
         );
+        expect(find.text(l.vodCast), findsOneWidget);
+        expect(find.text('Bryan Cranston'), findsNothing);
+
+        await tester.tap(find.text(l.vodCast));
+        await tester.pumpAndSettle();
+
+        // Sheet lists all 5 members with their characters.
         expect(find.text(l.castShowAll), findsOneWidget);
-
-        // Tile is past the visible viewport (4 × 144 + gaps > 420).
-        await tester.scrollUntilVisible(
-          find.text(l.castShowAll),
-          200,
-          scrollable: find.byType(Scrollable).first,
-        );
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text(l.castShowAll));
-        await tester.pumpAndSettle();
-
-        // Sheet shows all 5 names; inline row duplicates the first 3.
-        expect(find.text(l.castShowAll), findsAtLeast(1));
-        expect(find.text('Bryan Cranston'), findsNWidgets(2));
-        expect(find.text('Aaron Paul'), findsNWidgets(2));
-        expect(find.text('Anna Gunn'), findsNWidgets(2));
+        expect(find.text('Bryan Cranston'), findsOneWidget);
+        expect(find.text('Aaron Paul'), findsOneWidget);
+        expect(find.text('Anna Gunn'), findsOneWidget);
         expect(find.text('Dean Norris'), findsOneWidget);
         expect(find.text('Betsy Brandt'), findsOneWidget);
         expect(find.text('Marie Schrader'), findsOneWidget);
@@ -259,8 +258,7 @@ void main() {
     );
 
     testWidgets(
-      'wide layout: rich cast never renders the overflow tile '
-      '(all cast visible inline)',
+      'wide layout: no overflow tile when every cast card fits',
       (tester) async {
         // Wide window: 1600×900, the LayoutBuilder's wide branch renders.
         tester.view.physicalSize = const Size(1600, 900);
@@ -277,20 +275,72 @@ void main() {
         await tester.pumpWidget(
           _TestApp(
             service: _VodDetailsXtreamService(
-              info: VodInfo(id: 201, name: 'Big Buck Bunny', richCast: richCast),
+              info: VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                richCast: richCast,
+              ),
             ),
           ),
         );
         await tester.pumpAndSettle();
 
-        // All 4 names visible inline.
+        // All 4 names visible inline; 4 cards fit comfortably in 1600px.
         expect(find.text('Bryan Cranston'), findsOneWidget);
         expect(find.text('Dean Norris'), findsOneWidget);
-        // No overflow tile on wide layout, regardless of member count.
         final l = AppLocalizations.of(
           tester.element(find.byType(CastMemberRow)),
         );
         expect(find.text(l.castShowAll), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'wide layout: overflow tile opens the season-picker-style dialog '
+      'listing all members',
+      (tester) async {
+        // 900px window: the info column fits ~4 cast card slots, so 8
+        // members overflow into a "+N" tile as the last slot.
+        tester.view.physicalSize = const Size(900, 700);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        final richCast = <CastMember>[
+          for (var i = 1; i <= 8; i++)
+            CastMember(name: 'Cast Member $i', character: 'Role $i'),
+        ];
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                richCast: richCast,
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The trailing tile carries the localized show-all label; later
+        // members are not rendered inline.
+        final l = AppLocalizations.of(
+          tester.element(find.byType(CastMemberRow)),
+        );
+        expect(find.text(l.castShowAll), findsOneWidget);
+        expect(find.text('Cast Member 8'), findsNothing);
+
+        await tester.tap(find.text(l.castShowAll));
+        await tester.pumpAndSettle();
+
+        // Wide layout opens a centered dialog (season-picker chrome),
+        // not a bottom sheet, listing every member.
+        expect(find.byType(AlertDialog), findsOneWidget);
+        expect(find.byType(BottomSheet), findsNothing);
+        expect(find.text('Cast Member 1'), findsWidgets);
+        expect(find.text('Cast Member 8'), findsOneWidget);
+        expect(find.text('Role 8'), findsOneWidget);
       },
     );
   });

--- a/flutter_client/test/ui/features/vod_details_screen_test.dart
+++ b/flutter_client/test/ui/features/vod_details_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:m3u_tv/l10n/app_localizations.dart';
 import 'package:m3u_tv/navigation/app_router.dart';
 import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/services/xtream_service.dart';
+import 'package:m3u_tv/shared/cast_member_row.dart';
 
 void main() {
   group('VodDetailsScreen', () {
@@ -123,6 +124,87 @@ void main() {
 
       expect(playerArgs?.startPosition, 0.0);
     });
+  });
+
+  group('VodDetailsScreen — rich cast', () {
+    testWidgets(
+      'renders rich cast row when richCast is populated',
+      (tester) async {
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: const VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                cast: 'Bunny, Frank, Rinky',
+                richCast: <CastMember>[
+                  CastMember(name: 'Bunny', character: 'Frank'),
+                  CastMember(name: 'Big Buck', character: 'The Squirrel'),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsOneWidget);
+        expect(find.text('Bunny'), findsOneWidget);
+        expect(find.text('Frank'), findsOneWidget);
+        expect(find.text('Big Buck'), findsOneWidget);
+        expect(find.text('The Squirrel'), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'hides rich cast row when richCast is null (unpatched server)',
+      (tester) async {
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: const VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                cast: 'Bunny, Frank, Rinky',
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+        // Existing string-cast MetaCreditLine is preserved — RichText with
+        // the "Cast:" label is present in the tree.
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is RichText &&
+                w.text.toPlainText().contains('Cast:') &&
+                w.text.toPlainText().contains('Bunny, Frank, Rinky'),
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'hides rich cast row when richCast is empty list',
+      (tester) async {
+        await tester.pumpWidget(
+          _TestApp(
+            service: _VodDetailsXtreamService(
+              info: const VodInfo(
+                id: 201,
+                name: 'Big Buck Bunny',
+                richCast: <CastMember>[],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(CastMemberRow), findsNothing);
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

Three pieces of work on the Series Details screen, all stacked on a fresh branch off `dev`:

### 1. Hybrid season picker (replaces PR #264's draft)

Per issue #258: form-factor-aware selector with a mobile drawer and a TV/desktop inline control. Per maintainer review on #264: the TV/desktop control is now a **text chip** (no poster thumbnail), not the inline poster-card treatment.

- **Mobile (<700dp)** — pill anchor that opens a bottom-sheet drawer (~50% screen, capped at 480dp), 280ms slide-up, drag-down / X / scrim-tap dismiss.
- **TV/desktop (≥700dp)** — horizontally-scrolling row of stadium-shaped chips (season name + episode count). No poster. 56dp row height.
- Long-press on either surface triggers the existing mark-season confirmation.
- First-season default follows the same logic the rest of the app uses (furthest-along episode → resume if mid-watch → next episode → lowest season).

### 2. Rich cast row (CastMember + CastMemberRow + screen integrations)

When `info.series.richCast` / `info.richCast` is populated (patched m3u-editor server, TMDB-resolved), render `CastMemberRow` directly below the meta block on both VOD and Series detail screens. Falls back gracefully — when `richCast` is null/empty (old/unpatched server) the legacy string-cast `MetaCreditLine` still renders, so old clients see no regression.

### 3. Gradient decoration removed from cast cards

The decorative primary→secondary gradient ring and the bottom→surface fade overlay both produced visible artifacts on circular avatars in dark theme. Stripped: cast cards are now avatar + name + character, nothing else. Focus still comes from the project-wide `GradientBorderEffect` at the card level.

### Files changed

| File | Change |
|---|---|
| `lib/features/series/season_picker.dart` | NEW (picker wrapper + wide-chip row + mobile drawer) |
| `lib/features/series/series_details_screen.dart` | replaced upstream `_SeasonPicker` + `AlertDialog` with the new picker; inserted `CastMemberRow` after the meta block |
| `lib/features/vod/vod_details_screen.dart` | `_infoColumn` now wraps `ItemMetaInfo` in a `Column` with `CastMemberRow` after; `richCast` getter added |
| `lib/shared/cast_member_row.dart` | NEW (avatar + name + character card, gradient artifacts stripped) |
| `lib/services/domain_models.dart` | `CastMember` class + `richCast` field on `VodInfo` / `Series` (+ parser) |
| `lib/l10n/app_{en,de,es,fr,zh}.arb` | `seriesSeasonsSheetTitle`, `seriesCast`, `vodCast` keys |
| `lib/l10n/app_localizations*.dart` | regenerated bindings |
| `test/services/cast_member_test.dart` | NEW (5 cases) |
| `test/services/series_cast_test.dart` | NEW (5 cases) |
| `test/services/vod_info_cast_test.dart` | NEW (6 cases) |
| `test/services/season_model_test.dart` | NEW (5 cases) |
| `test/ui/features/cast_member_row_test.dart` | NEW (12 cases) |
| `test/ui/features/vod_details_screen_test.dart` | +3 cast cases |
| `test/features/series/series_details_screen_test.dart` | updated 16 picker tests for new chip key + 4 cast cases |

### Quality gates

- `flutter analyze lib test` → 0 issues
- `flutter test` (full suite) → 1169 pass, 7 skip, 1 pre-existing `push_token_lifecycle_test` cross-file flake (passes in isolation, same pattern as the `favorites_sync_test` / `media_request_ownership_test` flakes already documented in CLAUDE.md)
- `flutter build linux --debug` → ✓ Built

### Supersedes

This replaces draft PR #264 (which had only the picker with poster cards on wide). Close #264 as superseded once this lands.

### Notes for reviewers

- The wide-screen chip is intentionally minimal — no poster, no avatar. Tap-to-select + long-press-for-mark-season, same as the drawer pill on mobile.
- The cast row's bottom-fade overlay was removed in addition to the gradient ring — both produced visible dark artifacts on circular avatars.
- `seriesCast` ARB key was missing from the cherry-pick commit; added manually here.

### 4. Cast overflow UX: picker chip (narrow) + "+N" tile with dialog (wide)

Follow-up push (`eb2d603`, `846f5af`) reworking how cast overflow is handled on both breakpoints, mirroring the season picker's chrome throughout:

- **Narrow (<600dp)** — the compact cast card row is replaced by a single season-picker-style chip (localized "Cast" label, muted count badge, down-chevron) sitting **beside the season picker** in the action row. Tap opens the existing bottom-sheet cast list.
- **Wide (≥600dp)** — `CastMemberRow` measures how many 144px cards fit the available width; when the cast is larger, the last slot becomes a **"+N / Show all" tile** instead of scrolling off-screen. Tapping it opens the cast list in the same centered `AlertDialog` chrome the season picker uses on wide layouts (`ListPickerSheet` gained `asDialog`).
- Fixed a stale VOD narrow-layout test still asserting the pre-chip overflow-tile UI, and scoped the series narrow test's count-badge finder so it no longer collides with the season picker's episode-count badge.

**Verification:** `flutter analyze lib test` clean, `dart format` clean, 58/58 tests across the three affected test files, `flutter build linux --debug` ✓.
