### PR TITLE
feat: Add related content

### DIFF
--- a/flutter_client/lib/features/aiostreams/aiostreams_detail_screen.dart
+++ b/flutter_client/lib/features/aiostreams/aiostreams_detail_screen.dart
@@ -24,6 +24,7 @@ class AIOStreamsDetailScreen extends StatefulWidget {
     required this.onPlay,
     this.onSidebarActivate,
     this.appStateController,
+    this.onOpenRelated,
   });
 
   final AIOStreamsItem item;
@@ -32,6 +33,10 @@ class AIOStreamsDetailScreen extends StatefulWidget {
   final void Function(PlayerArgs) onPlay;
   final VoidCallback? onSidebarActivate;
   final AppStateController? appStateController;
+
+  /// Opens a related item's own detail screen. Null hides the row's actions
+  /// (the row itself still renders informationally when this is null).
+  final ValueChanged<RelatedItem>? onOpenRelated;
 
   @override
   State<AIOStreamsDetailScreen> createState() => _AIOStreamsDetailScreenState();
@@ -206,6 +211,7 @@ class _AIOStreamsDetailScreenState extends State<AIOStreamsDetailScreen> {
                 title: video.title.isNotEmpty ? video.title : item.name,
                 video: video,
               ),
+              onOpenRelated: widget.onOpenRelated,
             );
           }
           return _MovieBody(
@@ -219,6 +225,7 @@ class _AIOStreamsDetailScreenState extends State<AIOStreamsDetailScreen> {
               id: item.id,
               title: item.name,
             ),
+            onOpenRelated: widget.onOpenRelated,
           );
         },
       ),
@@ -237,11 +244,13 @@ class _MovieBody extends StatelessWidget {
     required this.onGetStreams,
     this.dominantColor,
     this.colorMatchReady = false,
+    this.onOpenRelated,
   });
 
   final AIOStreamsItem item;
   final bool isLoading;
   final VoidCallback onGetStreams;
+  final ValueChanged<RelatedItem>? onOpenRelated;
 
   /// Palette-extracted backdrop tone + whether it has resolved. Drives the
   /// same colour-matched, cross-faded hero as the Xtream VOD detail.
@@ -276,6 +285,8 @@ class _MovieBody extends StatelessWidget {
       ],
       richCast: richCast,
       castSemanticLabel: l.vodCast,
+      richRelated: item.related,
+      onRelatedTap: onOpenRelated,
       primaryButtonLabel: l.aiostreamsGetStreams,
       onPrimary: onGetStreams,
       isLoading: isLoading,
@@ -309,12 +320,14 @@ class _SeriesBody extends StatefulWidget {
     this.dominantColor,
     this.colorMatchReady = false,
     this.scrollController,
+    this.onOpenRelated,
   });
 
   final AIOStreamsItem item;
   final void Function(AIOStreamsVideo video) onEpisodeSelected;
   final AppStateController? appStateController;
   final ScrollController? scrollController;
+  final ValueChanged<RelatedItem>? onOpenRelated;
 
   /// Palette-extracted backdrop tone + whether it has resolved. Drives the
   /// same colour-matched, cross-faded hero as SeriesDetailsScreen.
@@ -554,6 +567,8 @@ class _SeriesBodyState extends State<_SeriesBody> {
       primaryActions: const [],
       richCast: richCast,
       castSemanticLabel: l.seriesCast,
+      richRelated: item.related,
+      onRelatedTap: widget.onOpenRelated,
       progressList: progress,
       progressResolver: _progressForEpisode,
       canMarkWatched: false,

--- a/flutter_client/lib/features/series/series_details_screen.dart
+++ b/flutter_client/lib/features/series/series_details_screen.dart
@@ -44,6 +44,7 @@ class SeriesDetailsScreen extends StatefulWidget {
     this.progressList = const [],
     this.onMarkEpisodeWatched,
     this.onSidebarActivate,
+    this.onOpenRelated,
   });
 
   final int seriesId;
@@ -63,6 +64,10 @@ class SeriesDetailsScreen extends StatefulWidget {
   final List<Progress> progressList;
   final MarkEpisodeWatched? onMarkEpisodeWatched;
   final VoidCallback? onSidebarActivate;
+
+  /// Opens a related item's own detail screen. Null hides the row's actions
+  /// (the row itself still renders informationally when this is null).
+  final ValueChanged<RelatedItem>? onOpenRelated;
 
   @override
   State<SeriesDetailsScreen> createState() => _SeriesDetailsScreenState();
@@ -215,6 +220,7 @@ class _SeriesDetailsScreenState extends State<SeriesDetailsScreen> {
             onEpisodeSelected: _playEpisode,
             onMarkEpisode: _markEpisode,
             onMarkSeason: _markSeason,
+            onOpenRelated: widget.onOpenRelated,
           );
         },
       ),
@@ -326,6 +332,7 @@ class _SeriesDetailsBody extends StatelessWidget {
     required this.onEpisodeSelected,
     required this.onMarkEpisode,
     required this.onMarkSeason,
+    this.onOpenRelated,
     this.scrollController,
   });
 
@@ -352,6 +359,7 @@ class _SeriesDetailsBody extends StatelessWidget {
   final void Function(Episode episode, {required bool watched}) onMarkEpisode;
   final void Function(List<Episode> episodes, {required bool watched})
   onMarkSeason;
+  final ValueChanged<RelatedItem>? onOpenRelated;
 
   List<int> get _seasonNumbers {
     final numbers = <int>{
@@ -600,6 +608,8 @@ class _SeriesDetailsBody extends StatelessWidget {
       primaryActions: _primaryActions(context, target),
       richCast: info.series.richCast,
       castSemanticLabel: AppLocalizations.of(context).seriesCast,
+      richRelated: info.series.related,
+      onRelatedTap: onOpenRelated,
       progressList: progressList,
       canMarkWatched: canMarkWatched,
       emptyEpisodesLabel: 'No episodes available',

--- a/flutter_client/lib/features/vod/vod_details_screen.dart
+++ b/flutter_client/lib/features/vod/vod_details_screen.dart
@@ -19,6 +19,7 @@ class VodDetailsScreen extends StatefulWidget {
     this.progressList = const [],
     this.onPlay,
     this.onSidebarActivate,
+    this.onOpenRelated,
   });
 
   final VodItem item;
@@ -26,6 +27,10 @@ class VodDetailsScreen extends StatefulWidget {
   final List<Progress> progressList;
   final void Function(PlayerArgs)? onPlay;
   final VoidCallback? onSidebarActivate;
+
+  /// Opens a related item's own detail screen. Null hides the row's actions
+  /// (the row itself still renders informationally when this is null).
+  final ValueChanged<RelatedItem>? onOpenRelated;
 
   @override
   State<VodDetailsScreen> createState() => _VodDetailsScreenState();
@@ -85,6 +90,7 @@ class _VodDetailsScreenState extends State<VodDetailsScreen> {
               item: widget.item,
               progressList: widget.progressList,
               onPlay: widget.onPlay,
+              onOpenRelated: widget.onOpenRelated,
               dominantColor: _dominantColor,
               colorMatchReady: _colorMatchResolved,
             )
@@ -97,6 +103,7 @@ class _VodDetailsScreenState extends State<VodDetailsScreen> {
                   isLoading: snapshot.connectionState != ConnectionState.done,
                   progressList: widget.progressList,
                   onPlay: widget.onPlay,
+                  onOpenRelated: widget.onOpenRelated,
                   dominantColor: _dominantColor,
                   // A failed info fetch means no backdrop and no palette step
                   // will run - reveal the (surface) hero rather than holding.
@@ -115,6 +122,7 @@ class _VodDetailsBody extends StatelessWidget {
     this.isLoading = false,
     this.progressList = const [],
     this.onPlay,
+    this.onOpenRelated,
     this.dominantColor,
     this.colorMatchReady = false,
   });
@@ -124,6 +132,7 @@ class _VodDetailsBody extends StatelessWidget {
   final bool isLoading;
   final List<Progress> progressList;
   final void Function(PlayerArgs)? onPlay;
+  final ValueChanged<RelatedItem>? onOpenRelated;
 
   /// Passed straight to the shared body's colour-match reveal - true once the
   /// palette extraction has resolved.
@@ -166,6 +175,8 @@ class _VodDetailsBody extends StatelessWidget {
       ],
       richCast: richCast,
       castSemanticLabel: l.vodCast,
+      richRelated: details.related,
+      onRelatedTap: onOpenRelated,
       primaryButtonLabel: buttonLabel,
       onPrimary: () =>
           _play(details, startPosition: progress?.positionSeconds.toDouble()),
@@ -247,6 +258,7 @@ class _ResolvedVodDetails {
   String? get director => _notEmpty(info?.director);
   String? get cast => _notEmpty(info?.cast);
   List<CastMember>? get richCast => info?.richCast;
+  List<RelatedItem>? get related => info?.related;
   String? get year => _notEmpty(info?.year) ?? _notEmpty(info?.releaseDate);
   String? get duration => _notEmpty(info?.duration);
   double? get rating => info?.rating ?? item.rating;

--- a/flutter_client/lib/l10n/app_de.arb
+++ b/flutter_client/lib/l10n/app_de.arb
@@ -381,6 +381,7 @@
   },
   "seriesSeasons": "Staffeln",
   "seriesCast": "Besetzung",
+  "relatedTitle": "Ähnliche Titel",
   "seriesEpisodeCount": "{count, plural, =1{1 Folge} other{{count} Folgen}}",
   "@seriesEpisodeCount": {
     "placeholders": {

--- a/flutter_client/lib/l10n/app_en.arb
+++ b/flutter_client/lib/l10n/app_en.arb
@@ -382,6 +382,7 @@
   },
   "seriesSeasons": "Seasons",
   "seriesCast": "Cast",
+  "relatedTitle": "Related",
   "seriesEpisodeCount": "{count, plural, =1{1 episode} other{{count} episodes}}",
   "@seriesEpisodeCount": {
     "placeholders": {

--- a/flutter_client/lib/l10n/app_es.arb
+++ b/flutter_client/lib/l10n/app_es.arb
@@ -381,6 +381,7 @@
   },
   "seriesSeasons": "Temporadas",
   "seriesCast": "Reparto",
+  "relatedTitle": "Relacionados",
   "seriesEpisodeCount": "{count, plural, =1{1 episodio} other{{count} episodios}}",
   "@seriesEpisodeCount": {
     "placeholders": {

--- a/flutter_client/lib/l10n/app_fr.arb
+++ b/flutter_client/lib/l10n/app_fr.arb
@@ -381,6 +381,7 @@
   },
   "seriesSeasons": "Saisons",
   "seriesCast": "Casting",
+  "relatedTitle": "Contenus similaires",
   "seriesEpisodeCount": "{count, plural, =1{1 épisode} other{{count} épisodes}}",
   "@seriesEpisodeCount": {
     "placeholders": {

--- a/flutter_client/lib/l10n/app_localizations.dart
+++ b/flutter_client/lib/l10n/app_localizations.dart
@@ -1442,6 +1442,12 @@ abstract class AppLocalizations {
   /// **'Cast'**
   String get seriesCast;
 
+  /// No description provided for @relatedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Related'**
+  String get relatedTitle;
+
   /// No description provided for @seriesEpisodeCount.
   ///
   /// In en, this message translates to:

--- a/flutter_client/lib/l10n/app_localizations_de.dart
+++ b/flutter_client/lib/l10n/app_localizations_de.dart
@@ -756,6 +756,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get seriesCast => 'Besetzung';
 
   @override
+  String get relatedTitle => 'Ähnliche Titel';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/flutter_client/lib/l10n/app_localizations_en.dart
+++ b/flutter_client/lib/l10n/app_localizations_en.dart
@@ -751,6 +751,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get seriesCast => 'Cast';
 
   @override
+  String get relatedTitle => 'Related';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/flutter_client/lib/l10n/app_localizations_es.dart
+++ b/flutter_client/lib/l10n/app_localizations_es.dart
@@ -757,6 +757,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get seriesCast => 'Reparto';
 
   @override
+  String get relatedTitle => 'Relacionados';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/flutter_client/lib/l10n/app_localizations_fr.dart
+++ b/flutter_client/lib/l10n/app_localizations_fr.dart
@@ -760,6 +760,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get seriesCast => 'Casting';
 
   @override
+  String get relatedTitle => 'Contenus similaires';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/flutter_client/lib/l10n/app_localizations_zh.dart
+++ b/flutter_client/lib/l10n/app_localizations_zh.dart
@@ -724,6 +724,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get seriesCast => '演员阵容';
 
   @override
+  String get relatedTitle => '相关内容';
+
+  @override
   String seriesEpisodeCount(int count) {
     String _temp0 = intl.Intl.pluralLogic(
       count,

--- a/flutter_client/lib/l10n/app_zh.arb
+++ b/flutter_client/lib/l10n/app_zh.arb
@@ -381,6 +381,7 @@
   },
   "seriesSeasons": "剧集季",
   "seriesCast": "演员阵容",
+  "relatedTitle": "相关内容",
   "seriesEpisodeCount": "{count, plural, =1{1 集} other{{count} 集}}",
   "@seriesEpisodeCount": {
     "placeholders": {

--- a/flutter_client/lib/navigation/go_router_config.dart
+++ b/flutter_client/lib/navigation/go_router_config.dart
@@ -47,17 +47,28 @@ CustomTransitionPage<void> _slidePage(Widget screen) =>
 /// needs resolving to the matching [VodItem]/[Series] by id.
 void _openRelated(ContentActions actions, RelatedItem related) {
   final targetId = int.tryParse(related.id);
-  if (targetId == null) return;
+  if (targetId == null) {
+    debugPrint('_openRelated: unparseable id "${related.id}"');
+    return;
+  }
   if (related.isSeries) {
     final series = actions.appState.seriesList.firstWhereOrNull(
       (s) => s.id == targetId,
     );
-    if (series != null) actions.onSeriesSelect(series);
+    if (series != null) {
+      actions.onSeriesSelect(series);
+    } else {
+      debugPrint('_openRelated: series #$targetId not found in library');
+    }
   } else {
     final vod = actions.appState.vodItems.firstWhereOrNull(
       (v) => v.id == targetId,
     );
-    if (vod != null) actions.onVodSelect(vod);
+    if (vod != null) {
+      actions.onVodSelect(vod);
+    } else {
+      debugPrint('_openRelated: VOD #$targetId not found in library');
+    }
   }
 }
 

--- a/flutter_client/lib/navigation/go_router_config.dart
+++ b/flutter_client/lib/navigation/go_router_config.dart
@@ -40,6 +40,27 @@ CustomTransitionPage<void> _slidePage(Widget screen) =>
       ),
     );
 
+/// Opens a Related-row tap's own detail screen, reusing the same
+/// `onVodSelect`/`onSeriesSelect` callbacks every other VOD/series entry
+/// point (grids, Continue Watching) already navigates through - a related
+/// item is guaranteed to already exist in the user's library, so it only
+/// needs resolving to the matching [VodItem]/[Series] by id.
+void _openRelated(ContentActions actions, RelatedItem related) {
+  final targetId = int.tryParse(related.id);
+  if (targetId == null) return;
+  if (related.isSeries) {
+    final series = actions.appState.seriesList.firstWhereOrNull(
+      (s) => s.id == targetId,
+    );
+    if (series != null) actions.onSeriesSelect(series);
+  } else {
+    final vod = actions.appState.vodItems.firstWhereOrNull(
+      (v) => v.id == targetId,
+    );
+    if (vod != null) actions.onVodSelect(vod);
+  }
+}
+
 GoRouter createGoRouter({
   required AppStateController appState,
   required bool nativeTelevisionHint,
@@ -163,6 +184,8 @@ GoRouter createGoRouter({
                             onPlay: actions.onOpenPlayer,
                             progressList: actions.progressList,
                             onSidebarActivate: actions.onSidebarActivate,
+                            onOpenRelated: (related) =>
+                                _openRelated(actions, related),
                           ),
                         ),
                       );
@@ -218,6 +241,8 @@ GoRouter createGoRouter({
                             progressList: actions.progressList,
                             onMarkEpisodeWatched: actions.onMarkEpisodeWatched,
                             onSidebarActivate: actions.onSidebarActivate,
+                            onOpenRelated: (related) =>
+                                _openRelated(actions, related),
                           ),
                         ),
                       );
@@ -283,6 +308,13 @@ GoRouter createGoRouter({
                           appStateController: actions.appState,
                           onPlay: actions.onOpenPlayer,
                           onSidebarActivate: actions.onSidebarActivate,
+                          onOpenRelated: (related) => context.go(
+                            RouteNames.aiostreamsDetailsFor(
+                              integrationId,
+                              related.type,
+                              related.id,
+                            ),
+                          ),
                         ),
                       );
                     },

--- a/flutter_client/lib/navigation/go_router_config.dart
+++ b/flutter_client/lib/navigation/go_router_config.dart
@@ -308,11 +308,27 @@ GoRouter createGoRouter({
                           appStateController: actions.appState,
                           onPlay: actions.onOpenPlayer,
                           onSidebarActivate: actions.onSidebarActivate,
-                          onOpenRelated: (related) => context.go(
+                          // push (not go) - a related item lands on the same
+                          // route pattern this screen is already on, and go()
+                          // to a same-pattern location updates this State in
+                          // place rather than creating a fresh one, so the
+                          // (late final) meta fetch never re-runs and the
+                          // pushed-detail sidebar-depth tracking every other
+                          // detail screen relies on never fires. push() gives
+                          // it a real, freshly-initialized instance and a
+                          // normal one-level pop on back, matching how
+                          // VOD/Series related items navigate.
+                          onOpenRelated: (related) => context.push(
                             RouteNames.aiostreamsDetailsFor(
                               integrationId,
                               related.type,
                               related.id,
+                            ),
+                            extra: AIOStreamsItem(
+                              id: related.id,
+                              type: related.type,
+                              name: related.title,
+                              poster: related.posterUrl,
                             ),
                           ),
                         ),

--- a/flutter_client/lib/services/aiostreams_api_service.dart
+++ b/flutter_client/lib/services/aiostreams_api_service.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:m3u_tv/services/domain_models.dart' show CastMember, Season;
+import 'package:m3u_tv/services/domain_models.dart'
+    show CastMember, RelatedItem, Season;
 import 'package:m3u_tv/services/xtream_service.dart';
 
 /// A stream option returned by AIOStreams for a given IMDb/TMDB content ID.
@@ -94,6 +95,7 @@ class AIOStreamsItem {
     this.writer,
     this.runtime,
     this.seasons = const <Season>[],
+    this.related,
   });
 
   factory AIOStreamsItem.fromJson(Map<String, dynamic> json) {
@@ -136,6 +138,7 @@ class AIOStreamsItem {
       writer: _joinNames(json['writer']),
       runtime: json['runtime'] == null ? null : '${json['runtime']}',
       seasons: seasons,
+      related: _parseRelatedList(json['related']),
     );
   }
 
@@ -170,6 +173,10 @@ class AIOStreamsItem {
   /// Season poster / overview metadata from the editor's TMDB enrichment,
   /// keyed by season number at the call site. Empty on a plain Stremio meta.
   final List<Season> seasons;
+
+  /// TMDB recommendations already in the user's library, from the editor's
+  /// TMDB-enriched `related`. Null on a plain Stremio meta.
+  final List<RelatedItem>? related;
 }
 
 int? _parseInt(dynamic value) {
@@ -209,6 +216,18 @@ List<CastMember>? _parseCastList(dynamic raw) {
   final parsed = raw
       .map(CastMember.fromXtream)
       .whereType<CastMember>()
+      .toList(growable: false);
+  return parsed.isEmpty ? null : parsed;
+}
+
+/// Parses the editor's `related` payload into [RelatedItem]s (AIOStreams
+/// shape: `{id, type, name, poster}`). Mirrors the private reader in
+/// domain_models.dart (kept local so that file's helper can stay private).
+List<RelatedItem>? _parseRelatedList(dynamic raw) {
+  if (raw is! List) return null;
+  final parsed = raw
+      .map(RelatedItem.fromAiostreams)
+      .whereType<RelatedItem>()
       .toList(growable: false);
   return parsed.isEmpty ? null : parsed;
 }

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -370,13 +370,18 @@ class RelatedItem {
     if (json is! Map) return null;
     final map = json.cast<String, Object?>();
     final id = _asNullableString(map['id']);
+    final type = _asNullableString(map['type']);
     final title = _asNullableString(map['name'])?.trim();
-    if (id == null || id.isEmpty || title == null || title.isEmpty) {
+    if (id == null ||
+        id.isEmpty ||
+        title == null ||
+        title.isEmpty ||
+        (type != 'movie' && type != 'series')) {
       return null;
     }
     return RelatedItem(
       id: id,
-      type: _asNullableString(map['type']) ?? 'movie',
+      type: type!,
       title: title,
       posterUrl: _asNullableString(map['poster']),
     );

--- a/flutter_client/lib/services/domain_models.dart
+++ b/flutter_client/lib/services/domain_models.dart
@@ -182,6 +182,7 @@ class VodInfo {
     this.containerExtension,
     this.tmdbId,
     this.edlUrl,
+    this.related,
   });
 
   final int id;
@@ -197,6 +198,10 @@ class VodInfo {
   final double? rating;
   final String? coverUrl;
   final String? backdropUrl;
+
+  /// TMDB recommendations already in the user's library. Rendered as the
+  /// "Related" row below the cast row.
+  final List<RelatedItem>? related;
 
   /// Transparent title logo (clearlogo). m3u-editor emits this as a `clearlogo`
   /// wire key in `get_vod_info`, distinct from the poster `cover_big`.
@@ -253,6 +258,7 @@ class VodInfo {
       ),
       tmdbId: _asIntOrNull(pick(['tmdb_id', 'tmdb'])),
       edlUrl: _asNullableString(pick(['edl_url'])),
+      related: _parseRelatedList(pick(['related'])),
     );
   }
 }
@@ -308,6 +314,85 @@ List<CastMember>? _parseCastList(Object? raw) {
   return parsed.isEmpty ? null : parsed;
 }
 
+/// A recommended title shown in the "Related" row below the cast row on a
+/// VOD/series detail screen.
+///
+/// Two wire shapes carry this, both keyed on m3u-editor's TMDB
+/// recommendations filtered down to titles already in the user's library:
+///  * Xtream `get_vod_info` / `get_series_info` `related`: `{type, id, name,
+///    cover, tmdb_id?}`, where `id` is the library's own Channel/Series id -
+///    exactly what VodDetailsScreen/SeriesDetailsScreen already navigate
+///    with. See [fromXtream].
+///  * AIOStreams meta `related`: `{id, type, name, poster}`, where `id` is a
+///    Stremio-style `tmdb:{id}` string - exactly what AIOStreamsDetailScreen
+///    already navigates with. See [fromAiostreams].
+///
+/// [id] is kept opaque here; the caller (not this class) knows which
+/// navigation scheme applies to it.
+class RelatedItem {
+  const RelatedItem({
+    required this.id,
+    required this.type,
+    required this.title,
+    this.posterUrl,
+  });
+
+  final String id;
+
+  /// `"movie"` or `"series"`.
+  final String type;
+  final String title;
+  final String? posterUrl;
+
+  bool get isSeries => type == 'series';
+
+  /// Xtream `related` entry: `{type, id, name, cover}`.
+  static RelatedItem? fromXtream(Object? json) {
+    if (json is! Map) return null;
+    final map = json.cast<String, Object?>();
+    final id = _asIntOrNull(map['id']);
+    final type = _asNullableString(map['type']);
+    final title = _asNullableString(map['name'])?.trim();
+    if (id == null || type == null || title == null || title.isEmpty) {
+      return null;
+    }
+    return RelatedItem(
+      id: '$id',
+      type: type,
+      title: title,
+      posterUrl: _asNullableString(map['cover']),
+    );
+  }
+
+  /// AIOStreams `related` entry: `{id, type, name, poster}`. `id` is already
+  /// the Stremio-style `tmdb:{id}` string other AIOStreams items use.
+  static RelatedItem? fromAiostreams(Object? json) {
+    if (json is! Map) return null;
+    final map = json.cast<String, Object?>();
+    final id = _asNullableString(map['id']);
+    final title = _asNullableString(map['name'])?.trim();
+    if (id == null || id.isEmpty || title == null || title.isEmpty) {
+      return null;
+    }
+    return RelatedItem(
+      id: id,
+      type: _asNullableString(map['type']) ?? 'movie',
+      title: title,
+      posterUrl: _asNullableString(map['poster']),
+    );
+  }
+}
+
+List<RelatedItem>? _parseRelatedList(Object? raw) {
+  if (raw is! List) return null;
+  final parsed = raw
+      .whereType<Map<Object?, Object?>>()
+      .map(RelatedItem.fromXtream)
+      .whereType<RelatedItem>()
+      .toList(growable: false);
+  return parsed.isEmpty ? null : parsed;
+}
+
 class Series {
   const Series({
     required this.id,
@@ -322,6 +407,7 @@ class Series {
     this.tmdbId,
     this.richCast,
     this.year,
+    this.related,
   });
 
   final int id;
@@ -348,6 +434,10 @@ class Series {
   /// `releaseDate` field (a date string) or a bare `year` when present.
   final String? year;
 
+  /// TMDB recommendations already in the user's library. Rendered as the
+  /// "Related" row below the cast row.
+  final List<RelatedItem>? related;
+
   factory Series.fromXtream(Map<String, Object?> json) => Series(
     id: _asInt(json['series_id']),
     name: '${json['name'] ?? ''}',
@@ -363,6 +453,7 @@ class Series {
     year: _yearString(
       json['releaseDate'] ?? json['release_date'] ?? json['year'],
     ),
+    related: _parseRelatedList(json['related']),
   );
 }
 

--- a/flutter_client/lib/shared/media_browsing_widgets.dart
+++ b/flutter_client/lib/shared/media_browsing_widgets.dart
@@ -45,6 +45,36 @@ class MediaBrowsingMetrics {
   static const double interstitialNavWidth = 200;
 }
 
+/// Small icon + label header used above a detail-page row (Cast, Related).
+/// Mirrors [MediaPreviewSection]'s own title-row styling so a header reads
+/// consistently whether the row sits inside a preview section or a locked
+/// D-pad row (CastRow/RelatedRow) on the Movie/Series detail pages.
+class DetailRowHeader extends StatelessWidget {
+  const DetailRowHeader({super.key, required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final scale = FontSizeScope.scaleOf(context);
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 20 * scale, color: theme.textTheme.titleSmall?.color),
+        const SizedBox(width: 8),
+        Text(
+          label,
+          style: theme.textTheme.titleSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 class InlineMediaSearchField extends StatefulWidget {
   const InlineMediaSearchField({
     required this.query,

--- a/flutter_client/lib/shared/movie_detail_body.dart
+++ b/flutter_client/lib/shared/movie_detail_body.dart
@@ -139,6 +139,7 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
   }
 
   Widget _buildWide(BuildContext context, ThemeData theme, Color bg) {
+    final l = AppLocalizations.of(context);
     final richCast = widget.richCast;
     final hasCast = richCast != null && richCast.isNotEmpty;
     final richRelated = widget.richRelated;
@@ -204,13 +205,29 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
                           Semantics(
                             label: widget.castSemanticLabel,
                             container: true,
-                            child: CastRow(members: richCast),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                DetailRowHeader(
+                                  icon: Icons.people,
+                                  label: widget.castSemanticLabel,
+                                ),
+                                const SizedBox(height: 8),
+                                CastRow(members: richCast),
+                              ],
+                            ),
                           ),
                         if (hasRelated) ...[
                           if (hasCast)
                             const SizedBox(
                               height: MediaBrowsingMetrics.contentPadding,
                             ),
+                          DetailRowHeader(
+                            icon: Icons.recommend,
+                            label: l.relatedTitle,
+                          ),
+                          const SizedBox(height: 8),
                           RelatedRow(
                             items: richRelated,
                             onTap: (item) => widget.onRelatedTap?.call(item),
@@ -338,6 +355,7 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
             ),
             child: MediaPreviewSection(
               title: l.relatedTitle,
+              titleIcon: Icons.recommend,
               emptyLabel: '',
               posterStyle: true,
               items: [

--- a/flutter_client/lib/shared/movie_detail_body.dart
+++ b/flutter_client/lib/shared/movie_detail_body.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:m3u_tv/l10n/app_localizations.dart';
@@ -93,10 +95,30 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
     debugLabel: 'movieDetailPrimary',
   );
 
+  /// Owned externally (rather than left to RowScrollRegion to create its own)
+  /// so this state can drive it directly - see [_scrollToTop] - mirroring
+  /// SeriesDetailBody's `_SeriesScrollHost`.
+  final ScrollController _scrollController = ScrollController();
+
   @override
   void dispose() {
     _primaryFocusNode.dispose();
+    _scrollController.dispose();
     super.dispose();
+  }
+
+  /// The poster/title/meta block is always the very top of the page, so any
+  /// focus landing anywhere inside it (including the Play button) means
+  /// "show the top of the page" - matches SeriesDetailBody's `_scrollToTop`.
+  void _scrollToTop() {
+    if (!_scrollController.hasClients) return;
+    unawaited(
+      _scrollController.animateTo(
+        0,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeOut,
+      ),
+    );
   }
 
   @override
@@ -122,37 +144,53 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
     final richRelated = widget.richRelated;
     final hasRelated = richRelated != null && richRelated.isNotEmpty;
     final scale = FontSizeScope.scaleOf(context);
+    final upper = Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: 220 * scale),
+          child: AspectRatio(
+            aspectRatio: 0.68,
+            child: ResilientMediaImage(
+              imageUrl: widget.posterUrl,
+              fallbackIcon: widget.fallbackIcon,
+              borderRadius: MediaBrowsingMetrics.cardRadius,
+              fallbackTitle: widget.name,
+            ),
+          ),
+        ),
+        const SizedBox(width: MediaBrowsingMetrics.pagePadding),
+        Expanded(child: _infoColumn(context, theme)),
+      ],
+    );
+
     // The whole page (poster + meta + cast + related) scrolls together via
     // RowScrollRegion, matching SeriesDetailBody - the poster/meta block
     // renders at its natural size and the page grows to fit a taller
     // footer, rather than the footer squeezing the poster into less height
-    // than its aspect ratio wants.
+    // than its aspect ratio wants. No contentPadding on BackdropDetailHero
+    // (unlike the narrow layout below) - the top/bottom insets live *inside*
+    // the scrolled column instead, so they scroll away with everything else
+    // rather than clipping the first/last row against a fixed boundary, and
+    // the hero/poster can run all the way up behind the transparent AppBar.
     final content = Padding(
-      padding: const EdgeInsets.all(MediaBrowsingMetrics.pagePadding),
+      padding: const EdgeInsets.symmetric(
+        horizontal: MediaBrowsingMetrics.pagePadding,
+      ),
       child: RowScrollRegion(
+        controller: _scrollController,
         onExitTop: _primaryFocusNode.requestFocus,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
           children: [
-            Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: [
-                ConstrainedBox(
-                  constraints: BoxConstraints(maxWidth: 220 * scale),
-                  child: AspectRatio(
-                    aspectRatio: 0.68,
-                    child: ResilientMediaImage(
-                      imageUrl: widget.posterUrl,
-                      fallbackIcon: widget.fallbackIcon,
-                      borderRadius: MediaBrowsingMetrics.cardRadius,
-                      fallbackTitle: widget.name,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: MediaBrowsingMetrics.pagePadding),
-                Expanded(child: _infoColumn(context, theme)),
-              ],
+            SizedBox(height: detailAppBarHeight(context) + 32),
+            Focus(
+              canRequestFocus: false,
+              skipTraversal: true,
+              onFocusChange: (hasFocus) {
+                if (hasFocus) _scrollToTop();
+              },
+              child: upper,
             ),
             CastRevealSlot(
               topPadding: MediaBrowsingMetrics.contentPadding,
@@ -181,6 +219,7 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
                       ],
                     ),
             ),
+            SizedBox(height: MediaQuery.paddingOf(context).bottom + 24),
           ],
         ),
       ),
@@ -193,10 +232,7 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
       backgroundColor: bg,
       scrimColors: [bg.withValues(alpha: 0.35), bg.withValues(alpha: 0.92), bg],
       colorMatchReady: widget.colorMatchReady,
-      contentPadding: EdgeInsets.only(
-        top: 24 + detailAppBarHeight(context),
-        bottom: 24,
-      ),
+      scrollController: _scrollController,
       content: content,
     );
   }

--- a/flutter_client/lib/shared/movie_detail_body.dart
+++ b/flutter_client/lib/shared/movie_detail_body.dart
@@ -12,6 +12,7 @@ import 'package:m3u_tv/shared/item_detail_scaffold.dart'
     show detailAppBarHeight;
 import 'package:m3u_tv/shared/item_meta_info.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+import 'package:m3u_tv/shared/related_strip.dart';
 
 /// Shared layout scaffold for a movie-style detail page - poster + meta +
 /// cast strip over a colour-matched BackdropDetailHero. Used by both the
@@ -37,6 +38,8 @@ class MovieDetailBody extends StatefulWidget {
     this.clearLogoUrl,
     this.plot,
     this.richCast,
+    this.richRelated,
+    this.onRelatedTap,
     this.onStartOver,
     this.progressValue,
     this.dominantColor,
@@ -52,6 +55,15 @@ class MovieDetailBody extends StatefulWidget {
   final List<MetaCreditLine> credits;
   final List<CastMember>? richCast;
   final String castSemanticLabel;
+
+  /// TMDB recommendations already in the user's library, shown as the
+  /// "Related" row directly below the cast row. Null/empty renders nothing.
+  final List<RelatedItem>? richRelated;
+
+  /// Required whenever [richRelated] is non-empty - opens that item's own
+  /// detail screen. The caller (Xtream vs AIOStreams) owns the navigation,
+  /// this widget only reports the tap.
+  final ValueChanged<RelatedItem>? onRelatedTap;
 
   final String primaryButtonLabel;
   final VoidCallback onPrimary;
@@ -80,6 +92,12 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
     debugLabel: 'movieDetailPrimary',
   );
 
+  /// Lets the wide related strip hop focus back up into the cast strip (when
+  /// both are present) instead of only ever going to the primary button.
+  final GlobalKey<CastStripState> _castStripKey = GlobalKey<CastStripState>();
+  final GlobalKey<RelatedStripState> _relatedStripKey =
+      GlobalKey<RelatedStripState>();
+
   @override
   void dispose() {
     _primaryFocusNode.dispose();
@@ -105,6 +123,9 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
 
   Widget _buildWide(BuildContext context, ThemeData theme, Color bg) {
     final richCast = widget.richCast;
+    final hasCast = richCast != null && richCast.isNotEmpty;
+    final richRelated = widget.richRelated;
+    final hasRelated = richRelated != null && richRelated.isNotEmpty;
     final scale = FontSizeScope.scaleOf(context);
     // Poster + scrolling info column fill the height; the rich cast strip is
     // pinned full-width below, out of that scroll view so left/right card
@@ -142,15 +163,41 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
           ),
           CastRevealSlot(
             topPadding: MediaBrowsingMetrics.contentPadding,
-            castRow: (richCast == null || richCast.isEmpty)
+            castRow: (!hasCast && !hasRelated)
                 ? null
-                : Semantics(
-                    label: widget.castSemanticLabel,
-                    container: true,
-                    child: CastStrip(
-                      members: richCast,
-                      onNavigateUp: _primaryFocusNode.requestFocus,
-                    ),
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (hasCast)
+                        Semantics(
+                          label: widget.castSemanticLabel,
+                          container: true,
+                          child: CastStrip(
+                            key: _castStripKey,
+                            members: richCast,
+                            onNavigateUp: _primaryFocusNode.requestFocus,
+                            onNavigateDown: hasRelated
+                                ? () =>
+                                      _relatedStripKey.currentState?.focusRow()
+                                : null,
+                          ),
+                        ),
+                      if (hasRelated) ...[
+                        if (hasCast)
+                          const SizedBox(
+                            height: MediaBrowsingMetrics.contentPadding,
+                          ),
+                        RelatedStrip(
+                          key: _relatedStripKey,
+                          items: richRelated,
+                          onTap: (item) => widget.onRelatedTap?.call(item),
+                          onNavigateUp: hasCast
+                              ? () => _castStripKey.currentState?.focusRow()
+                              : _primaryFocusNode.requestFocus,
+                        ),
+                      ],
+                    ],
                   ),
           ),
         ],
@@ -263,6 +310,28 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
                     onShowAll: () => showAllCast(context, richCast),
                     allCastSemanticLabel: l.castShowAll,
                   ),
+          ),
+        if (compact &&
+            widget.richRelated != null &&
+            widget.richRelated!.isNotEmpty)
+          Padding(
+            padding: const EdgeInsets.only(
+              top: MediaBrowsingMetrics.contentPadding,
+            ),
+            child: MediaPreviewSection(
+              title: l.relatedTitle,
+              emptyLabel: '',
+              posterStyle: true,
+              items: [
+                for (final item in widget.richRelated!)
+                  MediaPreviewItem(
+                    title: item.title,
+                    imageUrl: item.posterUrl,
+                    fallbackIcon: item.isSeries ? Icons.tv : Icons.movie,
+                    onTap: () => widget.onRelatedTap?.call(item),
+                  ),
+              ],
+            ),
           ),
       ],
     );

--- a/flutter_client/lib/shared/movie_detail_body.dart
+++ b/flutter_client/lib/shared/movie_detail_body.dart
@@ -5,14 +5,14 @@ import 'package:m3u_tv/services/domain_models.dart';
 import 'package:m3u_tv/shared/backdrop_detail_hero.dart';
 import 'package:m3u_tv/shared/cast_member_row.dart';
 import 'package:m3u_tv/shared/cast_reveal_slot.dart';
-import 'package:m3u_tv/shared/cast_strip.dart';
 import 'package:m3u_tv/shared/dominant_backdrop_color.dart';
 import 'package:m3u_tv/shared/image_quality_scope.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart'
     show detailAppBarHeight;
 import 'package:m3u_tv/shared/item_meta_info.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
-import 'package:m3u_tv/shared/related_strip.dart';
+import 'package:m3u_tv/shared/series_detail_widgets.dart'
+    show CastRow, RelatedRow, RowScrollRegion;
 
 /// Shared layout scaffold for a movie-style detail page - poster + meta +
 /// cast strip over a colour-matched BackdropDetailHero. Used by both the
@@ -87,16 +87,11 @@ class MovieDetailBody extends StatefulWidget {
 class _MovieDetailBodyState extends State<MovieDetailBody> {
   static const double _wideBreakpoint = 600;
 
-  /// Focus target for the wide cast strip's "up" hop - the primary button.
+  /// Focus target for the wide layout's top-row exit (RowScrollRegion's
+  /// onExitTop) - the primary button.
   final FocusNode _primaryFocusNode = FocusNode(
     debugLabel: 'movieDetailPrimary',
   );
-
-  /// Lets the wide related strip hop focus back up into the cast strip (when
-  /// both are present) instead of only ever going to the primary button.
-  final GlobalKey<CastStripState> _castStripKey = GlobalKey<CastStripState>();
-  final GlobalKey<RelatedStripState> _relatedStripKey =
-      GlobalKey<RelatedStripState>();
 
   @override
   void dispose() {
@@ -127,21 +122,24 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
     final richRelated = widget.richRelated;
     final hasRelated = richRelated != null && richRelated.isNotEmpty;
     final scale = FontSizeScope.scaleOf(context);
-    // Poster + scrolling info column fill the height; the rich cast strip is
-    // pinned full-width below, out of that scroll view so left/right card
-    // navigation never drags the page.
+    // The whole page (poster + meta + cast + related) scrolls together via
+    // RowScrollRegion, matching SeriesDetailBody - the poster/meta block
+    // renders at its natural size and the page grows to fit a taller
+    // footer, rather than the footer squeezing the poster into less height
+    // than its aspect ratio wants.
     final content = Padding(
       padding: const EdgeInsets.all(MediaBrowsingMetrics.pagePadding),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Expanded(
-            child: Row(
+      child: RowScrollRegion(
+        onExitTop: _primaryFocusNode.requestFocus,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
-                SizedBox(
-                  width: 220 * scale,
+                ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: 220 * scale),
                   child: AspectRatio(
                     aspectRatio: 0.68,
                     child: ResilientMediaImage(
@@ -153,54 +151,38 @@ class _MovieDetailBodyState extends State<MovieDetailBody> {
                   ),
                 ),
                 const SizedBox(width: MediaBrowsingMetrics.pagePadding),
-                Expanded(
-                  child: SingleChildScrollView(
-                    child: _infoColumn(context, theme),
-                  ),
-                ),
+                Expanded(child: _infoColumn(context, theme)),
               ],
             ),
-          ),
-          CastRevealSlot(
-            topPadding: MediaBrowsingMetrics.contentPadding,
-            castRow: (!hasCast && !hasRelated)
-                ? null
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (hasCast)
-                        Semantics(
-                          label: widget.castSemanticLabel,
-                          container: true,
-                          child: CastStrip(
-                            key: _castStripKey,
-                            members: richCast,
-                            onNavigateUp: _primaryFocusNode.requestFocus,
-                            onNavigateDown: hasRelated
-                                ? () =>
-                                      _relatedStripKey.currentState?.focusRow()
-                                : null,
-                          ),
-                        ),
-                      if (hasRelated) ...[
+            CastRevealSlot(
+              topPadding: MediaBrowsingMetrics.contentPadding,
+              castRow: (!hasCast && !hasRelated)
+                  ? null
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
                         if (hasCast)
-                          const SizedBox(
-                            height: MediaBrowsingMetrics.contentPadding,
+                          Semantics(
+                            label: widget.castSemanticLabel,
+                            container: true,
+                            child: CastRow(members: richCast),
                           ),
-                        RelatedStrip(
-                          key: _relatedStripKey,
-                          items: richRelated,
-                          onTap: (item) => widget.onRelatedTap?.call(item),
-                          onNavigateUp: hasCast
-                              ? () => _castStripKey.currentState?.focusRow()
-                              : _primaryFocusNode.requestFocus,
-                        ),
+                        if (hasRelated) ...[
+                          if (hasCast)
+                            const SizedBox(
+                              height: MediaBrowsingMetrics.contentPadding,
+                            ),
+                          RelatedRow(
+                            items: richRelated,
+                            onTap: (item) => widget.onRelatedTap?.call(item),
+                          ),
+                        ],
                       ],
-                    ],
-                  ),
-          ),
-        ],
+                    ),
+            ),
+          ],
+        ),
       ),
     );
 

--- a/flutter_client/lib/shared/related_strip.dart
+++ b/flutter_client/lib/shared/related_strip.dart
@@ -88,6 +88,7 @@ class RelatedStripState extends State<RelatedStrip> {
     super.didUpdateWidget(oldWidget);
     if (_focusedIndex >= widget.items.length) {
       _focusedIndex = widget.items.isEmpty ? 0 : widget.items.length - 1;
+      if (widget.items.isNotEmpty) _centerFocused(animate: false);
     }
   }
 

--- a/flutter_client/lib/shared/related_strip.dart
+++ b/flutter_client/lib/shared/related_strip.dart
@@ -1,0 +1,270 @@
+import 'dart:async';
+
+import 'package:dpad/dpad.dart' show DpadFocusState;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'
+    show KeyDownEvent, KeyEvent, KeyRepeatEvent, LogicalKeyboardKey;
+
+import 'package:m3u_tv/services/domain_models.dart';
+import 'package:m3u_tv/shared/gradient_border_effect.dart';
+import 'package:m3u_tv/shared/hover_scroll_arrows.dart';
+import 'package:m3u_tv/shared/image_quality_scope.dart';
+import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+import 'package:m3u_tv/shared/series_detail_widgets.dart' show SelectHold;
+
+const double _kCardWidth = 130;
+const double _kCardAspectRatio = 0.68;
+const double _kCardTextHeight = 20;
+const double _kCardGap = 12;
+
+/// A "locked focus" horizontal poster row for the "Related" titles shown
+/// below the cast row on a movie/series detail screen.
+///
+/// Follows the exact focus-handling pattern of `CastStrip`
+/// (cast_strip.dart): one plain [Focus] stop that owns every arrow/select key
+/// itself and always consumes it, so nothing reaches dpad's directional
+/// traversal. Left/right move an internal index; up/down are handed to
+/// [onNavigateUp] / [onNavigateDown] (always consumed). Unlike `CastStrip`,
+/// each card here is actionable - selecting a poster opens that title's own
+/// detail screen via [onTap].
+///
+/// Shared by the Series and VOD/movie detail screens (Xtream and AIOStreams)
+/// so a related-items row cannot drift on layout/behaviour between them.
+class RelatedStrip extends StatefulWidget {
+  const RelatedStrip({
+    super.key,
+    required this.items,
+    required this.onTap,
+    this.onNavigateUp,
+    this.onNavigateDown,
+    this.onReveal,
+    this.autofocus = false,
+    this.debugLabel = 'relatedStrip',
+  });
+
+  final List<RelatedItem> items;
+  final ValueChanged<RelatedItem> onTap;
+
+  /// Up pressed while the row holds focus. Always consumed regardless.
+  final VoidCallback? onNavigateUp;
+
+  /// Down pressed while the row holds focus. Always consumed regardless.
+  final VoidCallback? onNavigateDown;
+
+  /// Called with this strip's [BuildContext] whenever it gains focus, so a
+  /// host scroll region can bring it into view. Null when the row is always
+  /// on-screen.
+  final void Function(BuildContext context)? onReveal;
+
+  final bool autofocus;
+  final String debugLabel;
+
+  @override
+  State<RelatedStrip> createState() => RelatedStripState();
+}
+
+class RelatedStripState extends State<RelatedStrip> {
+  final ScrollController _controller = ScrollController();
+  late final FocusNode _focusNode = FocusNode(debugLabel: widget.debugLabel);
+  final SelectHold _selectHold = SelectHold();
+  int _focusedIndex = 0;
+  bool _hasFocus = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.addListener(_handleFocusChange);
+  }
+
+  @override
+  void didUpdateWidget(RelatedStrip oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (_focusedIndex >= widget.items.length) {
+      _focusedIndex = widget.items.isEmpty ? 0 : widget.items.length - 1;
+    }
+  }
+
+  @override
+  void dispose() {
+    _selectHold.dispose();
+    _focusNode
+      ..removeListener(_handleFocusChange)
+      ..dispose();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChange() {
+    if (!mounted) return;
+    setState(() => _hasFocus = _focusNode.hasFocus);
+    if (_focusNode.hasFocus) {
+      _centerFocused(animate: false);
+      widget.onReveal?.call(context);
+    }
+  }
+
+  /// Take focus, park the cursor, and ask the host to reveal the row. Public
+  /// so a sibling row / screen can hop focus here.
+  void focusRow() {
+    _focusNode.requestFocus();
+    _centerFocused(animate: false);
+    widget.onReveal?.call(context);
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    final key = event.logicalKey;
+    if (SelectHold.isSelectKey(key)) {
+      return _selectHold.handle(
+        event,
+        isActive: () => mounted,
+        onTap: _selectFocused,
+      );
+    }
+    final isDown = event is KeyDownEvent || event is KeyRepeatEvent;
+    if (key == LogicalKeyboardKey.arrowLeft) {
+      if (isDown) _moveFocus(-1);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowRight) {
+      if (isDown) _moveFocus(1);
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowUp) {
+      if (widget.onNavigateUp == null) return KeyEventResult.ignored;
+      if (isDown) widget.onNavigateUp!();
+      return KeyEventResult.handled;
+    }
+    if (key == LogicalKeyboardKey.arrowDown) {
+      if (widget.onNavigateDown == null) return KeyEventResult.ignored;
+      if (isDown) widget.onNavigateDown!();
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  double get _scale => FontSizeScope.scaleOf(context);
+  double get _cardWidth => _kCardWidth * _scale;
+  double get _cardGap => _kCardGap * _scale;
+  double get _itemExtent => _cardWidth + _cardGap;
+
+  void _centerFocused({bool animate = true}) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_controller.hasClients) return;
+      final position = _controller.position;
+      final target =
+          (_focusedIndex * _itemExtent +
+                  _cardWidth / 2 -
+                  position.viewportDimension / 2)
+              .clamp(0.0, position.maxScrollExtent);
+      if ((target - position.pixels).abs() < 1) return;
+      if (animate) {
+        unawaited(
+          position.animateTo(
+            target,
+            duration: const Duration(milliseconds: 150),
+            curve: Curves.easeOut,
+          ),
+        );
+      } else {
+        position.jumpTo(target);
+      }
+    });
+  }
+
+  void _moveFocus(int delta) {
+    if (widget.items.isEmpty) return;
+    final target = (_focusedIndex + delta).clamp(0, widget.items.length - 1);
+    if (target == _focusedIndex) return;
+    setState(() => _focusedIndex = target);
+    _centerFocused();
+  }
+
+  void _selectFocused() {
+    if (_focusedIndex < 0 || _focusedIndex >= widget.items.length) return;
+    widget.onTap(widget.items[_focusedIndex]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final items = widget.items;
+    // No Scrollbar wrapper - see CastStrip.build for why (fast key-repeat
+    // races the ListView's own ignore-pointer toggling into a semantics
+    // assertion storm).
+    return Focus(
+      focusNode: _focusNode,
+      autofocus: widget.autofocus,
+      descendantsAreFocusable: false,
+      onKeyEvent: _handleKeyEvent,
+      child: SizedBox(
+        height:
+            _cardWidth / _kCardAspectRatio +
+            8 +
+            _kCardTextHeight * FontSizeScope.scaleOf(context),
+        child: HoverScrollArrows(
+          controller: _controller,
+          child: ListView.builder(
+            controller: _controller,
+            scrollDirection: Axis.horizontal,
+            itemExtent: _itemExtent,
+            itemCount: items.length,
+            itemBuilder: (context, index) => Padding(
+              padding: EdgeInsets.only(right: _cardGap),
+              child: _RelatedStripCard(
+                item: items[index],
+                width: _cardWidth,
+                focused: _hasFocus && index == _focusedIndex,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RelatedStripCard extends StatelessWidget {
+  const _RelatedStripCard({
+    required this.item,
+    required this.width,
+    required this.focused,
+  });
+
+  final RelatedItem item;
+  final double width;
+  final bool focused;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final body = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AspectRatio(
+          aspectRatio: _kCardAspectRatio,
+          child: ResilientMediaImage(
+            imageUrl: item.posterUrl,
+            fallbackIcon: item.isSeries ? Icons.tv : Icons.movie,
+            borderRadius: MediaBrowsingMetrics.cardRadius,
+            fallbackTitle: item.title,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          item.title,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ],
+    );
+    return SizedBox(
+      width: width,
+      child: GradientBorderEffect(
+        borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
+      ).build(context, DpadFocusState(focused: focused, pressed: false), body),
+    );
+  }
+}

--- a/flutter_client/lib/shared/related_strip.dart
+++ b/flutter_client/lib/shared/related_strip.dart
@@ -276,7 +276,8 @@ class _RelatedStripCardState extends State<_RelatedStripCard> {
   @override
   void initState() {
     super.initState();
-    final delay = _staggerStep * widget.staggerIndex.clamp(0, _maxStaggeredIndex);
+    final delay =
+        _staggerStep * widget.staggerIndex.clamp(0, _maxStaggeredIndex);
     _timer = Timer(delay, () {
       if (mounted) setState(() => _visible = true);
     });
@@ -335,9 +336,16 @@ class _RelatedStripCardState extends State<_RelatedStripCard> {
         curve: Curves.easeOut,
         child: SizedBox(
           width: width,
-          child: GradientBorderEffect(
-            borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
-          ).build(context, DpadFocusState(focused: focused, pressed: false), body),
+          child:
+              GradientBorderEffect(
+                borderRadius: BorderRadius.circular(
+                  MediaBrowsingMetrics.cardRadius,
+                ),
+              ).build(
+                context,
+                DpadFocusState(focused: focused, pressed: false),
+                body,
+              ),
         ),
       ),
     );

--- a/flutter_client/lib/shared/related_strip.dart
+++ b/flutter_client/lib/shared/related_strip.dart
@@ -12,7 +12,10 @@ import 'package:m3u_tv/shared/image_quality_scope.dart';
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
 import 'package:m3u_tv/shared/series_detail_widgets.dart' show SelectHold;
 
-const double _kCardWidth = 130;
+// Matches MediaPreviewCard's posterStyle width elsewhere in the app (Movies/
+// Series grids, AIOStreams catalog rows) - a "related" card is the same kind
+// of poster tile, not a smaller cast-avatar-style thumbnail.
+const double _kCardWidth = MediaBrowsingMetrics.posterCardWidth;
 const double _kCardAspectRatio = 0.68;
 const double _kCardTextHeight = 20;
 const double _kCardGap = 12;

--- a/flutter_client/lib/shared/related_strip.dart
+++ b/flutter_client/lib/shared/related_strip.dart
@@ -229,9 +229,11 @@ class RelatedStripState extends State<RelatedStrip> {
                 behavior: HitTestBehavior.opaque,
                 onTap: () => _selectByMouse(index),
                 child: _RelatedStripCard(
+                  key: ValueKey(items[index].id),
                   item: items[index],
                   width: _cardWidth,
                   focused: _hasFocus && index == _focusedIndex,
+                  staggerIndex: index,
                 ),
               ),
             ),
@@ -242,20 +244,56 @@ class RelatedStripState extends State<RelatedStrip> {
   }
 }
 
-class _RelatedStripCard extends StatelessWidget {
+/// Fades and slides a card up into place, staggered by [staggerIndex] so the
+/// row cascades in one card at a time rather than popping in as a single
+/// block (matches how CastRevealSlot's own arrival reads as one gentle
+/// motion rather than a jump-cut).
+class _RelatedStripCard extends StatefulWidget {
   const _RelatedStripCard({
+    super.key,
     required this.item,
     required this.width,
     required this.focused,
+    required this.staggerIndex,
   });
 
   final RelatedItem item;
   final double width;
   final bool focused;
+  final int staggerIndex;
+
+  @override
+  State<_RelatedStripCard> createState() => _RelatedStripCardState();
+}
+
+class _RelatedStripCardState extends State<_RelatedStripCard> {
+  static const _staggerStep = Duration(milliseconds: 45);
+  static const _maxStaggeredIndex = 8;
+
+  bool _visible = false;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    final delay = _staggerStep * widget.staggerIndex.clamp(0, _maxStaggeredIndex);
+    _timer = Timer(delay, () {
+      if (mounted) setState(() => _visible = true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final item = widget.item;
+    final width = widget.width;
+    final focused = widget.focused;
     final body = Padding(
       // Keep the focus border off the poster / title.
       padding: const EdgeInsets.symmetric(
@@ -287,11 +325,21 @@ class _RelatedStripCard extends StatelessWidget {
         ],
       ),
     );
-    return SizedBox(
-      width: width,
-      child: GradientBorderEffect(
-        borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
-      ).build(context, DpadFocusState(focused: focused, pressed: false), body),
+    return AnimatedOpacity(
+      opacity: _visible ? 1 : 0,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+      child: AnimatedSlide(
+        offset: _visible ? Offset.zero : const Offset(0, 0.15),
+        duration: const Duration(milliseconds: 250),
+        curve: Curves.easeOut,
+        child: SizedBox(
+          width: width,
+          child: GradientBorderEffect(
+            borderRadius: BorderRadius.circular(MediaBrowsingMetrics.cardRadius),
+          ).build(context, DpadFocusState(focused: focused, pressed: false), body),
+        ),
+      ),
     );
   }
 }

--- a/flutter_client/lib/shared/related_strip.dart
+++ b/flutter_client/lib/shared/related_strip.dart
@@ -16,6 +16,10 @@ const double _kCardWidth = 130;
 const double _kCardAspectRatio = 0.68;
 const double _kCardTextHeight = 20;
 const double _kCardGap = 12;
+// Breathing room between the poster/title and the focus border - without it
+// the border is drawn flush against (and visually overlaps) the content.
+const double _kCardVerticalPadding = 4;
+const double _kCardHorizontalPadding = 4;
 
 /// A "locked focus" horizontal poster row for the "Related" titles shown
 /// below the cast row on a movie/series detail screen.
@@ -184,6 +188,15 @@ class RelatedStripState extends State<RelatedStrip> {
     widget.onTap(widget.items[_focusedIndex]);
   }
 
+  /// Mouse/touch tap on a card - the row is a single locked focus stop for
+  /// D-pad purposes, so this bypasses that and activates directly rather
+  /// than routing through key-based selection.
+  void _selectByMouse(int index) {
+    _focusNode.requestFocus();
+    setState(() => _focusedIndex = index);
+    widget.onTap(widget.items[index]);
+  }
+
   @override
   Widget build(BuildContext context) {
     final items = widget.items;
@@ -198,7 +211,7 @@ class RelatedStripState extends State<RelatedStrip> {
       child: SizedBox(
         height:
             _cardWidth / _kCardAspectRatio +
-            8 +
+            _kCardVerticalPadding * 2 +
             _kCardTextHeight * FontSizeScope.scaleOf(context),
         child: HoverScrollArrows(
           controller: _controller,
@@ -209,10 +222,14 @@ class RelatedStripState extends State<RelatedStrip> {
             itemCount: items.length,
             itemBuilder: (context, index) => Padding(
               padding: EdgeInsets.only(right: _cardGap),
-              child: _RelatedStripCard(
-                item: items[index],
-                width: _cardWidth,
-                focused: _hasFocus && index == _focusedIndex,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => _selectByMouse(index),
+                child: _RelatedStripCard(
+                  item: items[index],
+                  width: _cardWidth,
+                  focused: _hasFocus && index == _focusedIndex,
+                ),
               ),
             ),
           ),
@@ -236,29 +253,36 @@ class _RelatedStripCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final body = Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        AspectRatio(
-          aspectRatio: _kCardAspectRatio,
-          child: ResilientMediaImage(
-            imageUrl: item.posterUrl,
-            fallbackIcon: item.isSeries ? Icons.tv : Icons.movie,
-            borderRadius: MediaBrowsingMetrics.cardRadius,
-            fallbackTitle: item.title,
+    final body = Padding(
+      // Keep the focus border off the poster / title.
+      padding: const EdgeInsets.symmetric(
+        vertical: _kCardVerticalPadding,
+        horizontal: _kCardHorizontalPadding,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          AspectRatio(
+            aspectRatio: _kCardAspectRatio,
+            child: ResilientMediaImage(
+              imageUrl: item.posterUrl,
+              fallbackIcon: item.isSeries ? Icons.tv : Icons.movie,
+              borderRadius: MediaBrowsingMetrics.cardRadius,
+              fallbackTitle: item.title,
+            ),
           ),
-        ),
-        const SizedBox(height: 6),
-        Text(
-          item.title,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.bodySmall?.copyWith(
-            fontWeight: FontWeight.w700,
+          const SizedBox(height: 6),
+          Text(
+            item.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodySmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
     return SizedBox(
       width: width,

--- a/flutter_client/lib/shared/series_detail_widgets.dart
+++ b/flutter_client/lib/shared/series_detail_widgets.dart
@@ -1784,6 +1784,7 @@ class SeriesDetailBody extends StatelessWidget {
             padding: const EdgeInsets.only(top: 20),
             child: MediaPreviewSection(
               title: l.relatedTitle,
+              titleIcon: Icons.recommend,
               emptyLabel: '',
               posterStyle: true,
               items: [
@@ -1839,12 +1840,7 @@ class SeriesDetailBody extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                l.seriesCast,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
+              DetailRowHeader(icon: Icons.people, label: l.seriesCast),
               const SizedBox(height: 8),
               CastRow(members: richCastList),
             ],
@@ -1857,12 +1853,7 @@ class SeriesDetailBody extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                l.relatedTitle,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
+              DetailRowHeader(icon: Icons.recommend, label: l.relatedTitle),
               const SizedBox(height: 8),
               RelatedRow(
                 items: richRelatedList,

--- a/flutter_client/lib/shared/series_detail_widgets.dart
+++ b/flutter_client/lib/shared/series_detail_widgets.dart
@@ -21,6 +21,7 @@ import 'package:m3u_tv/shared/image_quality_scope.dart';
 import 'package:m3u_tv/shared/item_detail_scaffold.dart'
     show detailAppBarHeight;
 import 'package:m3u_tv/shared/media_browsing_widgets.dart';
+import 'package:m3u_tv/shared/related_strip.dart';
 
 /// Shared building blocks for the series-style detail screens (Xtream Series
 /// and the AIOStreams series body): the season picker, the locked-focus
@@ -1444,6 +1445,57 @@ class _CastRowState extends State<CastRow> implements LockedRow {
   }
 }
 
+/// Bridges the shared [RelatedStrip] to a [RowScrollRegion]: registers as a
+/// [LockedRow] so the cast row can hop down into it (and it can hop back up),
+/// and routes the strip's reveal through the region.
+class RelatedRow extends StatefulWidget {
+  const RelatedRow({super.key, required this.items, required this.onTap});
+
+  final List<RelatedItem> items;
+  final ValueChanged<RelatedItem> onTap;
+
+  @override
+  State<RelatedRow> createState() => _RelatedRowState();
+}
+
+class _RelatedRowState extends State<RelatedRow> implements LockedRow {
+  final GlobalKey<RelatedStripState> _stripKey = GlobalKey<RelatedStripState>();
+  RowScrollRegionState? _region;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final region = RowScrollRegion.of(context);
+    if (region != _region) {
+      _region?.unregisterRow(this);
+      _region = region;
+      _region?.registerRow(this);
+    }
+  }
+
+  @override
+  void dispose() {
+    _region?.unregisterRow(this);
+    super.dispose();
+  }
+
+  @override
+  void focusRow() => _stripKey.currentState?.focusRow();
+
+  @override
+  Widget build(BuildContext context) {
+    return RelatedStrip(
+      key: _stripKey,
+      items: widget.items,
+      onTap: widget.onTap,
+      onNavigateUp: () => _region?.navigateVertical(this, up: true),
+      // Consume down so focus never escapes below the related row.
+      onNavigateDown: () => _region?.navigateVertical(this, up: false),
+      onReveal: (ctx) => _region?.reveal(ctx),
+    );
+  }
+}
+
 extension _IterableX<T> on Iterable<T> {
   T? _firstWhereOrNull(bool Function(T element) test) {
     for (final element in this) {
@@ -1510,6 +1562,8 @@ class SeriesDetailBody extends StatelessWidget {
     required this.primaryActions,
     required this.richCast,
     required this.castSemanticLabel,
+    this.richRelated,
+    this.onRelatedTap,
     required this.progressList,
     required this.canMarkWatched,
     required this.emptyEpisodesLabel,
@@ -1557,6 +1611,15 @@ class SeriesDetailBody extends StatelessWidget {
 
   final List<CastMember>? richCast;
   final String castSemanticLabel;
+
+  /// TMDB recommendations already in the user's library, shown as the
+  /// "Related" row directly below the cast row. Null/empty renders nothing.
+  final List<RelatedItem>? richRelated;
+
+  /// Required whenever [richRelated] is non-empty - opens that item's own
+  /// detail screen. The caller (Xtream vs AIOStreams) owns the navigation,
+  /// this widget only reports the tap.
+  final ValueChanged<RelatedItem>? onRelatedTap;
 
   final List<Progress> progressList;
   final Progress? Function(Episode episode)? progressResolver;
@@ -1714,6 +1777,28 @@ class SeriesDetailBody extends StatelessWidget {
           : SizedBox(height: stripHeight, child: strip);
     }
 
+    final richRelatedList = richRelated;
+    final compactRelatedSection =
+        (compact && richRelatedList != null && richRelatedList.isNotEmpty)
+        ? Padding(
+            padding: const EdgeInsets.only(top: 20),
+            child: MediaPreviewSection(
+              title: l.relatedTitle,
+              emptyLabel: '',
+              posterStyle: true,
+              items: [
+                for (final item in richRelatedList)
+                  MediaPreviewItem(
+                    title: item.title,
+                    imageUrl: item.posterUrl,
+                    fallbackIcon: item.isSeries ? Icons.tv : Icons.movie,
+                    onTap: () => onRelatedTap?.call(item),
+                  ),
+              ],
+            ),
+          )
+        : null;
+
     if (compact) {
       final content = Padding(
         padding: const EdgeInsets.symmetric(
@@ -1722,7 +1807,12 @@ class SeriesDetailBody extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
-          children: [upper, const SizedBox(height: 12), episodeSection],
+          children: [
+            upper,
+            const SizedBox(height: 12),
+            episodeSection,
+            ?compactRelatedSection,
+          ],
         ),
       );
       final bandHeight = MediaQuery.sizeOf(context).height * 0.5;
@@ -1761,6 +1851,27 @@ class SeriesDetailBody extends StatelessWidget {
           )
         : null;
 
+    final relatedSection =
+        (richRelatedList != null && richRelatedList.isNotEmpty)
+        ? Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                l.relatedTitle,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 8),
+              RelatedRow(
+                items: richRelatedList,
+                onTap: (item) => onRelatedTap?.call(item),
+              ),
+            ],
+          )
+        : null;
+
     return _SeriesScrollHost(
       backdropUrl: backdropUrl,
       bg: bg,
@@ -1769,6 +1880,7 @@ class SeriesDetailBody extends StatelessWidget {
       upper: upper,
       episodeSection: episodeSection,
       castSection: castSection,
+      relatedSection: relatedSection,
       scrollController: scrollController,
     );
   }
@@ -1791,6 +1903,7 @@ class _SeriesScrollHost extends StatefulWidget {
     required this.upper,
     required this.episodeSection,
     required this.castSection,
+    this.relatedSection,
     this.scrollController,
   });
 
@@ -1801,6 +1914,7 @@ class _SeriesScrollHost extends StatefulWidget {
   final Widget upper;
   final Widget episodeSection;
   final Widget? castSection;
+  final Widget? relatedSection;
 
   /// External controller (see [SeriesDetailBody.scrollController]) so the
   /// caller can also snap to top from outside, e.g. the AppBar back button
@@ -1878,6 +1992,10 @@ class _SeriesScrollHostState extends State<_SeriesScrollHost> {
               if (widget.castSection != null) ...[
                 const SizedBox(height: 24),
                 widget.castSection!,
+              ],
+              if (widget.relatedSection != null) ...[
+                const SizedBox(height: 24),
+                widget.relatedSection!,
               ],
               SizedBox(height: MediaQuery.paddingOf(context).bottom + 24),
             ],

--- a/flutter_client/test/services/aiostreams_item_test.dart
+++ b/flutter_client/test/services/aiostreams_item_test.dart
@@ -102,5 +102,28 @@ void main() {
       expect(item.clearLogoUrl, isNull);
       expect(item.richCast, isNull);
     });
+
+    test('parses the related array (tmdb: id form)', () {
+      final json = movieMeta()
+        ..['related'] = [
+          {
+            'id': 'tmdb:680',
+            'type': 'movie',
+            'name': 'Pulp Fiction',
+            'poster': 'https://img/pulp.jpg',
+          },
+        ];
+      final item = AIOStreamsItem.fromJson(json);
+
+      expect(item.related, hasLength(1));
+      expect(item.related!.single.id, 'tmdb:680');
+      expect(item.related!.single.title, 'Pulp Fiction');
+      expect(item.related!.single.posterUrl, 'https://img/pulp.jpg');
+    });
+
+    test('related is null when absent (no TMDB recommendations)', () {
+      final item = AIOStreamsItem.fromJson(movieMeta());
+      expect(item.related, isNull);
+    });
   });
 }

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -380,4 +380,121 @@ void main() {
       expect(series.categoryIds, <String>['30', '900000002']);
     });
   });
+
+  group('RelatedItem', () {
+    test('fromXtream parses a movie entry', () {
+      final item = RelatedItem.fromXtream(<String, Object?>{
+        'type': 'movie',
+        'id': 42,
+        'name': 'Pulp Fiction',
+        'cover': 'https://example.com/pulp.jpg',
+        'tmdb_id': 680,
+      });
+
+      expect(item, isNotNull);
+      expect(item!.id, '42');
+      expect(item.type, 'movie');
+      expect(item.isSeries, isFalse);
+      expect(item.title, 'Pulp Fiction');
+      expect(item.posterUrl, 'https://example.com/pulp.jpg');
+    });
+
+    test('fromXtream parses a series entry with no cover', () {
+      final item = RelatedItem.fromXtream(<String, Object?>{
+        'type': 'series',
+        'id': 7,
+        'name': 'Better Call Saul',
+      });
+
+      expect(item, isNotNull);
+      expect(item!.id, '7');
+      expect(item.isSeries, isTrue);
+      expect(item.posterUrl, isNull);
+    });
+
+    test('fromXtream returns null when id or name is missing', () {
+      expect(
+        RelatedItem.fromXtream(<String, Object?>{'type': 'movie', 'id': 1}),
+        isNull,
+      );
+      expect(
+        RelatedItem.fromXtream(<String, Object?>{
+          'type': 'movie',
+          'name': 'Untitled',
+        }),
+        isNull,
+      );
+    });
+
+    test('VodInfo.fromXtream parses the related array', () {
+      final info = VodInfo.fromXtream(<String, Object?>{
+        'info': {
+          'related': [
+            {'type': 'movie', 'id': 42, 'name': 'Pulp Fiction'},
+          ],
+        },
+        'movie_data': {'stream_id': 1, 'name': 'Reservoir Dogs'},
+      });
+
+      expect(info.related, hasLength(1));
+      expect(info.related!.single.title, 'Pulp Fiction');
+    });
+
+    test('VodInfo.fromXtream related is null when absent', () {
+      final info = VodInfo.fromXtream(<String, Object?>{
+        'movie_data': {'stream_id': 1, 'name': 'Reservoir Dogs'},
+      });
+
+      expect(info.related, isNull);
+    });
+
+    test('Series.fromXtream parses the related array', () {
+      final series = Series.fromXtream(<String, Object?>{
+        'series_id': 7,
+        'name': 'Better Call Saul',
+        'related': [
+          {'type': 'series', 'id': 99, 'name': 'Breaking Bad'},
+        ],
+      });
+
+      expect(series.related, hasLength(1));
+      expect(series.related!.single.isSeries, isTrue);
+    });
+
+    test('fromAiostreams parses the tmdb: id form', () {
+      final item = RelatedItem.fromAiostreams(<String, Object?>{
+        'id': 'tmdb:680',
+        'type': 'movie',
+        'name': 'Pulp Fiction',
+        'poster': 'https://example.com/pulp.jpg',
+      });
+
+      expect(item, isNotNull);
+      expect(item!.id, 'tmdb:680');
+      expect(item.type, 'movie');
+      expect(item.posterUrl, 'https://example.com/pulp.jpg');
+    });
+
+    test('fromAiostreams defaults to movie when type is absent', () {
+      final item = RelatedItem.fromAiostreams(<String, Object?>{
+        'id': 'tmdb:680',
+        'name': 'Pulp Fiction',
+      });
+
+      expect(item, isNotNull);
+      expect(item!.type, 'movie');
+      expect(item.posterUrl, isNull);
+    });
+
+    test('fromAiostreams returns null when id or name is missing', () {
+      expect(
+        RelatedItem.fromAiostreams(<String, Object?>{'name': 'No Id'}),
+        isNull,
+      );
+      expect(
+        RelatedItem.fromAiostreams(<String, Object?>{'id': 'tmdb:1'}),
+        isNull,
+      );
+    });
+  });
 }

--- a/flutter_client/test/services/domain_models_test.dart
+++ b/flutter_client/test/services/domain_models_test.dart
@@ -475,15 +475,22 @@ void main() {
       expect(item.posterUrl, 'https://example.com/pulp.jpg');
     });
 
-    test('fromAiostreams defaults to movie when type is absent', () {
-      final item = RelatedItem.fromAiostreams(<String, Object?>{
-        'id': 'tmdb:680',
-        'name': 'Pulp Fiction',
-      });
-
-      expect(item, isNotNull);
-      expect(item!.type, 'movie');
-      expect(item.posterUrl, isNull);
+    test('fromAiostreams returns null when type is absent or invalid', () {
+      expect(
+        RelatedItem.fromAiostreams(<String, Object?>{
+          'id': 'tmdb:680',
+          'name': 'Pulp Fiction',
+        }),
+        isNull,
+      );
+      expect(
+        RelatedItem.fromAiostreams(<String, Object?>{
+          'id': 'tmdb:680',
+          'type': 'episode',
+          'name': 'Pulp Fiction',
+        }),
+        isNull,
+      );
     });
 
     test('fromAiostreams returns null when id or name is missing', () {


### PR DESCRIPTION
Adds related items row to all detail screens. Requires the TMDB metadata enrichment to be used in M3U Editor, or the TMDB enrichment be toggled for AIOStreams media servers (enabled by default).